### PR TITLE
Changed ontop script to ensure SIGINT signals are received by ontop java process

### DIFF
--- a/client/cli/src/main/resources/ontop
+++ b/client/cli/src/main/resources/ontop
@@ -25,5 +25,5 @@ if [ -z "${ONTOP_FILE_ENCODING}" ]; then
   ONTOP_FILE_ENCODING="UTF-8"
 fi
 
-${JAVA} ${ONTOP_JAVA_ARGS} -cp "${ONTOP_HOME}/lib/*:${ONTOP_HOME}/jdbc/*" -Dfile.encoding=${ONTOP_FILE_ENCODING} -Dlogback.configurationFile="${ONTOP_HOME}/log/logback.xml" -Dlogging.config="${ONTOP_HOME}/log/logback.xml" \
+exec ${JAVA} ${ONTOP_JAVA_ARGS} -cp "${ONTOP_HOME}/lib/*:${ONTOP_HOME}/jdbc/*" -Dfile.encoding=${ONTOP_FILE_ENCODING} -Dlogback.configurationFile="${ONTOP_HOME}/log/logback.xml" -Dlogging.config="${ONTOP_HOME}/log/logback.xml" \
  it.unibz.inf.ontop.cli.Ontop $@


### PR DESCRIPTION
Trivial change to `ontop` bash script consisting in calling java through `exec`, so that java is run in the same process (no forking) and SIGINT (or other) signals targeting the script, such as the ones sent by process controllers like [supervisord](http://supervisord.org/), are received and properly handled (e.g., clean shutdown) by ontop.

Evaluated by building & testing ontop bundles and Docker image. Everything works.

Fixes bug #414 

