### PR TITLE
JDBC statement not always closed

### DIFF
--- a/binding/owlapi/src/main/java/it/unibz/inf/ontop/owlapi/connection/OWLStatement.java
+++ b/binding/owlapi/src/main/java/it/unibz/inf/ontop/owlapi/connection/OWLStatement.java
@@ -7,8 +7,10 @@ import it.unibz.inf.ontop.owlapi.connection.impl.DefaultOntopOWLConnection;
 import org.semanticweb.owlapi.model.OWLException;
 
 /***
- * A Statement to execute queries over a OntopOWLConnection. The logic of this
- * statement is equivalent to that of JDBC's Statements.
+ * A Statement to execute queries over a OntopOWLConnection.
+ *
+ * RESTRICTION: By contrast with JDBC statements, an OWLStatement accepts AT MOST ONE query execution.
+ * It cannot be reused.
  *
  * <p>
  * <strong>Performance</strong> Note that you should not create multiple

--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/LeftJoinMultipleMatchingTest.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/LeftJoinMultipleMatchingTest.java
@@ -73,7 +73,6 @@ public class LeftJoinMultipleMatchingTest {
 
         // Now we are ready for querying
         conn = reasoner.getConnection();
-        OWLStatement st = conn.createStatement();
 
         QueryController qc = new QueryController();
         QueryIOManager qman = new QueryIOManager(qc);
@@ -85,20 +84,22 @@ public class LeftJoinMultipleMatchingTest {
                 log.debug("Executing query: {}", query.getID());
                 log.debug("Query: \n{}", query.getQuery());
 
-                long start = System.nanoTime();
-                TupleOWLResultSet res = st.executeSelectQuery(query.getQuery());
-                long end = System.nanoTime();
+                try(OWLStatement st = conn.createStatement()) {
+                    long start = System.nanoTime();
+                    TupleOWLResultSet res = st.executeSelectQuery(query.getQuery());
+                    long end = System.nanoTime();
 
-                double time = (end - start) / 1000;
+                    double time = (end - start) / 1000;
 
-                int count = 0;
-                while (res.hasNext()) {
-                    res.next();
-                    count += 1;
+                    int count = 0;
+                    while (res.hasNext()) {
+                        res.next();
+                        count += 1;
+                    }
+                    log.debug("Total result: {}", count);
+                    assertFalse(count == 0);
+                    log.debug("Elapsed time: {} ms", time);
                 }
-                log.debug("Total result: {}", count);
-                assertFalse(count == 0);
-                log.debug("Elapsed time: {} ms", time);
             }
         }
     }

--- a/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/connection/OBDAStatement.java
+++ b/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/connection/OBDAStatement.java
@@ -5,6 +5,16 @@ import it.unibz.inf.ontop.answering.reformulation.input.InputQuery;
 import it.unibz.inf.ontop.answering.resultset.OBDAResultSet;
 import it.unibz.inf.ontop.exception.*;
 
+/**
+ * An OBDAStatement can execute at most one high-level InputQuery.
+ *
+ * By high-level InputQuery, we mean a query issued by the user,
+ * not the SELECT and CONSTRUCT queries generated internally for answering a high-level DESCRIBE query.
+ *
+ * This restriction has been introduced as binding libraries like RDF4J do not use the OBDAStatement in a standard manner.
+ * It allows to carefully close the underlying DB statement.
+ *
+ */
 public interface OBDAStatement extends AutoCloseable {
 
 	void cancel() throws OntopConnectionException;

--- a/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/resultset/impl/DefaultSimpleGraphResultSet.java
+++ b/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/resultset/impl/DefaultSimpleGraphResultSet.java
@@ -15,7 +15,6 @@ import org.eclipse.rdf4j.query.algebra.ProjectionElem;
 import org.eclipse.rdf4j.query.algebra.ProjectionElemList;
 import org.eclipse.rdf4j.query.algebra.ValueConstant;
 import org.eclipse.rdf4j.query.algebra.ValueExpr;
-import org.eclipse.rdf4j.sail.SailException;
 
 import com.google.common.collect.ImmutableMap;
 import it.unibz.inf.ontop.answering.reformulation.input.ConstructTemplate;
@@ -38,14 +37,8 @@ public class DefaultSimpleGraphResultSet implements GraphResultSet {
 			TupleResultSet tupleResultSet,
 			ConstructTemplate constructTemplate,
 			TermFactory termFactory,
-			org.apache.commons.rdf.api.RDF rdfFactory)
-			throws OntopConnectionException {
-		try {
-			iterator =
-					new ResultSetIterator(tupleResultSet, constructTemplate, termFactory, rdfFactory);
-		} catch (Exception e) {
-			throw new SailException(e.getCause());
-		}
+			org.apache.commons.rdf.api.RDF rdfFactory) {
+		iterator = new ResultSetIterator(tupleResultSet, constructTemplate, termFactory, rdfFactory);
 	}
 
 	@Override

--- a/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/resultset/impl/OntopConnectionCloseable.java
+++ b/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/resultset/impl/OntopConnectionCloseable.java
@@ -1,0 +1,8 @@
+package it.unibz.inf.ontop.answering.resultset.impl;
+
+import it.unibz.inf.ontop.exception.OntopConnectionException;
+
+@FunctionalInterface
+public interface OntopConnectionCloseable {
+    void close() throws OntopConnectionException;
+}

--- a/engine/system/sql/core/src/main/java/it/unibz/inf/ontop/answering/connection/impl/SQLQuestStatement.java
+++ b/engine/system/sql/core/src/main/java/it/unibz/inf/ontop/answering/connection/impl/SQLQuestStatement.java
@@ -167,7 +167,7 @@ public class SQLQuestStatement extends QuestStatement {
             try {
                 java.sql.ResultSet set = sqlStatement.executeQuery(sqlQuery);
                 queryLogger.declareResultSetUnblockedAndSerialize();
-                return new SQLBooleanResultSet(set, queryLogger);
+                return new SQLBooleanResultSet(set, queryLogger, this::close);
             } catch (SQLException e) {
                 throw new OntopQueryEvaluationException(e.getMessage());
             }
@@ -178,7 +178,8 @@ public class SQLQuestStatement extends QuestStatement {
     }
 
     @Override
-    public TupleResultSet executeSelectQuery(IQ executableQuery, QueryLogger queryLogger)
+    protected TupleResultSet executeSelectQuery(IQ executableQuery, QueryLogger queryLogger,
+                                                boolean shouldAlsoCloseStatement)
             throws OntopQueryEvaluationException {
         try {
             String sqlQuery = extractSQLQuery(executableQuery);
@@ -186,12 +187,17 @@ public class SQLQuestStatement extends QuestStatement {
             NativeNode nativeNode = extractNativeNode(executableQuery);
             ImmutableSortedSet<Variable> signature = nativeNode.getVariables();
             ImmutableMap<Variable, DBTermType> typeMap = nativeNode.getTypeMap();
+
+            OntopConnectionCloseable statementClosingCB = shouldAlsoCloseStatement ? this::close : null;
+
             try {
                 java.sql.ResultSet set = sqlStatement.executeQuery(sqlQuery);
                 queryLogger.declareResultSetUnblockedAndSerialize();
                 return settings.isDistinctPostProcessingEnabled()
-                        ? new DistinctJDBCTupleResultSet(set, signature, typeMap, constructionNode, executableQuery.getProjectionAtom(), queryLogger, termFactory, substitutionFactory)
-                        : new JDBCTupleResultSet(set, signature, typeMap, constructionNode, executableQuery.getProjectionAtom(), queryLogger, termFactory, substitutionFactory);
+                        ? new DistinctJDBCTupleResultSet(set, signature, typeMap, constructionNode,
+                            executableQuery.getProjectionAtom(), queryLogger, statementClosingCB, termFactory, substitutionFactory)
+                        : new JDBCTupleResultSet(set, signature, typeMap, constructionNode, executableQuery.getProjectionAtom(),
+                            queryLogger, statementClosingCB, termFactory, substitutionFactory);
             } catch (SQLException e) {
                 throw new OntopQueryEvaluationException(e);
             }
@@ -201,9 +207,12 @@ public class SQLQuestStatement extends QuestStatement {
         }
     }
 
+    /**
+     * TODO: make it SQL-independent
+     */
     @Override
     protected GraphResultSet executeConstructQuery(ConstructTemplate constructTemplate, IQ executableQuery, QueryLogger queryLogger,
-                                                   boolean isSubQueryOfDescribe)
+                                                   boolean shouldAlsoCloseStatement)
             throws OntopQueryEvaluationException, OntopResultConversionException, OntopConnectionException {
         TupleResultSet tuples;
         try {
@@ -212,11 +221,14 @@ public class SQLQuestStatement extends QuestStatement {
             NativeNode nativeNode = extractNativeNode(executableQuery);
             ImmutableSortedSet<Variable> SQLSignature = nativeNode.getVariables();
             ImmutableMap<Variable, DBTermType> SQLTypeMap = nativeNode.getTypeMap();
+
+            OntopConnectionCloseable statementClosingCB = shouldAlsoCloseStatement ? this::close : null;
+
             try {
                 ResultSet rs = sqlStatement.executeQuery(sqlQuery);
                 queryLogger.declareResultSetUnblockedAndSerialize();
                 tuples = new JDBCTupleResultSet(rs, SQLSignature, SQLTypeMap, constructionNode,
-                        executableQuery.getProjectionAtom(), queryLogger, termFactory, substitutionFactory);
+                        executableQuery.getProjectionAtom(), queryLogger, statementClosingCB, termFactory, substitutionFactory);
             } catch (SQLException e) {
                 throw new OntopQueryEvaluationException(e.getMessage());
             }
@@ -224,7 +236,7 @@ public class SQLQuestStatement extends QuestStatement {
             queryLogger.declareResultSetUnblockedAndSerialize();
             tuples = new EmptyTupleResultSet(executableQuery.getProjectionAtom().getArguments(), queryLogger);
         }
-        return new DefaultSimpleGraphResultSet(tuples, constructTemplate, termFactory, rdfFactory, this, isSubQueryOfDescribe);
+        return new DefaultSimpleGraphResultSet(tuples, constructTemplate, termFactory, rdfFactory);
     }
 
     private NativeNode extractNativeNode(IQ executableQuery) throws EmptyQueryException {

--- a/engine/system/sql/core/src/main/java/it/unibz/inf/ontop/answering/resultset/impl/DistinctJDBCTupleResultSet.java
+++ b/engine/system/sql/core/src/main/java/it/unibz/inf/ontop/answering/resultset/impl/DistinctJDBCTupleResultSet.java
@@ -32,6 +32,7 @@ import it.unibz.inf.ontop.model.term.Variable;
 import it.unibz.inf.ontop.model.type.DBTermType;
 import it.unibz.inf.ontop.substitution.SubstitutionFactory;
 
+import javax.annotation.Nullable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
@@ -41,16 +42,18 @@ import java.util.*;
  * See test case DistinctResultSetTest
  */
 
+@Deprecated
 public class DistinctJDBCTupleResultSet extends JDBCTupleResultSet implements TupleResultSet {
 
     private Set<List<Object>> rowKeys;
 
     public DistinctJDBCTupleResultSet(ResultSet rs, ImmutableSortedSet<Variable> sqlSignature, ImmutableMap<Variable, DBTermType> sqlTypes,
                                       ConstructionNode constructionNode,
-                                      DistinctVariableOnlyDataAtom answerAtom, QueryLogger queryLogger, TermFactory termFactory,
+                                      DistinctVariableOnlyDataAtom answerAtom, QueryLogger queryLogger,
+                                      @Nullable OntopConnectionCloseable statementClosingCB, TermFactory termFactory,
                                       SubstitutionFactory substitutionFactory) {
 
-        super(rs, sqlSignature, sqlTypes, constructionNode, answerAtom, queryLogger, termFactory, substitutionFactory);
+        super(rs, sqlSignature, sqlTypes, constructionNode, answerAtom, queryLogger, statementClosingCB, termFactory, substitutionFactory);
         rowKeys = new HashSet<>();
     }
 

--- a/engine/system/sql/core/src/main/java/it/unibz/inf/ontop/answering/resultset/impl/JDBCTupleResultSet.java
+++ b/engine/system/sql/core/src/main/java/it/unibz/inf/ontop/answering/resultset/impl/JDBCTupleResultSet.java
@@ -29,10 +29,11 @@ public class JDBCTupleResultSet extends AbstractTupleResultSet {
                               ImmutableSortedSet<Variable> sqlSignature,
                               ImmutableMap<Variable, DBTermType> sqlTypeMap,
                               ConstructionNode constructionNode,
-                              DistinctVariableOnlyDataAtom answerAtom,
-                              QueryLogger queryLogger, TermFactory termFactory,
+                              DistinctVariableOnlyDataAtom answerAtom, QueryLogger queryLogger,
+                              @Nullable OntopConnectionCloseable statementClosingCB,
+                              TermFactory termFactory,
                               SubstitutionFactory substitutionFactory) {
-        super(rs, answerAtom.getArguments(),queryLogger);
+        super(rs, answerAtom.getArguments(),queryLogger, statementClosingCB);
         this.sqlSignature = sqlSignature;
         this.sqlTypeMap = sqlTypeMap;
         this.substitutionFactory = substitutionFactory;
@@ -68,11 +69,7 @@ public class JDBCTupleResultSet extends AbstractTupleResultSet {
         return termFactory.getDBConstant(jdbcValue, termType);
     }
 
-    private OntopBinding[] computeBindingMap(
-            // ImmutableList<Variable> signature,
-            ImmutableSubstitution<Constant> sqlVar2Constant
-            // ImmutableSubstitution<ImmutableTerm> sparqlVar2Term
-    ) {
+    private OntopBinding[] computeBindingMap(ImmutableSubstitution<Constant> sqlVar2Constant) {
         ImmutableSubstitution<ImmutableTerm> composition = sqlVar2Constant.composeWith(sparqlVar2Term);
         //this can be improved and simplified
         return signature.stream()

--- a/engine/system/sql/core/src/main/java/it/unibz/inf/ontop/answering/resultset/impl/SQLBooleanResultSet.java
+++ b/engine/system/sql/core/src/main/java/it/unibz/inf/ontop/answering/resultset/impl/SQLBooleanResultSet.java
@@ -31,20 +31,23 @@ public class SQLBooleanResultSet implements BooleanResultSet {
 
     private final ResultSet set;
     private final QueryLogger queryLogger;
+    private final OntopConnectionCloseable statementClosingCB;
     private boolean hasRead;
 
-    public SQLBooleanResultSet(ResultSet set, QueryLogger queryLogger) {
+    public SQLBooleanResultSet(ResultSet set, QueryLogger queryLogger,
+                               OntopConnectionCloseable statementClosingCB) {
         this.set = set;
         this.queryLogger = queryLogger;
+        this.statementClosingCB = statementClosingCB;
         this.hasRead = false;
     }
 
     @Override
     public void close() throws OntopConnectionException {
-        if (set == null)
-            return;
         try {
-            set.close();
+            if (set != null)
+                set.close();
+            statementClosingCB.close();
         } catch (SQLException e) {
             queryLogger.declareConnectionException(e);
             throw new OntopConnectionException(e);

--- a/test/docker-tests/src/test/java/it/unibz/inf/ontop/docker/oracle/OracleRegexpTest.java
+++ b/test/docker-tests/src/test/java/it/unibz/inf/ontop/docker/oracle/OracleRegexpTest.java
@@ -48,20 +48,21 @@ public class OracleRegexpTest extends AbstractVirtualModeTest {
 	}
 
 
-	private String runTest(OWLStatement st, String query, boolean hasResult) throws Exception {
+	private String runTest(String query, boolean hasResult) throws Exception {
 		String retval;
-		TupleOWLResultSet rs = st.executeSelectQuery(query);
-		if(hasResult){
-			assertTrue(rs.hasNext());
-            final OWLBindingSet bindingSet = rs.next();
-            OWLIndividual ind1 = bindingSet.getOWLIndividual("country")	 ;
-			retval = ind1.toString();
-		} else {
-			assertFalse(rs.hasNext());
-			retval = "";
+		try (OWLStatement st = createStatement();
+			 TupleOWLResultSet rs = st.executeSelectQuery(query)) {
+			if (hasResult) {
+				assertTrue(rs.hasNext());
+				final OWLBindingSet bindingSet = rs.next();
+				OWLIndividual ind1 = bindingSet.getOWLIndividual("country");
+				retval = ind1.toString();
+			} else {
+				assertFalse(rs.hasNext());
+				retval = "";
+			}
+			return retval;
 		}
-
-		return retval;
 	}
 
 	/**
@@ -70,9 +71,7 @@ public class OracleRegexpTest extends AbstractVirtualModeTest {
 	 */
 	@Test
 	public void testSparql2OracleRegex() throws Exception {
-		OWLStatement st = null;
 		try {
-			st = createStatement();
 
 			String[] queries = {
 					"'E[a-z]*t'", 
@@ -84,7 +83,7 @@ public class OracleRegexpTest extends AbstractVirtualModeTest {
 					};
 			for (String regex : queries){
 				String query = "PREFIX : <http://www.semanticweb.org/ontologies/2013/7/untitled-ontology-150#> SELECT ?country WHERE {?country a :Country; :name ?country_name . FILTER regex(?country_name, " + regex + ")}";
-				String countryName = runTest(st, query, true);
+				String countryName = runTest(query, true);
 				assertEquals(countryName, "<http://www.semanticweb.org/ontologies/2013/7/untitled-ontology-150#Country-Egypt>");
 			}
 			String[] wrongs = {
@@ -94,14 +93,11 @@ public class OracleRegexpTest extends AbstractVirtualModeTest {
 					};
 			for (String regex : wrongs){
 				String query = "PREFIX : <http://www.semanticweb.org/ontologies/2013/7/untitled-ontology-150#> SELECT ?country WHERE {?country a :Country; :name ?country_name . FILTER regex(?country_name, " + regex + ")}";
-				String countryName = runTest(st, query, false);
+				String countryName = runTest(query, false);
 				assertEquals(countryName, "");
 			}
 		} catch (Exception e) {
 			throw e;
-		} finally {
-			if (st != null)
-				st.close();
 		}
 	}
 

--- a/test/docker-tests/src/test/java/it/unibz/inf/ontop/docker/regex/RegexpTest.java
+++ b/test/docker-tests/src/test/java/it/unibz/inf/ontop/docker/regex/RegexpTest.java
@@ -192,26 +192,28 @@ public class RegexpTest extends TestCase {
 	 */
 	@Test
 	public void testSparql2sqlRegex() throws Exception {
-		try (OWLStatement st = conn.createStatement()) {
-			List<String> queries = Lists.newArrayList(
-					"'J[ano]*'",
-					"'^J[ano]*$'",
-					"'J'");
-			if (acceptFlags) {
-				queries.add("'j[ANO]*', 'i'");
-				queries.add("'^J[ano]*$', 'm'");
-			}
+		List<String> queries = Lists.newArrayList(
+				"'J[ano]*'",
+				"'^J[ano]*$'",
+				"'J'");
+		if (acceptFlags) {
+			queries.add("'j[ANO]*', 'i'");
+			queries.add("'^J[ano]*$', 'm'");
+		}
 
-			for (String regex : queries){
+		for (String regex : queries){
+			try (OWLStatement st = conn.createStatement()) {
 				String query = "PREFIX : <http://www.owl-ontologies.com/Ontology1207768242.owl#> SELECT DISTINCT ?x WHERE { ?x a :StockBroker. ?x :firstName ?name. FILTER regex (?name, " + regex + ")}";
 				String broker = runTest(st, query, true);
 				assertEquals(broker, "<http://www.owl-ontologies.com/Ontology1207768242.owl#person-112>");
 			}
-			String[] wrongs = {
-					"'^j[ANO]*$'",
-					"'j[ANO]*'"
-					};
-			for (String regex : wrongs){
+		}
+		String[] wrongs = {
+				"'^j[ANO]*$'",
+				"'j[ANO]*'"
+				};
+		for (String regex : wrongs){
+			try (OWLStatement st = conn.createStatement()) {
 				String query = "PREFIX : <http://www.owl-ontologies.com/Ontology1207768242.owl#> SELECT DISTINCT ?x WHERE { ?x a :StockBroker. ?x :firstName ?name. FILTER regex (?name, " + regex + ")}";
 				String res = runTest(st, query, false);
 				assertEquals(res, "");

--- a/test/semantic-index/src/test/java/it/unibz/inf/ontop/owlapi/ClassicABoxAssertionTestPositiveNoRangeTest.java
+++ b/test/semantic-index/src/test/java/it/unibz/inf/ontop/owlapi/ClassicABoxAssertionTestPositiveNoRangeTest.java
@@ -45,7 +45,6 @@ public class ClassicABoxAssertionTestPositiveNoRangeTest extends TestCase {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ClassicABoxAssertionTestPositiveNoRangeTest.class);
 
 	private OWLConnection conn;
-	private OWLStatement st;
 
 	public ClassicABoxAssertionTestPositiveNoRangeTest() throws Exception {
 		Properties p = new Properties();
@@ -60,22 +59,23 @@ public class ClassicABoxAssertionTestPositiveNoRangeTest extends TestCase {
 		}
 
 		conn = reasoner.getConnection();
-		st = conn.createStatement();
 	}
 
 	private int executeQuery(String q) throws OWLException {
 		String prefix = "PREFIX : <http://it.unibz.inf/obda/ontologies/quest-typing-test.owl#> \n PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> \n PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>";
 		String query = prefix + " " + q;
 
-		TupleOWLResultSet res = st.executeSelectQuery(query);
-		int count = 0;
-		while (res.hasNext()) {
-            final OWLBindingSet bindingSet = res.next();
-            LOGGER.info(bindingSet.toString());
-			count += 1;
+		try(OWLStatement st = conn.createStatement();
+			TupleOWLResultSet res = st.executeSelectQuery(query)) {
+			int count = 0;
+			while (res.hasNext()) {
+				final OWLBindingSet bindingSet = res.next();
+				LOGGER.info(bindingSet.toString());
+				count += 1;
+			}
+			res.close();
+			return count;
 		}
-		res.close();
-		return count;
 	}
 
 	public void testClassAssertions() throws OWLException {


### PR DESCRIPTION
In its core modules, Ontop provides some interfaces inspired by JDBC like `OBDAStatement` and `OBDAResultSet` for allowing higher-level APIs to issue queries. 

With this design, it was initially expected that the underlying JDBC statement would be closed by closing the `OBDAStatement` just after using it. However, this design is challenged by RDF4J, which does not provide an abstraction similar to JDBC statements.

In this PR, we propose to restrict `OBDAStatement`s to the execution of at most one high-level SPARQL query (i.e. queries issued by the user, not queries involved in the processing of a DESCRIBE query). With this restriction, the  `OBDAResultSet` takes the responsibility of closing the statement when closing itself (except if it is involved in the processing of a DESCRIBE query).

This new style was introduced in https://github.com/ontop/ontop/pull/370 for CONSTRUCT queries. It is now generalized to all SPARQL queries. The implementation of `DefaultSimpleGraphResultSet` has been simplified to delegate the statement management responsibility to the underlying `TupleResultSet`.

In the case of a DESCRIBE query, all the generated SQL queries continue to be executed on the same JDBC statement, so the responsibility of closing the statement goes to the `DefaultDescribeGraphResultSet`, not to the underlying `OBDAResultSet`-s.
