### PR TITLE
Fixed SQL parsing error when functions appear on select clause.

### DIFF
--- a/mapping/sql/core/src/main/java/it/unibz/inf/ontop/spec/mapping/parser/impl/SelectQueryAttributeExtractor.java
+++ b/mapping/sql/core/src/main/java/it/unibz/inf/ontop/spec/mapping/parser/impl/SelectQueryAttributeExtractor.java
@@ -41,6 +41,8 @@ public class SelectQueryAttributeExtractor {
     private final QuotedIDFactory idfac;
 
     private static final Pattern AS = Pattern.compile("\\sAS\\s", Pattern.CASE_INSENSITIVE);
+    
+    private static final Pattern SQL_FUNCTION = Pattern.compile("\\w+\\s*\\(.*\\)\\s*as", Pattern.CASE_INSENSITIVE);
 
     private final SelectQueryAttributeExtractor2 sqae;
 
@@ -75,6 +77,15 @@ public class SelectQueryAttributeExtractor {
             // remove all brackets
             while (projection.matches("\\([^\\(]*\\)"))
                 projection = projection.replaceAll("\\([^\\(]*\\)", "");
+            
+            // fabad (3 Oct 2017): Remove functions from the projection
+            // in order to avoid parser errors because of commas inside
+            // the function parameters.
+            // For example:
+            // to_char(ALMAES001.INIT_DATE,'YYYY-MM-DD') AS INIT_DATE => INIT_DATE.
+            // It is mandatory to rename the result of the function with "AS" clause.
+            // In other case the parser error occurs.
+            projection = SQL_FUNCTION.matcher(projection).replaceAll("");
 
             for (String col : projection.split(",")) {
                 // TODO: AS should be treated as optional
@@ -100,3 +111,4 @@ public class SelectQueryAttributeExtractor {
     }
 
 }
+


### PR DESCRIPTION
Related to #211.
There was a bug parsing SQL. Ontop was expecting that identifiers in SELECT clause were separated by commas in order to extract the column names. This produces an error if a function appears. In my case
`to_char(ALMAES001.FECALTA,'YYYY-MM-DD') AS FECALTA,`
was splitted into 
`to_char(ALMAES001.FECALTA`
and
`'YYYY-MM-DD') AS FECALTA`

Each string is treated individually so the application tried to insert FECALTA twice, which causes a "Duplicate attribute name" error.

What I've done to avoid this behaviour is to detect functions with the regexp 
`\w+\s*\(.*\)\s*(as|AS)`
and to delete it, keeping the column name given to the result of the function.

The use of "AS" clause is mandatory to avoid the bug.