### PR TITLE
Disable 'set querying annotations in ontology' when materialization.

### DIFF
--- a/reformulation-core/src/main/java/it/unibz/inf/ontop/owlrefplatform/core/abox/QuestMaterializer.java
+++ b/reformulation-core/src/main/java/it/unibz/inf/ontop/owlrefplatform/core/abox/QuestMaterializer.java
@@ -160,7 +160,7 @@ public class QuestMaterializer {
 		preferences.setCurrentValueOf(QuestPreferences.ABOX_MODE, QuestConstants.VIRTUAL);
 
 		questInstance = new Quest(ontology, this.model, preferences);
-		questInstance.setQueryingAnnotationsInOntology(true);
+		questInstance.setQueryingAnnotationsInOntology(false);
 
 		questInstance.setupRepository();
 	}


### PR DESCRIPTION
The QuestMaterializer class is using a Quest reasoner instance with the option "setQueryingAnnotationsInOntology" set as true always.

This is causing several issues:
Issue #186 -> If we allow Quest reasoner to be asked about annotations in the ontology, the classes with any annotation in the owl file of the ontology will be populated as individuals in order to be visible through SPARQL queries. Of course, this is a great feature when we want to perform SPARQL queries. However, if we are performing a materialization of triples into an empty ontology, this is provoking the apparition of individuals with the same name of the class and the same annotations. These individuals are not necessary; the annotations of the classes are already in the classes of the ontology.

Issue #183 -> "setQueryingAnnotationsInOntology" set as true causes a big SQL during the materialization of triples. This happens because all annotations found in the owl file are hard coded  in the SQL query in order to return annotations defined in the mappings and the annotations defined in the ontology. This is not necessary due to the same reason shown in the previous issue: the annotations that belong to the ontology are already in the ontology, so it is not necessary to include it in the SQL.