### PR TITLE
Changes the R2RML Import and Export actions from the protege plugin t…

### DIFF
--- a/ontop-protege/src/main/java/it/unibz/inf/ontop/protege/gui/action/R2RMLExportAction.java
+++ b/ontop-protege/src/main/java/it/unibz/inf/ontop/protege/gui/action/R2RMLExportAction.java
@@ -88,12 +88,12 @@ public class R2RMLExportAction extends ProtegeAction {
 
                     R2RMLWriter writer = new R2RMLWriter(obdaModel, sourceID, modelManager.getActiveOntology());
                     writer.write(file);
-                    JOptionPane.showMessageDialog(workspace, "R2rml Export completed.");
+                    JOptionPane.showMessageDialog(workspace, "R2RML Export completed.");
                 }
             }
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(null, "An error occurred. For more info, see the logs.");
-            log.error("Error during r2rml export. \n");
+            log.error("Error during R2RML export. \n");
             ex.printStackTrace();
         }
 

--- a/ontop-protege/src/main/java/it/unibz/inf/ontop/protege/gui/action/R2RMLExportAction.java
+++ b/ontop-protege/src/main/java/it/unibz/inf/ontop/protege/gui/action/R2RMLExportAction.java
@@ -28,6 +28,8 @@ import org.protege.editor.core.ui.action.ProtegeAction;
 import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.model.OWLModelManager;
 import org.protege.editor.owl.model.OWLWorkspace;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLOntology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +60,7 @@ public class R2RMLExportAction extends ProtegeAction {
 		// Does nothing!
 	}
 
+        // Assumes initialise() has been run and has set modelManager to active OWLModelManager
 	@Override
 	public void actionPerformed(ActionEvent arg0) {
 
@@ -70,7 +73,12 @@ public class R2RMLExportAction extends ProtegeAction {
             else {
                 URI sourceID = obdaModel.getSources().get(0).getSourceID();
 
-                final JFileChooser fc = new JFileChooser();
+		// Get the path of the file of the active OWL model
+		OWLOntology activeOntology = modelManager.getActiveOntology();
+                IRI documentIRI = modelManager.getOWLOntologyManager().getOntologyDocumentIRI(activeOntology);
+		File ontologyDir = new File(documentIRI.toURI().getPath());
+		
+		final JFileChooser fc = new JFileChooser(ontologyDir);
                 fc.setSelectedFile(new File(sourceID + "-mappings.ttl"));
                 int approve = fc.showSaveDialog(workspace);
 

--- a/ontop-protege/src/main/java/it/unibz/inf/ontop/protege/gui/action/R2RMLImportAction.java
+++ b/ontop-protege/src/main/java/it/unibz/inf/ontop/protege/gui/action/R2RMLImportAction.java
@@ -29,6 +29,9 @@ import it.unibz.inf.ontop.r2rml.R2RMLReader;
 import org.protege.editor.core.ui.action.ProtegeAction;
 import org.protege.editor.owl.OWLEditorKit;
 import org.protege.editor.owl.model.OWLWorkspace;
+import org.protege.editor.owl.model.OWLModelManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLOntology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +46,7 @@ public class R2RMLImportAction extends ProtegeAction {
 
 	private OWLEditorKit editorKit = null;
 	private OBDAModel obdaModel = null;
+    	private OWLModelManager modelManager= null;
 
 	private Logger log = LoggerFactory.getLogger(R2RMLImportAction.class);
 
@@ -51,6 +55,7 @@ public class R2RMLImportAction extends ProtegeAction {
 		editorKit = (OWLEditorKit) getEditorKit();
 		obdaModel = ((OBDAModelManager) editorKit.get(OBDAModelImpl.class
 				.getName())).getActiveOBDAModel();
+		modelManager = editorKit.getOWLModelManager();
 	}
 
 	@Override
@@ -73,8 +78,12 @@ public class R2RMLImportAction extends ProtegeAction {
 					"Confirmation", JOptionPane.YES_NO_OPTION);
 
 			if (response == JOptionPane.YES_OPTION) {
-
-				final JFileChooser fc = new JFileChooser();
+				// Get the path of the file of the active OWL model
+				OWLOntology activeOntology = modelManager.getActiveOntology();
+				IRI documentIRI = modelManager.getOWLOntologyManager().getOntologyDocumentIRI(activeOntology);
+				File ontologyDir = new File(documentIRI.toURI().getPath());		
+				final JFileChooser fc = new JFileChooser(ontologyDir);
+		       
 				fc.showOpenDialog(workspace);
 				File file = null;
 				try {

--- a/ontop-protege/src/main/java/it/unibz/inf/ontop/protege/gui/action/R2RMLImportAction.java
+++ b/ontop-protege/src/main/java/it/unibz/inf/ontop/protege/gui/action/R2RMLImportAction.java
@@ -109,7 +109,7 @@ public class R2RMLImportAction extends ProtegeAction {
 
 							}
 						}
-						JOptionPane.showMessageDialog(workspace, "R2rml Import completed. " );
+						JOptionPane.showMessageDialog(workspace, "R2RML Import completed. " );
 					} catch (DuplicateMappingException dm) {
 						JOptionPane.showMessageDialog(workspace, "Duplicate mapping id found. Please correct the Resource node name: " + dm.getLocalizedMessage());
 						throw new RuntimeException("Duplicate mapping found: " + dm.getMessage());
@@ -117,7 +117,7 @@ public class R2RMLImportAction extends ProtegeAction {
 
 					} catch (Exception e) {
 						JOptionPane.showMessageDialog(null, "An error occurred. For more info, see the logs.");
-						log.error("Error during r2rml import. \n");
+						log.error("Error during R2RML import. \n");
 						e.printStackTrace();
 					}
 


### PR DESCRIPTION
Changes the R2RML Import and Export actions from the protege plugin to use by default the folder in which the active ontology and obda file is stored.

 This contrasts the current behaviour which uses the JFileChooser default (I think the execution folder)
