### PR TITLE
Feature/GitHub maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
         <semargl-sesame.version>0.6.1</semargl-sesame.version>
         <semargl.version>0.7</semargl.version>
         <sesame.version>2.7.16</sesame.version>
+        <tomcat-embed-core.version>9.0.37</tomcat-embed-core.version>
     </properties>
 
     <dependencyManagement>
@@ -1062,6 +1063,11 @@
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
                 <version>${junit-jupiter-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat-embed-core.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/test/docker-tests/pom.xml
+++ b/test/docker-tests/pom.xml
@@ -143,8 +143,8 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <id>third-party-jars</id>
-            <url>https://raw.githubusercontent.com/fracorco/third-party-jars/master/releases/</url>
+            <id>ontop-maven-repo</id>
+            <url>https://raw.githubusercontent.com/ontop/ontop-maven-repo/master/repository/</url>
         </repository>
     </repositories>
 

--- a/test/docker-tests/pom.xml
+++ b/test/docker-tests/pom.xml
@@ -131,26 +131,20 @@
 
     <repositories>
         <repository>
-            <!-- for 3rd party JDBC drivers -->
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>bolzano-nexus-public</id>
-            <url>http://obdavm.inf.unibz.it:8080/nexus/content/groups/public/</url>
-        </repository>
-        <repository>
-            <!-- for monetdb -->
+            <!--
+                For 3rd party JDBC drivers:
+                - madgit.adp:adp-jdbc:0.1.2
+                - monetdb:monetdb-jdbc:11.19.15
+                - com.dremio.jdbc:dremio-jdbc:1.4.4
+            -->
             <releases>
                 <enabled>true</enabled>
             </releases>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <id>clojars.org</id>
-            <url>http://clojars.org/repo</url>
+            <id>third-party-jars</id>
+            <url>https://raw.githubusercontent.com/fracorco/third-party-jars/master/releases/</url>
         </repository>
     </repositories>
 

--- a/test/docker-tests/pom.xml
+++ b/test/docker-tests/pom.xml
@@ -143,8 +143,8 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <id>ontop-maven-repo</id>
-            <url>https://raw.githubusercontent.com/ontop/ontop-maven-repo/master/repository/</url>
+            <id>ontop-3rd-party-maven-repo</id>
+            <url>https://raw.githubusercontent.com/ontop/ontop-3rd-party-maven-repo/master/repository/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This pull request aims at replacing custom Maven repositories `clojars` and `bolzano-nexus-public`, which are deemed too slow, with a new custom Maven repository hosted directly on GitHub, and consisting of a [Git repository](https://github.com/ontop/ontop-maven-repo) owned by the ontop GitHub team. 

Everything works, but I invite you to consider the following:

1. Decide on repository name `ontop-maven-repo`. Previously we discussed using `third-party-jars`, but I realized that this repository may be also used to deploy Ontop-related artifacts (e.g., Ontop snapshots not ready for Maven central, or the JARs of some other project under the ontop team that is not meant/ready to go on Maven central), so I switched to a more general name.

2. Read the [README.txt](https://github.com/ontop/ontop-maven-repo/blob/master/README.md) of such repository, focusing in particular on the disclaimers about license and third-party use (the instructions have been tested and work fine). Note that if we pick a different repository name the content of the README file should be adapted correspondingly.

3. Please be aware that this feature branch also include a somehow unrelated change, i.e., the pinning of `tomcat-embed-core` to a specific version in the root `pom.xml`. That was needed for some reason in order to satisfy the `maven-enforcer-plugin`. If you prefer, we can implement this change as a separate bug fix.