### PR TITLE
Add the specific Creative Commons license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -8,7 +8,8 @@ The -ontop- framework is available under a dual licensing:
    
 ==== Documentation ==== 
 
-All documentation is licensed under the Creative Commons license.
+All documentation is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike-3.0
+(http://creativecommons.org/licenses/by-nc-sa/3.0/) license.
 
 ====  Contributing to the ontop project ==== 
 


### PR DESCRIPTION
The text may have lost the link when it was copied from the website. It is not suitable to just say "the Creative Commons license" in either case though, as there are many very distinct versions of it.
