### PR TITLE
Excluded generation of ontop-webapps-[version].zip from release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1609,7 +1609,6 @@
                 <maven.javadoc.skip>false</maven.javadoc.skip>
                 <maven.test.skip>false</maven.test.skip>
                 <assembly.cli.skip>false</assembly.cli.skip>
-                <assembly.webapps.skip>false</assembly.webapps.skip>
                 <assembly.protege.skip>false</assembly.protege.skip>
                 <bundle.protege.phase>package</bundle.protege.phase>
                 <maven.war.skip>false</maven.war.skip>


### PR DESCRIPTION
This change excludes the generation of bundle `ontop-webapps-[version].zip` from the `release` profile.

Note that the two WAR files for modules `ontop-rdf4j-server` and `ontop-rdf4j-workbench` are still generated and will be deployed to maven central at release time (just the ZIP bundle will not be generated).

If that's not desired, we may either:
1. exclude those two Ontop modules in the default configuration of Ontop root `pom.xml`, and then add them back only when profile `webapps` is enabled; or
2. disable `maven-war-plugin`, `maven-install-plugin` and `maven-deploy-plugin` in default configuration of Ontop root `pom.xml` (note: they are already disabled in profiles `cli` and `protege` to speed up build), and enable them only when profile `webapps` is selected.