### PR TITLE
Bugfix/error constants in arguments

### DIFF
--- a/mapping/core/src/main/java/it/unibz/inf/ontop/spec/mapping/transformer/impl/MappingDataTypeCompletion.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/spec/mapping/transformer/impl/MappingDataTypeCompletion.java
@@ -174,14 +174,35 @@ public class MappingDataTypeCompletion {
         RelationID tableId = Relation2Predicate.createRelationFromPredicateName(metadata.getQuotedIDFactory(), ip.atom
                 .getFunctionSymbol());
         RelationDefinition td = metadata.getRelation(tableId);
-        Attribute attribute = td.getAttribute(ip.pos);
+        
+        // fabad (4 Oct 2017) Quick fix if there are constants in arguments.
+        // Calculate the attribute position taking account on how many constants
+        // are before the attribute in the list.
+        int attributePos = this.getAttributePos(ip, variable);
+        Attribute attribute = td.getAttribute(attributePos);
 
         return metadata.getColType(attribute)
                 // Default datatype : XSD_STRING
                 .orElse(Predicate.COL_TYPE.STRING);
     }
 
-    private static class IndexedPosition {
+    private int getAttributePos(IndexedPosition ip, Variable variable) {
+    	int constBeforeAttribute = 0;
+		for(Term term : ip.atom.getTerms()){
+			if(term.equals(variable)){
+				break;
+			}
+			
+			if(term instanceof ValueConstant){
+				constBeforeAttribute++;
+			}
+		}
+		
+
+		return ip.pos + constBeforeAttribute;
+	}
+
+	private static class IndexedPosition {
         final Function atom;
         final int pos;
 
@@ -228,4 +249,5 @@ public class MappingDataTypeCompletion {
     }
 
 }
+
 

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/spec/mapping/transformer/impl/MappingDataTypeCompletion.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/spec/mapping/transformer/impl/MappingDataTypeCompletion.java
@@ -175,32 +175,13 @@ public class MappingDataTypeCompletion {
                 .getFunctionSymbol());
         RelationDefinition td = metadata.getRelation(tableId);
         
-        // fabad (4 Oct 2017) Quick fix if there are constants in arguments.
-        // Calculate the attribute position taking account on how many constants
-        // are before the attribute in the list.
-        int attributePos = this.getAttributePos(ip, variable);
-        Attribute attribute = td.getAttribute(attributePos);
+        
+        Attribute attribute = td.getAttribute(ip.pos);
 
         return metadata.getColType(attribute)
                 // Default datatype : XSD_STRING
                 .orElse(Predicate.COL_TYPE.STRING);
     }
-
-    private int getAttributePos(IndexedPosition ip, Variable variable) {
-    	int constBeforeAttribute = 0;
-		for(Term term : ip.atom.getTerms()){
-			if(term.equals(variable)){
-				break;
-			}
-			
-			if(term instanceof ValueConstant){
-				constBeforeAttribute++;
-			}
-		}
-		
-
-		return ip.pos + constBeforeAttribute;
-	}
 
 	private static class IndexedPosition {
         final Function atom;
@@ -225,7 +206,7 @@ public class MappingDataTypeCompletion {
                         aux = new LinkedList<>();
                     aux.add(new IndexedPosition(a, i));
                     termOccurenceIndex.put(var.getName(), aux);
-                    i++; // increase the position index for the next variable
+                    
                 } else if (t instanceof FunctionalTermImpl) {
                     // NO-OP
                 } else if (t instanceof ValueConstant) {
@@ -233,6 +214,11 @@ public class MappingDataTypeCompletion {
                 } else if (t instanceof URIConstant) {
                     // NO-OP
                 }
+                // fabad (4 Oct 2017) Quick fix if there are constants in arguments.
+                // Increase i in all cases. If there are terms that are not variables
+                // and i is not incremented then indexedPosition.pos contains a wrong
+                // index that may points to terms that are not variables.
+                i++; // increase the position index for the next variable
             }
         }
         return termOccurenceIndex;
@@ -249,5 +235,4 @@ public class MappingDataTypeCompletion {
     }
 
 }
-
 


### PR DESCRIPTION
There was a bug obtaining the data type of the variables.

The application creates an index based on IndexedPosition object. This object have the property "pos", which indicates the index of a variable in a list of terms. The program iterates over all terms in the list and it checks if the term is a variable. If there exist constants in the list of terms, the pointer that iterates the list of terms was not updated. For instance, if we have the following terms:
`var1 var2 const1 var3`
Then the created index was:
var     pos
var1   0
var2   1
var3   2

This causes an error when var3 is accessed via terms.get(2) due to this position is occupied by "const1". What i've done to fix this is to increment the iterator for each term in the list and not only when the term is a variable.