### PR TITLE
ontop-590 FIXED OracleDBMetaDataProvider add additional owner exclusions

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/OracleDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/OracleDBMetadataProvider.java
@@ -90,6 +90,8 @@ public class OracleDBMetadataProvider extends DefaultSchemaDBMetadataProvider {
                         "'LBACSYS', " +
                         "'DVSYS', " +
                         "'APPQOSSYS', " +
+                        "'WMSYS', " +
+                        "'ORDDATA', " +
                         "'AUDSYS') AND " +
                 "   NOT (owner = 'SYSTEM' AND table_name IN ('ROLLING$DIRECTIVES', " +
                         "'SCHEDULER_JOB_ARGS_TBL', " +


### PR DESCRIPTION
Fixes #590 