### PR TITLE
Preserve SRID in nested GeoSPARQL expressions

### DIFF
--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/GeoSPARQLTest.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/GeoSPARQLTest.java
@@ -20,6 +20,7 @@ import java.sql.DriverManager;
 
 import static it.unibz.inf.ontop.utils.OWLAPITestingTools.executeFromFile;
 import static junit.framework.TestCase.*;
+import static org.junit.Assert.assertEquals;
 
 public class GeoSPARQLTest {
 
@@ -1397,8 +1398,24 @@ public class GeoSPARQLTest {
                 "geo:asWKT ?w2 .\n" +
                 "BIND(geof:distance(?w1,?w2,uom:metre) as ?x) .\n" +
                 "} LIMIT 1\n";
-        Double val = runQueryAndReturnDoubleX(query);
-        assertEquals(111657.03929352836, val);
+        double val = runQueryAndReturnDoubleX(query);
+        assertEquals(111657.03929352836, val, 1);
+    }
+
+    @Test // ST_BUFFER as sub-argument of ST_WITHIN
+    public void testAskWithinBuffer() throws Exception {
+        String query = "PREFIX : <http://ex.org/> \n" +
+                "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\n" +
+                "PREFIX geof: <http://www.opengis.net/def/function/geosparql/>\n" +
+                "PREFIX uom: <http://www.opengis.net/def/uom/OGC/1.0/>\n" +
+                "ASK WHERE {\n" +
+                "<http://ex.org/feature/1> a :Feature; geo:hasGeometry/geo:asWKT ?xWkt.\n" +
+                "<http://ex.org/feature/2> a :Feature; geo:hasGeometry/geo:asWKT ?yWkt.\n" +
+                "BIND(geof:buffer(?yWkt, 3500000, uom:metre) AS ?bWkt) .\n" +
+                "FILTER (geof:sfWithin(?xWkt, ?bWkt))\n" +
+                "}\n";
+        boolean val = runQueryAndReturnBooleanX(query);
+        assertTrue(val);
     }
 
     private boolean runQueryAndReturnBooleanX(String query) throws Exception {

--- a/binding/owlapi/src/test/resources/geosparql/geosparql-h2.obda
+++ b/binding/owlapi/src/test/resources/geosparql/geosparql-h2.obda
@@ -55,8 +55,8 @@ target		:feature/{ID} a :Feature ; geo:hasGeometry :geomid/{GID} ; rdfs:label {N
 source		SELECT * FROM FEATURES
 
 mappingId	features
-target		:geomid/{GID} a :Geom ; geo:asWKT {THE_GEOM}^^geo:wktLiteral .
-source		SELECT * FROM FEATURES
+target		:geomid/{GID} a :Geom ; geo:asWKT {THE_NEW_GEOM}^^geo:wktLiteral .
+source		SELECT *, ST_SETSRID(THE_GEOM, '4326') AS THE_NEW_GEOM FROM FEATURES
 
 mappingId	rivers
 target		:rivers/{id} a :River ; geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> POINT ({lon} {lat})"^^geo:wktLiteral .


### PR DESCRIPTION
This pull request provides a solution to a GeoSPARQL bug due to mixed SRIDs.

Background on bug:
* Non-topological functions are always enveloped with ST_ASTEXT in order to render the WKT i.e. POINT(x,y) rather than some unintelligible serialization.
* However, ST_ASTEXT resets SRID to 0.
* If the ST_BUFFER clause (or any other non-topological clause) is an argument of another topological/non-topological clause e.g. ST_WITHIN(geom1, ST_BUFFER(geom2)), then we have geom1 -> SRID 4326 and ST_ASTEXT(ST_BUFFER(geom2)) -> SRID 0

Proposed solution:
In case an argument of a GeoSPARQL function is another functions i.e. CAST(ST_ASTEXT(GeoSPARQLFunction) AS TEXT), then we unwrap it and retrieve the GeoSPARQLFunction.

Testing:
Because Ontop still uses H2GIS v1.+, in order to check whether it is working the debug mode in the log needs to active to inspect the resulting query for testAskWithinBuffer. H2GIS v1.+ allows operations between any geometry with SRID=0 and geometries with any other SRID. This is not an issue in H2GIS v2.+ (once the upgrade occurs) and PostGIS which correctly throw an error. Another useful test which now passes is [Q7 in the LGD project](https://github.com/GeoKnow/LinkedGeoData/blob/develop/lgd-docker/lgd-ontop-web/lgd.portal.toml#L160).