### PR TITLE
Fixes bug in R2RML parser

### DIFF
--- a/mapping/sql/r2rml/src/main/java/it/unibz/inf/ontop/spec/mapping/parser/impl/R2RMLToSQLPPTriplesMapConverter.java
+++ b/mapping/sql/r2rml/src/main/java/it/unibz/inf/ontop/spec/mapping/parser/impl/R2RMLToSQLPPTriplesMapConverter.java
@@ -305,10 +305,12 @@ public class R2RMLToSQLPPTriplesMapConverter {
 
 
 	private <T extends TermMap> NonVariableTerm extract(ImmutableMap<IRI, TermMapFactory<T, ? extends TemplateFactory>> map, T termMap) {
-		return map.computeIfAbsent(termMap.getTermType(), k -> {
+		TermMapFactory<T, ? extends TemplateFactory> termMapFactory = map.get(termMap.getTermType());
+		if (termMapFactory == null) {
 			throw new R2RMLParsingBugException("Was expecting one of " + map.keySet() +
-						" when encountered " + termMap);
-		}).extract(termMap);
+					" when encountered " + termMap);
+		}
+		return termMapFactory.extract(termMap);
 	}
 
 	/*
@@ -353,7 +355,7 @@ public class R2RMLToSQLPPTriplesMapConverter {
 		@Override
 		protected NonVariableTerm onConstant(RDFTerm constant) {
 			return templateFactory.getConstant(
-							R2RMLVocabulary.resolveIri(constant.toString(), baseIri));
+					R2RMLVocabulary.resolveIri(((IRI)constant).getIRIString(), baseIri));
 		}
 		@Override
 		protected NonVariableTerm onTemplate(String template) {


### PR DESCRIPTION
Hi folks,

this PR request fixes an issue in the R2RML parser, in particular in the `R2RMLToSQLPPTriplesMapConverter` class:

Using just `toString()` on the Common RDF `RDFTerm` is to vague. For example, I use Ontop with Apache Jena as the R2RML graph provider, and their `toString()` implementation does return an N-Triples rendered String, i.e. `<http://foo.bar/ex>` - clearly, this String will lead to an invalid IRI resolver result: `http://example.org/base/<http://foo.bar/ex>`. I changed the code to explicitly call the method that does return the IRI string. Note, I didn't check for the type before casting, hope this is fine - at least I assume that the `IriTermMapFactory` does only get IRI constants. If not, will free to adapt and check for the type before casting to avoid a `ClassCastException`.


You can also see another change I made: you call `computeIfAbsent` on a Guava `ImmutableMap` - I understand you did this for convenience, but given that the Map is immutable, later Guava versions (>21.0) will deprecate this method and will always throw an `UnsupportedOperationException` [1]
Feel free to undo this change if you want, but keep in mind that whenever you're willing to upgrade your Guava dependency, this will be an issue.


Cheers.

[1] https://guava.dev/releases/21.0/api/docs/com/google/common/collect/ImmutableMap.html#computeIfAbsent-K-java.util.function.Function-