### PR TITLE
Fix "cli" profile build error when ontop-rdf4j-* WAR generation is disabled

### DIFF
--- a/build/distribution/pom.xml
+++ b/build/distribution/pom.xml
@@ -18,46 +18,34 @@
         <assembly.attach>false</assembly.attach>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>ontop-protege</artifactId>
+                <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>*</artifactId>
+                        <groupId>*</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ontop-owlapi</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ontop-rdf4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>ontop-cli</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>ontop-rdf4j-server</artifactId>
-            <type>war</type>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>ontop-rdf4j-workbench</artifactId>
-            <type>war</type>
-        </dependency>
-        <dependency>
-            <!-- this dependency serves to order ontop-distribution after ontop-protege
-                 during a multi-module build, so that ontop-protege bundle can be
-                 resolved from reactor instead of having to install & download it from
-                 a maven repository -->
-            <groupId>${project.groupId}</groupId>
-            <artifactId>ontop-protege</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>*</artifactId>
-                    <groupId>*</groupId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
         </dependency>
     </dependencies>
 
@@ -241,5 +229,54 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>cli</id>
+            <dependencies>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>ontop-cli</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>protege</id>
+            <dependencies>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>ontop-protege</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>webapps</id>
+            <dependencies>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>ontop-rdf4j-server</artifactId>
+                    <type>war</type>
+                </dependency>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>ontop-rdf4j-workbench</artifactId>
+                    <type>war</type>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>release</id>
+            <dependencies>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>ontop-cli</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>ontop-protege</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/build/distribution/src/assembly/ontop-cli.xml
+++ b/build/distribution/src/assembly/ontop-cli.xml
@@ -22,14 +22,14 @@
 				<include>logback-debug.xml</include>
 			</includes>
 		</fileSet>
-        <fileSet>
-            <directory>${maven.multiModuleProjectDirectory}/client/cli/src/main/resources/
-            </directory>
-            <outputDirectory>/</outputDirectory>
-            <includes>
-                <include>*</include>
-            </includes>
-        </fileSet>
+		<fileSet>
+			<directory>${maven.multiModuleProjectDirectory}/client/cli/src/main/resources/
+			</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>*</include>
+			</includes>
+		</fileSet>
 		<fileSet>
 			<directory>${maven.multiModuleProjectDirectory}/engine/owlapi/src/main/resources/
 			</directory>

--- a/client/docker/build-image.sh
+++ b/client/docker/build-image.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 ONTOP_HOME=${CURRENT_DIR}/../..

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <assembly.webapps.skip>true</assembly.webapps.skip>
         <assembly.protege.skip>true</assembly.protege.skip>
         <bundle.protege.phase>none</bundle.protege.phase>
-        <maven.war.skip>false</maven.war.skip>
+        <maven.war.skip>true</maven.war.skip>
         <metadata.git.skip>true</metadata.git.skip>
         <metadata.buildInfo.phase>none</metadata.buildInfo.phase>
         <thirdparty.skip>true</thirdparty.skip>
@@ -1494,7 +1494,6 @@
                 <maven.javadoc.skip>true</maven.javadoc.skip>
                 <maven.test.skip>true</maven.test.skip>
                 <assembly.cli.skip>false</assembly.cli.skip>
-                <maven.war.skip>true</maven.war.skip>
             </properties>
         </profile>
         <profile>
@@ -1509,7 +1508,6 @@
                 <maven.test.skip>true</maven.test.skip>
                 <assembly.protege.skip>false</assembly.protege.skip>
                 <bundle.protege.phase>package</bundle.protege.phase>
-                <maven.war.skip>true</maven.war.skip>
             </properties>
         </profile>
         <profile>
@@ -1539,7 +1537,6 @@
                 <assembly.cli.skip>false</assembly.cli.skip>
                 <assembly.protege.skip>false</assembly.protege.skip>
                 <bundle.protege.phase>package</bundle.protege.phase>
-                <maven.war.skip>false</maven.war.skip>
             </properties>
         </profile>
 


### PR DESCRIPTION
**tldr; dependencies of ontop-distribution now depend on active profile, to avoid failures when RDF4J wars are not built and are not available online**

This issue was likely present in version 4.1 too but I didn't notice it as it occurs only in very specific conditions.

Cause:
* maven is called with `cli` profile enabled (e.g., by `client/docker/build-image.sh`)
* the `cli` profile (as well as `protege` and `release` ones) skip the generation of the ontop-rdf4j-* WAR files
* still, ontop-distribution was unconditionally depending on those WAR files (for the case profile `webapps` was activated)
* if Maven could not resolve these WAR files locally (i.e., in the scope of current build) it tries to download them from remote repositories
  * that was working in version 4.1, so I didn't realize the issue
  * that did not work right after version was changed to 4.2-snapshot, as there were no JAR/WARs uploaded online for this new version yet
  * that started working again this evening while testing for version 4.2-snapshot, as apparently artifacts were uploaded to an online Maven repo

Fix:
* I changed ontop-distribution pom.xml so that dependencies are controlled by active profile, so Maven does not look anymore for these WAR files in case their generation is not enabled by current profile

Additional changes:
* I disabled by default the generation of WAR files, which was still done with profile -Prelease (although they were not zipped in a 
  release ZIP file under ontop-distribution/target). WAR files are now generated only if profile webapps is enabled.
* I added "set -e" at the beginning of build-image.sh, to prevent the script from continuing execution if Maven (or other build step) fails

Note: currently, profiles do not affect the Ontop modules included in the build, so all modules are always considered. What changes is only which Maven plugins are run on each module. In general, expensive plugins are disabled in profiles where they are not needed, while inexpensive plugins run always. This may be changed in case.