### PR TITLE
Moved JDBC drivers and repositories from root pom.xml to ontop-docker…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,6 @@
         <filter.main.resources>false</filter.main.resources>
         <filter.test.resources>false</filter.test.resources>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <repo.clojars>false</repo.clojars>
-        <repo.ontop>false</repo.ontop>
         <assembly.cli.skip>true</assembly.cli.skip>
         <assembly.webapps.skip>true</assembly.webapps.skip>
         <assembly.protege.skip>true</assembly.protege.skip>
@@ -131,6 +129,8 @@
         <guava-failureaccess.version>1.0.1</guava-failureaccess.version>
         <guava.version>18.0</guava.version>
         <guice.version>4.1.0</guice.version>
+        <h2gis.version>1.3.2</h2gis.version>
+        <h2.version>1.4.196</h2.version>
         <hikari-cp.version>3.4.5</hikari-cp.version>
         <httpclient.version>4.5.10</httpclient.version>
         <httpcore.version>4.4.14</httpcore.version>
@@ -161,21 +161,6 @@
         <urlbuilder.version>2.0.9</urlbuilder.version>
         <xerces.version>2.12.0</xerces.version>
         <xml-apis.version>1.4.01</xml-apis.version>
-
-        <!-- Dependency versions: JDBC drivers (for test) -->
-        <adp-jdbc.version>0.1.2</adp-jdbc.version>
-        <db2-jcc.version>11.5.4.0</db2-jcc.version>
-        <dremio-jdbc.version>1.4.4</dremio-jdbc.version>
-        <h2gis.version>1.3.2</h2gis.version>
-        <h2.version>1.4.196</h2.version>
-        <hsqldb.version>2.5.1</hsqldb.version>
-        <jtds.version>1.3.1</jtds.version>
-        <monetdb-jdbc.version>11.19.15</monetdb-jdbc.version>
-        <mssql-jdbc.version>8.4.1.jre8</mssql-jdbc.version>
-        <mysql.version>8.0.21</mysql.version>
-        <oracle-ojdbc8.version>19.3.0.0</oracle-ojdbc8.version>
-        <postgresql.version>42.2.14.jre7</postgresql.version>
-        <sap-ngdbc.version>2.6.30</sap-ngdbc.version>
 
         <!-- Dependency versions: indirectly used & pinned for enforcer plugin -->
         <commons-io.version>2.5</commons-io.version>
@@ -1009,7 +994,7 @@
                 <version>${junit.version}</version>
             </dependency>
 
-            <!-- JDBC Drivers (for testing) -->
+            <!-- H2 -->
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
@@ -1019,61 +1004,6 @@
                 <groupId>org.orbisgis</groupId>
                 <artifactId>h2gis-ext</artifactId>
                 <version>${h2gis.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>madgik.adp</groupId>
-                <artifactId>adp-jdbc</artifactId>
-                <version>${adp-jdbc.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.sourceforge.jtds</groupId>
-                <artifactId>jtds</artifactId>
-                <version>${jtds.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>monetdb</groupId>
-                <artifactId>monetdb-jdbc</artifactId>
-                <version>${monetdb-jdbc.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hsqldb</groupId>
-                <artifactId>hsqldb</artifactId>
-                <version>${hsqldb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sap.cloud.db.jdbc</groupId>
-                <artifactId>ngdbc</artifactId>
-                <version>${sap-ngdbc.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.dremio.jdbc</groupId>
-                <artifactId>dremio-jdbc</artifactId>
-                <version>${dremio-jdbc.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.sqlserver</groupId>
-                <artifactId>mssql-jdbc</artifactId>
-                <version>${mssql-jdbc.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.oracle.ojdbc</groupId>
-                <artifactId>ojdbc8</artifactId>
-                <version>${oracle-ojdbc8.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
-                <version>${mysql.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>${postgresql.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.ibm.db2</groupId>
-                <artifactId>jcc</artifactId>
-                <version>${db2-jcc.version}</version>
             </dependency>
 
             <!-- Indirectly used & pinned (for maven-enforcer-plugin) -->
@@ -1124,31 +1054,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <repositories>
-        <repository>
-            <!-- for 3rd party JDBC drivers -->
-            <releases>
-                <enabled>${repo.ontop}</enabled>
-            </releases>
-            <snapshots>
-                <enabled>${repo.ontop}</enabled>
-            </snapshots>
-            <id>bolzano-nexus-public</id>
-            <url>http://obdavm.inf.unibz.it:8080/nexus/content/groups/public/</url>
-        </repository>
-        <repository>
-            <!-- for monetdb -->
-            <releases>
-                <enabled>${repo.clojars}</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>clojars.org</id>
-            <url>http://clojars.org/repo</url>
-        </repository>
-    </repositories>
 
     <build>
         <defaultGoal>package</defaultGoal>

--- a/test/docker-tests/pom.xml
+++ b/test/docker-tests/pom.xml
@@ -16,8 +16,6 @@
     <properties>
         <filter.test.resources>true</filter.test.resources>
         <skipTests>true</skipTests>
-        <repo.ontop>true</repo.ontop>
-        <repo.clojars>true</repo.clojars>
         <docker.url>localhost</docker.url>
         <docker.db2.password>obda-pwd</docker.db2.password>
         <docker.mssql.password>Mssql1.0</docker.mssql.password>
@@ -50,68 +48,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>madgik.adp</groupId>
-            <artifactId>adp-jdbc</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.jtds</groupId>
-            <artifactId>jtds</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-sparql-testsuite</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>monetdb</groupId>
-            <artifactId>monetdb-jdbc</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hsqldb</groupId>
-            <artifactId>hsqldb</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sap.cloud.db.jdbc</groupId>
-            <artifactId>ngdbc</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.dremio.jdbc</groupId>
-            <artifactId>dremio-jdbc</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.microsoft.sqlserver</groupId>
-            <artifactId>mssql-jdbc</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.db2</groupId>
-            <artifactId>jcc</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -119,6 +57,102 @@
             <artifactId>rdf4j-queryparser-serql</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>madgik.adp</groupId>
+            <artifactId>adp-jdbc</artifactId>
+            <version>0.1.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.jtds</groupId>
+            <artifactId>jtds</artifactId>
+            <version>1.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>monetdb</groupId>
+            <artifactId>monetdb-jdbc</artifactId>
+            <version>11.19.15</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.5.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sap.cloud.db.jdbc</groupId>
+            <artifactId>ngdbc</artifactId>
+            <version>2.6.30</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.dremio.jdbc</groupId>
+            <artifactId>dremio-jdbc</artifactId>
+            <version>1.4.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>8.4.1.jre8</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.ojdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>19.3.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.21</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.2.14.jre7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.ibm.db2</groupId>
+            <artifactId>jcc</artifactId>
+            <version>11.5.4.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <!-- for 3rd party JDBC drivers -->
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>bolzano-nexus-public</id>
+            <url>http://obdavm.inf.unibz.it:8080/nexus/content/groups/public/</url>
+        </repository>
+        <repository>
+            <!-- for monetdb -->
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>clojars.org</id>
+            <url>http://clojars.org/repo</url>
+        </repository>
+    </repositories>
 
 </project>

--- a/test/rdb2rdf-compliance/pom.xml
+++ b/test/rdb2rdf-compliance/pom.xml
@@ -13,7 +13,6 @@
     <artifactId>ontop-rdb2rdf-compliance</artifactId>
 
     <properties>
-        <repo.ontop>true</repo.ontop>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 


### PR DESCRIPTION
Dependencies for JDBC drivers (except H2) moved from `dependencyManagement` of root `pom.xml` to `dependencies` of module `ontop-docker-tests`, which is the only one using them.

Extra repositories `clojars.org` and `bolzano-nexus-public` also moved to `ontop-docker-tests`, which is the only one using them. There they are always enabled, i.e., enabling properties `repo.clojars` and `repo.ontop` have been removed.

Repository `bolzano-nexus-public` removed from `ontop-rdb2rdf-compliance`, where it is not actually needed.