### PR TITLE
Limit on adding EmptyNodes

### DIFF
--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/executor/merging/QueryMergingExecutorImpl.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/executor/merging/QueryMergingExecutorImpl.java
@@ -267,19 +267,21 @@ public class QueryMergingExecutorImpl implements QueryMergingExecutor {
             QueryNode nodeToInsert = getNodeToInsert(transformation, treeComponent);
 
             /**
-             * Adds the transformed node to the tree.
+             * Adds the transformed node to the tree if its not empty or there are less then 2 nodes for parent 
              */
-            treeComponent.addChild(transformation.getTransformedParent(),
-                    nodeToInsert,
-                    transformation.getOptionalPosition(), false);
-
-            Optional<? extends ImmutableSubstitution<? extends ImmutableTerm>> substitutionToPropagate =
-                    transformation.getSubstitutionToPropagate();
+            if (!(nodeToInsert instanceof EmptyNode) || (treeComponent.getChildren(transformation.getTransformedParent()).size()<2))
+                treeComponent.addChild(transformation.getTransformedParent(),
+                        nodeToInsert,
+                        transformation.getOptionalPosition(), false);
 
             /**
              * Puts the children into the queue except if the transformed node is unsatisfied
              */
             if (!(nodeToInsert instanceof EmptyNode)) {
+
+                Optional<? extends ImmutableSubstitution<? extends ImmutableTerm>> substitutionToPropagate =
+                        transformation.getSubstitutionToPropagate();
+
                 QueryNode originalNode = transformation.getNodeFromSubQuery();
 
                 renamedSubQuery.getChildren(originalNode)


### PR DESCRIPTION
When dealing with thousands of mappings, unfolding even simple queries leads to addition of large number of EmptyNodes (in mergeSubQuery()) and their subsequent removal (in apply()). Artificial limitation of them by 2 per parent speed up unfolding at least 3 times in my environment.