### PR TITLE
Optional properties file

### DIFF
--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopBootstrap.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopBootstrap.java
@@ -32,8 +32,10 @@ public class OntopBootstrap extends OntopMappingOntologyRelatedCommand {
 
             Objects.requireNonNull(owlFile, "ontology file must not be null");
 
-            OntopSQLOWLAPIConfiguration.Builder<? extends OntopSQLOWLAPIConfiguration.Builder> builder = OntopSQLOWLAPIConfiguration.defaultBuilder()
-                    .propertyFile(propertiesFile);
+            OntopSQLOWLAPIConfiguration.Builder<? extends OntopSQLOWLAPIConfiguration.Builder> builder = OntopSQLOWLAPIConfiguration.defaultBuilder();
+
+            if (propertiesFile != null)
+                builder.propertyFile(propertiesFile);
 
             if (dbPassword != null)
                 builder.jdbcPassword(dbPassword);
@@ -43,6 +45,12 @@ public class OntopBootstrap extends OntopMappingOntologyRelatedCommand {
 
             if (dbUser != null)
                 builder.jdbcUser(dbUser);
+
+            if (dbName != null)
+                builder.jdbcName(dbName);
+
+            if (dbDriver != null)
+                builder.jdbcDriver(dbDriver);
 
             if (dbMetadataFile != null)
                 builder.dbMetadataFile(dbMetadataFile);

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopEndpoint.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopEndpoint.java
@@ -63,12 +63,15 @@ public class OntopEndpoint extends OntopReasoningCommandBase {
 
         ArrayList<String> argList = Lists.newArrayList(
                 "--mapping=" + this.mappingFile,
-                "--properties=" + this.propertiesFile,
+                //"--properties=" + this.propertiesFile,
                 "--port=" + this.port,
                 "--lazy=" + this.lazy,
                 "--dev=" + this.dev,
                 "--disable-portal-page=" + this.disablePortalPage
                 );
+
+        if (this.propertiesFile != null)
+            argList.add("--properties=" + this.propertiesFile);
 
         if (this.corsAllowedOrigins != null)
             argList.add("--cors-allowed-origins=" + this.corsAllowedOrigins);
@@ -108,6 +111,12 @@ public class OntopEndpoint extends OntopReasoningCommandBase {
 
         if (dbUrl != null)
             argList.add("--db-url=" + this.dbUrl);
+
+        if (dbName != null)
+            argList.add("--db-name=" + this.dbName);
+
+        if (dbDriver != null)
+            argList.add("--db-driver=" + this.dbDriver);
 
         String[] args = new String[argList.size()];
         argList.toArray(args);

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMappingOntologyRelatedCommand.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMappingOntologyRelatedCommand.java
@@ -22,7 +22,7 @@ abstract class OntopMappingOntologyRelatedCommand implements OntopCommand {
 
     @Option(type = OptionType.COMMAND, name = {"-p", "--properties"}, title = "properties file",
             description = "Properties file")
-    @Required
+    //@Required
     @BashCompletion(behaviour = CompletionBehaviour.FILENAMES)
     String propertiesFile;
 
@@ -55,6 +55,16 @@ abstract class OntopMappingOntologyRelatedCommand implements OntopCommand {
             description = "DB URL (overrides the properties)")
     @BashCompletion(behaviour = CompletionBehaviour.FILENAMES)
     String dbUrl;
+
+    @Option(type = OptionType.COMMAND, name = {"--db-name"}, title = "DB name",
+            description = "DB name (overrides the properties)")
+    @BashCompletion(behaviour = CompletionBehaviour.FILENAMES)
+    String dbName;
+
+    @Option(type = OptionType.COMMAND, name = {"--db-driver"}, title = "DB driver",
+            description = "DB driver (overrides the properties)")
+    @BashCompletion(behaviour = CompletionBehaviour.FILENAMES)
+    String dbDriver;
 
     protected boolean isR2rmlFile(String mappingFile) {
         return !mappingFile.endsWith(".obda");

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopQuery.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopQuery.java
@@ -66,9 +66,12 @@ public class OntopQuery extends OntopReasoningCommandBase {
         }
 
         OntopSQLOWLAPIConfiguration.Builder configurationBuilder = OntopSQLOWLAPIConfiguration.defaultBuilder()
-                .propertyFile(propertiesFile)
                 .ontology(ontology)
                 .enableOntologyAnnotationQuerying(enableAnnotations);
+
+        if (propertiesFile != null) {
+            configurationBuilder.propertyFile(propertiesFile);
+        }
 
         if (isR2rmlFile(mappingFile)) {
             configurationBuilder.r2rmlMappingFile(mappingFile);
@@ -90,6 +93,12 @@ public class OntopQuery extends OntopReasoningCommandBase {
 
         if (dbUser != null)
             configurationBuilder.jdbcUser(dbUser);
+
+        if (dbName != null)
+            configurationBuilder.jdbcName(dbName);
+
+        if (dbDriver != null)
+            configurationBuilder.jdbcDriver(dbDriver);
 
         OntopOWLFactory factory = OntopOWLFactory.defaultFactory();
 

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopValidate.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopValidate.java
@@ -33,8 +33,11 @@ public class OntopValidate extends OntopMappingOntologyRelatedCommand {
 
         OntopSQLOWLAPIConfiguration.Builder<? extends OntopSQLOWLAPIConfiguration.Builder> builder =
                 OntopSQLOWLAPIConfiguration.defaultBuilder()
-                        .ontologyFile(owlFile)
-                        .propertyFile(propertiesFile);
+                        .ontologyFile(owlFile);
+        //                .propertyFile(propertiesFile);
+
+        if (propertiesFile != null)
+            builder.propertyFile(propertiesFile);
 
         if (dbPassword != null)
             builder.jdbcPassword(dbPassword);
@@ -44,6 +47,12 @@ public class OntopValidate extends OntopMappingOntologyRelatedCommand {
 
         if (dbUser != null)
             builder.jdbcUser(dbUser);
+
+        if (dbName != null)
+            builder.jdbcName(dbName);
+
+        if (dbDriver != null)
+            builder.jdbcDriver(dbDriver);
 
         if (isR2rmlFile(mappingFile))
             builder.r2rmlMappingFile(mappingFile);

--- a/client/cli/src/test/java/it/unibz/inf/ontop/cli/OntopEndpointTest.java
+++ b/client/cli/src/test/java/it/unibz/inf/ontop/cli/OntopEndpointTest.java
@@ -24,15 +24,24 @@ public class OntopEndpointTest {
     @ClassRule
     public static ExternalResource h2Connection = new H2ExternalResourceForBookExample();
     private static String PORT = "29831";
+    private static String DBNAME = "books";
+    private static String DBURL = "jdbc:h2:tcp://localhost:19123/./src/test/resources/h2/books;ACCESS_MODE_DATA=r";
+    private static String DBUSER = "sa";
+    private static String DBPASSWORD = "test";
 
 
     @BeforeClass
     public static void setupEndpoint() {
         Ontop.main("endpoint", "-m", "src/test/resources/books/exampleBooks.obda",
-                "-p", "src/test/resources/books/exampleBooks.properties",
+                //"-p", "src/test/resources/books/exampleBooks.properties",
                 "-t", "src/test/resources/books/exampleBooks.owl",
-                "-d", "src/test/resources/output/exampleBooks-metadata.json",
+                //"-d", "src/test/resources/output/exampleBooks-metadata.json",
                 //"-v", "src/test/resources/output/exampleBooks-metadata.json",
+                "--db-url=" + DBURL,
+                //"--db-driver="
+                "--db-user=" + DBUSER,
+                "--db-name=" + DBNAME,
+                "--db-password=" + DBPASSWORD,
                 "--port=" + PORT);
     }
 

--- a/client/docker/README.md
+++ b/client/docker/README.md
@@ -9,7 +9,7 @@ One can either use `ontop/ontop-endpoint` directly, or create a dedicated image 
 Here is a list of environment variables. Most of them directly correspond to arguments of the CLI `ontop-endpoint`command. Please refer to [its documentation page for more details about these arguments](https://ontop-vkg.org/guide/cli.html#ontop-endpoint).
 
 - `ONTOP_MAPPING_FILE` (required). Corresponds to the argument `--mapping`.
-- `ONTOP_PROPERTIES_FILE` (required). Corresponds to the argument `--properties`.
+- `ONTOP_PROPERTIES_FILE` (optional). Corresponds to the argument `--properties`.
 - `ONTOP_ONTOLOGY_FILE` (optional). Corresponds to the argument `--ontology`.
 - `ONTOP_DB_PASSWORD` (optional). Corresponds to the argument `--db-password`. Added in 4.1.0.
 - `ONTOP_DB_PASSWORD_FILE` (optional). Loads the DB password from a separate file (e.g. a Docker secret) and assigns it to the argument `--db-password`. Introduced in 4.1.0.
@@ -17,6 +17,8 @@ Here is a list of environment variables. Most of them directly correspond to arg
 - `ONTOP_DB_USER_FILE` (optional). Loads the DB user from a separate file (e.g. a Docker secret) and assigns it to the argument `--db-user`. Introduced in 4.1.0.
 - `ONTOP_DB_URL` (optional). Corresponds to the argument `--db-url`. Added in 4.1.0.
 - `ONTOP_DB_URL_FILE` (optional). Loads the DB url from a separate file (e.g. a Docker secret) and assigns it to the argument `--db-url`. Introduced in 4.1.0.
+- `ONTOP_DB_NAME` (optional). Corresponds to the argument `--db-name`. Added in 4.2.0.
+- `ONTOP_DB_DRIVER` (optional). Corresponds to the argument `--db-driver`. Added in 4.2.0.
 - `ONTOP_XML_CATALOG_FILE` (optional). Corresponds to the argument `--xml-catalog`.
 - `ONTOP_CONSTRAINT_FILE` (optional). Corresponds to the argument `--constraint`.
 - `ONTOP_DB_METADATA_FILE` (optional). Corresponds to the argument `--db-metadata`. Added in 4.1.0.

--- a/client/docker/entrypoint.sh
+++ b/client/docker/entrypoint.sh
@@ -31,8 +31,6 @@ fi
 
 if [ "${ONTOP_PROPERTIES_FILE+x}" ]; then
   args_array+=("--properties=${ONTOP_PROPERTIES_FILE}")
-else
-  echo "ERROR: environment variable ONTOP_PROPERTIES_FILE is not set" && exit 1
 fi
 
 if [ "${ONTOP_DB_USER+x}" ]; then
@@ -66,6 +64,14 @@ if [ "${ONTOP_DB_URL_FILE+x}" ]; then
     echo "ERROR: environment variables ONTOP_DB_URL and ONTOP_DB_URL_FILE are conflicting. Please choose one of the two." && exit 1
   fi
   args_array+=("--db-url=$(< "${ONTOP_DB_URL_FILE}")")
+fi
+
+if [ "${ONTOP_DB_NAME+x}" ]; then
+  args_array+=("--db-name=${ONTOP_DB_NAME}")
+fi
+
+if [ "${ONTOP_DB_DRIVER+x}" ]; then
+  args_array+=("--db-driver=${ONTOP_DB_DRIVER}")
 fi
 
 if [ "${ONTOP_XML_CATALOG_FILE+x}" ]; then

--- a/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/beans/OntopVirtualRepositoryBean.java
+++ b/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/beans/OntopVirtualRepositoryBean.java
@@ -16,15 +16,19 @@ public class OntopVirtualRepositoryBean {
     private OntopSystemConfiguration setupOntopConfiguration(@Value("${mapping}") String mappings,
                                                              @Value("${ontology:#{null}}") String ontology,
                                                              @Value("${xml-catalog:#{null}}") String xmlCatalog,
-                                                             @Value("${properties}") String properties,
+                                                             @Value("${properties:#{null}}") String properties,
                                                              @Value("${constraint:#{null}}") String constraint,
                                                              @Value("${db-metadata:#{null}}") String dbMetadata,
                                                              @Value("${ontop-views:#{null}}") String ontopViews,
                                                              @Value("${db-user:#{null}}") String dbUser,
                                                              @Value("${db-password:#{null}}") String dbPassword,
-                                                             @Value("${db-url:#{null}}") String dbUrl) throws RepositoryException {
-        OntopSQLOWLAPIConfiguration.Builder<? extends OntopSQLOWLAPIConfiguration.Builder> builder = OntopSQLOWLAPIConfiguration.defaultBuilder()
-                .propertyFile(properties);
+                                                             @Value("${db-url:#{null}}") String dbUrl,
+                                                             @Value("${db-name:#{null}}") String dbName,
+                                                             @Value("${db-driver:#{null}}") String dbDriver) throws RepositoryException {
+        OntopSQLOWLAPIConfiguration.Builder<? extends OntopSQLOWLAPIConfiguration.Builder> builder = OntopSQLOWLAPIConfiguration.defaultBuilder();
+
+        if (properties != null && !properties.isEmpty())
+            builder.propertyFile(properties);
 
         if (mappings.endsWith(".obda"))
             builder.nativeOntopMappingFile(mappings);
@@ -55,6 +59,13 @@ public class OntopVirtualRepositoryBean {
 
         if (dbUrl != null && !dbUrl.isEmpty())
             builder.jdbcUrl(dbUrl);
+
+        if (dbName != null && !dbName.isEmpty())
+            builder.jdbcName(dbName);
+
+        //TODO Can this be empty?
+        if (dbDriver != null && !dbDriver.isEmpty())
+            builder.jdbcDriver(dbDriver);
 
         return builder.build();
     }

--- a/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/controllers/AutoRestartController.java
+++ b/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/controllers/AutoRestartController.java
@@ -25,7 +25,7 @@ public class AutoRestartController {
 
     @Autowired
     public AutoRestartController(@Value("${mapping}") String mappingFile,
-                                 @Value("${properties}") String propertiesFile,
+                                 @Value("${properties:#{null}}") String propertiesFile,
                                  @Value("${ontology:#{null}}") String owlFile,
                                  @Value("${portal:#{null}}") String portalFile) {
         registerFileWatcher(mappingFile, owlFile, propertiesFile, portalFile);
@@ -36,7 +36,7 @@ public class AutoRestartController {
         OntopEndpointApplication.restart();
     }
 
-    private void registerFileWatcher(String mappingFile, @Nullable String owlFile, String propertiesFile, @Nullable String portalFile) {
+    private void registerFileWatcher(String mappingFile, @Nullable String owlFile, @Nullable String propertiesFile, @Nullable String portalFile) {
         FileSystem fileSystem = FileSystems.getDefault();
 
         ImmutableList<Path> filesToWatch = Stream.of(mappingFile, owlFile, propertiesFile, portalFile)


### PR DESCRIPTION
This pull request renders the use of a .properties file as an argument for the Ontop CLI and Docker optional.

The user can now define all of the properties either via 
* command line, e.g. ```./ontop endpoint --ontology=bsbm.owl --mapping=bsbm.obda --properties=bsbm.properties --db-user=postgres --db-password=postgres --db-url=jdbc:postgresql://localhost/benchmark --db-name=test0 --db-driver=org.postgresql.Driver``` or,  
* docker-compose, e.g. https://github.com/GeoKnow/LinkedGeoData/blob/test/ontop-optional-properties-file/linkedgeodata-docker/docker-compose.yml#L86

The existing settings were not modified therefore if these arguments are set manually in this manner and a .properties file is provided, the former will overwrite any values in the properties file.

One of the advantages when not using the properties file is that when arguments are missing the messages generated by Ontop are already more informative e.g. ```it.unibz.inf.ontop.exception.InvalidOntopConfigurationException: jdbc.url is required``` vs. ```Exception: org.postgresql.util.PSQLException: FATAL: no PostgreSQL user name specified in startup packet```.

A particularly useful scenario is the docker [case above](https://github.com/GeoKnow/LinkedGeoData/blob/test/ontop-optional-properties-file/linkedgeodata-docker/docker-compose.yml#L86) where an environment variable can be modified in the env.dist file and when such values change they can be propagated easily across any other interdependent containers including ontop.