### PR TITLE
Cleaning up Trino/Presto/Athena/Redshift/DuckDB Adapters

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DuckDBDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DuckDBDBFunctionSymbolFactory.java
@@ -149,7 +149,7 @@ public class DuckDBDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
 
     @Override
     protected DBConcatFunctionSymbol createRegularDBConcat(int arity) {
-        return createNullRejectingDBConcat(arity);
+        return new NullToleratingDBConcatFunctionSymbol("CONCAT", arity, dbStringType, abstractRootDBType, false);
     }
 
     @Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/RedshiftDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/RedshiftDBFunctionSymbolFactory.java
@@ -28,20 +28,9 @@ public class RedshiftDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
         Table<String, Integer, DBFunctionSymbol> table = HashBasedTable.create(
                 createDefaultRegularFunctionTable(typeFactory));
 
-        /*  TODO-SCAFFOLD: Remove function symbols that are not supported, if any:
-         *-------------------------------------------------------------------
-         *      table.remove("UNSUPPORTED_FUNCTION", arity);
-         */
         table.remove(REGEXP_LIKE_STR, 2);
         table.remove(REGEXP_LIKE_STR, 3);
 
-        /*  TODO-SCAFFOLD: Change signature of basic functions, if necessary:
-         *-------------------------------------------------------------------
-         *      DBFunctionSymbol nowFunctionSymbol = new WithoutParenthesesSimpleTypedDBFunctionSymbolImpl(
-         *              CURRENT_TIMESTAMP_STR,
-         *              dbTypeFactory.getDBDateTimestampType(), abstractRootDBType);
-         *      table.put(CURRENT_TIMESTAMP_STR, 0, nowFunctionSymbol);
-         */
         DBFunctionSymbol nowFunctionSymbol = new WithoutParenthesesSimpleTypedDBFunctionSymbolImpl(
                 CURRENT_TIMESTAMP_STR,
                 dbTypeFactory.getDBDateTimestampType(), abstractRootDBType);
@@ -52,7 +41,6 @@ public class RedshiftDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
 
 
 
-    // TODO-SCAFFOLD: Modify this default implementation, if necessary
     @Override
     protected String serializeContains(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         return String.format("(POSITION(%s IN %s) > 0)",
@@ -60,7 +48,6 @@ public class RedshiftDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
                 termConverter.apply(terms.get(0)));
     }
 
-    // TODO-SCAFFOLD: Modify this default implementation, if necessary
     @Override
     protected String serializeStrBefore(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String str = termConverter.apply(terms.get(0));
@@ -69,7 +56,6 @@ public class RedshiftDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
         return String.format("CASE POSITION(%s IN %s) WHEN 0 THEN '' ELSE SUBSTRING(%s,1,POSITION(%s IN %s)-1) END", before, str, str, before, str);
     }
 
-    // TODO-SCAFFOLD: Modify this default implementation, if necessary
     @Override
     protected String serializeStrAfter(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String str = termConverter.apply(terms.get(0));
@@ -77,37 +63,31 @@ public class RedshiftDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
         return String.format("CASE POSITION(%s IN %s) WHEN 0 THEN '' ELSE SUBSTRING(%s, POSITION(%s IN %s) + LENGTH(%s)) END", after, str, str, after, str, after);
     }
 
-    // TODO-SCAFFOLD: Modify this default implementation, if necessary
     @Override
     protected String serializeMD5(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         return String.format("MD5(%s)", termConverter.apply(terms.get(0)));
     }
 
-    // TODO-SCAFFOLD: Modify this default implementation, if necessary
     @Override
     protected String serializeSHA1(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         return String.format("SHA1(%s)", termConverter.apply(terms.get(0)));
     }
 
-    // TODO-SCAFFOLD: Modify this default implementation, if necessary
     @Override
     protected String serializeSHA256(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         return String.format("SHA2(%s, 256)", termConverter.apply(terms.get(0)));
     }
 
-    // TODO-SCAFFOLD: Modify this default implementation, if necessary
     @Override
     protected String serializeSHA384(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         return String.format("SHA2(%s, 384)", termConverter.apply(terms.get(0)));
     }
 
-    // TODO-SCAFFOLD: Modify this default implementation, if necessary
     @Override
     protected String serializeSHA512(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         return String.format("SHA2(%s, 512)", termConverter.apply(terms.get(0)));
     }
 
-    // TODO-SCAFFOLD: Modify this default implementation, if necessary
     @Override
     protected String serializeTz(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String str = termConverter.apply(terms.get(0));
@@ -117,32 +97,28 @@ public class RedshiftDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
 
 
 
-    // TODO-SCAFFOLD: Modify this default implementation, if necessary
     @Override
     protected DBConcatFunctionSymbol createNullRejectingDBConcat(int arity) {
         return createDBConcatOperator(arity);
     }
 
-    // TODO-SCAFFOLD: Modify this default implementation, if necessary
     @Override
     protected DBConcatFunctionSymbol createDBConcatOperator(int arity) {
         return new NullRejectingDBConcatFunctionSymbol(CONCAT_OP_STR, arity, dbStringType, abstractRootDBType,
                 Serializers.getOperatorSerializer(CONCAT_OP_STR));
     }
 
-    // TODO-SCAFFOLD: Modify this default implementation, if necessary
     @Override
     protected DBConcatFunctionSymbol createRegularDBConcat(int arity) {
-        return createNullRejectingDBConcat(arity);
+        return new NullToleratingDBConcatFunctionSymbol("CONCAT", arity, dbStringType, abstractRootDBType, false);
     }
 
-    // TODO-SCAFFOLD: Implement DateTimeNorm serialization in ISO 8601 Format 'YYYY-MM-DDTHH:MM:SS+HH:MM'
     @Override
     protected String serializeDateTimeNorm(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         return String.format("TO_CHAR(%s, 'YYYY-MM-DD\"T\"HH24:MI:SSOF')", termConverter.apply(terms.get(0)));
     }
 
-    // TODO-SCAFFOLD: Modify this default name, if necessary
+    //Care: Redshift does not support the UUID function
     @Override
     protected String getUUIDNameInDialect() {
         return "UUID";

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/TrinoDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/TrinoDBFunctionSymbolFactory.java
@@ -144,7 +144,7 @@ public class TrinoDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
 
     @Override
     protected DBConcatFunctionSymbol createRegularDBConcat(int arity) {
-        return createNullRejectingDBConcat(arity);
+        return new NullToleratingDBConcatFunctionSymbol("CONCAT", arity, dbStringType, abstractRootDBType, false);
     }
 
     @Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/DuckDBDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/DuckDBDBTypeFactory.java
@@ -13,8 +13,6 @@ import static it.unibz.inf.ontop.model.type.impl.NonStringNonNumberNonBooleanNon
 import static it.unibz.inf.ontop.model.type.impl.NonStringNonNumberNonBooleanNonDatetimeDBTermType.StrictEqSupport.SAME_TYPE_NO_CONSTANT;
 
 public class DuckDBDBTypeFactory extends DefaultSQLDBTypeFactory {
-    protected static final String VARBIT_STR = "VARBIT";
-    protected static final String BIT_STR = "BIT";
     protected static final String INT2_STR = "INT2";
     protected static final String INT4_STR = "INT4";
     protected static final String INT8_STR = "INT8";
@@ -22,22 +20,13 @@ public class DuckDBDBTypeFactory extends DefaultSQLDBTypeFactory {
     protected static final String HUGEINT_STR = "HUGEINT";
     protected static final String FLOAT4_STR = "FLOAT4";
     protected static final String FLOAT8_STR = "FLOAT8";
-    protected static final String SMALLSERIAL_STR = "SMALLSERIAL";
-    public static final String SERIAL_STR = "SERIAL";
-    protected static final String BIGSERIAL_STR = "BIGSERIAL";
     protected static final String BPCHAR_STR = "BPCHAR";
-    protected static final String NAME_STR = "NAME";
     public static final String TIMESTAMPTZ_STR = "TIMESTAMP WITH TIME ZONE";
     public static final String TIMETZ_STR = "TIME WITH TIME ZONE";
     public static final String BOOL_STR = "BOOL";
     public static final String UUID_STR = "UUID";
     public static final String JSON_STR = "JSON";
-    public static final String JSONB_STR = "JSONB";
-    public static final String ARRAY_STR = "ARRAY";
     public static final String BYTEA_STR = "BYTEA";
-
-    protected static final String GEOMETRY_STR = "GEOMETRY";
-    protected static final String GEOGRAPHY_STR = "GEOGRAPHY";
 
     private static final String DEFAULT_DECIMAL_STR = "DECIMAL(38, 18)";
 
@@ -54,16 +43,7 @@ public class DuckDBDBTypeFactory extends DefaultSQLDBTypeFactory {
         TermTypeAncestry rootAncestry = rootTermType.getAncestry();
         RDFDatatype xsdString = typeFactory.getXsdStringDatatype();
 
-        // TODO: treat it as a proper binary type
-        BooleanDBTermType bitType = new BooleanDBTermType(BIT_STR, rootAncestry,
-                typeFactory.getXsdBooleanDatatype());
-
-        // TODO: treat it as a proper binary type
-        BooleanDBTermType varBitType = new BooleanDBTermType(VARBIT_STR, rootAncestry,
-                typeFactory.getXsdBooleanDatatype());
-
         StringDBTermType bpCharType = new StringDBTermType(BPCHAR_STR, rootAncestry, xsdString);
-        StringDBTermType nameType = new StringDBTermType(NAME_STR, rootAncestry, xsdString);
 
         // TODO: shall we map it to xsd.datetimeStamp ? (would not follow strictly R2RML but be more precise)
         DatetimeDBTermType timestampTz = new DatetimeDBTermType(TIMESTAMPTZ_STR, rootTermType.getAncestry(),
@@ -86,25 +66,15 @@ public class DuckDBDBTypeFactory extends DefaultSQLDBTypeFactory {
                 typeFactory.getXsdDecimalDatatype(), DECIMAL);
 
         Map<String, DBTermType> map = createDefaultSQLTypeMap(rootTermType, typeFactory);
-        map.put(BIT_STR, bitType);
         map.put(INT2_STR, map.get(SMALLINT_STR));
         map.put(INT4_STR, map.get(INTEGER_STR));
         map.put(INT8_STR, map.get(BIGINT_STR));
-        map.put(VARBIT_STR, varBitType);
         map.put(FLOAT4_STR, map.get(REAL_STR));
         map.put(FLOAT8_STR, map.get(DOUBLE_PREC_STR));
         map.put(DEFAULT_DECIMAL_STR, defaultDecimalType);
         map.put(HUGEINT_STR, map.get(BIGINT_STR));
-        /*
-         * <a href='https://www.postgresql.org/docs/current/datatype-numeric.html'>8.1. Numeric Types</a>
-         * The data types smallserial, serial and bigserial are not true types, but merely a notational convenience for
-         * creating unique identifier columns (similar to the AUTO_INCREMENT property supported by some other databases).
-         */
-        map.put(SMALLSERIAL_STR, map.get(SMALLINT_STR));
-        map.put(SERIAL_STR, map.get(INTEGER_STR));
-        map.put(BIGSERIAL_STR, map.get(BIGINT_STR));
+
         map.put(BPCHAR_STR, bpCharType);
-        map.put(NAME_STR, nameType);
         map.put(TIMESTAMPTZ_STR, timestampTz);
         map.put(TIMETZ_STR, timeTzType);
         map.put(DATE_STR, dateType);
@@ -113,17 +83,9 @@ public class DuckDBDBTypeFactory extends DefaultSQLDBTypeFactory {
         map.put(BYTEA_STR, byteAType);
 
         /*
-         * POSTGIS types
-         *
-         */
-        map.put(GEOMETRY_STR, new NonStringNonNumberNonBooleanNonDatetimeDBTermType(GEOMETRY_STR, rootAncestry, xsdString));
-        map.put(GEOGRAPHY_STR, new NonStringNonNumberNonBooleanNonDatetimeDBTermType(GEOGRAPHY_STR, rootAncestry, xsdString));
-
-        /*
          * JSON
          */
         map.put(JSON_STR, new JsonDBTermTypeImpl(JSON_STR, rootAncestry));
-        map.put(JSONB_STR, new JsonDBTermTypeImpl(JSONB_STR, rootAncestry));
 
         return map;
     }
@@ -134,15 +96,7 @@ public class DuckDBDBTypeFactory extends DefaultSQLDBTypeFactory {
         map.put(DefaultTypeCode.DATETIMESTAMP, TIMESTAMPTZ_STR);
         map.put(DefaultTypeCode.HEXBINARY, BYTEA_STR);
         map.put(DefaultTypeCode.STRING, VARCHAR_STR);
-        /*
-         * POSTGIS types
-         */
-        map.put(DefaultTypeCode.GEOGRAPHY, GEOGRAPHY_STR);
-        map.put(DefaultTypeCode.GEOMETRY, GEOMETRY_STR);
-        /*
-         * JSON: JSONB is more efficient than JSON
-         */
-        map.put(DefaultTypeCode.JSON, JSONB_STR);
+        map.put(DefaultTypeCode.JSON, JSON_STR);
         map.put(DefaultTypeCode.DECIMAL, DEFAULT_DECIMAL_STR);
 
         return ImmutableMap.copyOf(map);
@@ -166,6 +120,11 @@ public class DuckDBDBTypeFactory extends DefaultSQLDBTypeFactory {
     @Override
     public boolean supportsJson() {
         return true;
+    }
+
+    @Override
+    public boolean supportsArrayType() {
+        return false;
     }
 
     @Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/RedshiftDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/RedshiftDBTypeFactory.java
@@ -13,26 +13,15 @@ import static it.unibz.inf.ontop.model.type.impl.NonStringNonNumberNonBooleanNon
 import static it.unibz.inf.ontop.model.type.impl.NonStringNonNumberNonBooleanNonDatetimeDBTermType.StrictEqSupport.SAME_TYPE_NO_CONSTANT;
 
 public class RedshiftDBTypeFactory extends DefaultSQLDBTypeFactory {
-    protected static final String VARBIT_STR = "VARBIT";
-    protected static final String BIT_STR = "BIT";
     protected static final String INT2_STR = "INT2";
     protected static final String INT4_STR = "INT4";
     protected static final String INT8_STR = "INT8";
     protected static final String FLOAT4_STR = "FLOAT4";
     protected static final String FLOAT8_STR = "FLOAT8";
-    protected static final String SMALLSERIAL_STR = "SMALLSERIAL";
-    public static final String SERIAL_STR = "SERIAL";
-    protected static final String BIGSERIAL_STR = "BIGSERIAL";
     protected static final String BPCHAR_STR = "BPCHAR";
-    protected static final String NAME_STR = "NAME";
     public static final String TIMESTAMPTZ_STR = "TIMESTAMPTZ";
     public static final String TIMETZ_STR = "TIMETZ";
     public static final String BOOL_STR = "BOOL";
-    public static final String UUID_STR = "UUID";
-    public static final String JSON_STR = "JSON";
-    public static final String JSONB_STR = "JSONB";
-    public static final String ARRAY_STR = "ARRAY";
-    public static final String BYTEA_STR = "BYTEA";
     private static final String DEFAULT_DECIMAL_STR = "DECIMAL(38, 18)";
 
     protected static final String GEOMETRY_STR = "GEOMETRY";
@@ -51,16 +40,7 @@ public class RedshiftDBTypeFactory extends DefaultSQLDBTypeFactory {
         TermTypeAncestry rootAncestry = rootTermType.getAncestry();
         RDFDatatype xsdString = typeFactory.getXsdStringDatatype();
 
-        // TODO: treat it as a proper binary type
-        BooleanDBTermType bitType = new BooleanDBTermType(BIT_STR, rootAncestry,
-                typeFactory.getXsdBooleanDatatype());
-
-        // TODO: treat it as a proper binary type
-        BooleanDBTermType varBitType = new BooleanDBTermType(VARBIT_STR, rootAncestry,
-                typeFactory.getXsdBooleanDatatype());
-
         StringDBTermType bpCharType = new StringDBTermType(BPCHAR_STR, rootAncestry, xsdString);
-        StringDBTermType nameType = new StringDBTermType(NAME_STR, rootAncestry, xsdString);
 
         // TODO: shall we map it to xsd.datetimeStamp ? (would not follow strictly R2RML but be more precise)
         DatetimeDBTermType timestampTz = new DatetimeDBTermType(TIMESTAMPTZ_STR, rootTermType.getAncestry(),
@@ -72,39 +52,21 @@ public class RedshiftDBTypeFactory extends DefaultSQLDBTypeFactory {
         DBTermType dateType = new DateDBTermType(DATE_STR, rootAncestry,
                 typeFactory.getDatatype(XSD.DATE));
 
-        DBTermType byteAType = new NonStringNonNumberNonBooleanNonDatetimeDBTermType(BYTEA_STR, rootAncestry,
-                typeFactory.getDatatype(XSD.HEXBINARY), SAME_TYPE_NO_CONSTANT);
-
-        DBTermType uuidType = new UUIDDBTermType(UUID_STR, rootTermType.getAncestry(), xsdString);
-
         NumberDBTermType defaultDecimalType = new NumberDBTermType(DEFAULT_DECIMAL_STR, rootAncestry,
                 typeFactory.getXsdDecimalDatatype(), DECIMAL);
 
         Map<String, DBTermType> map = createDefaultSQLTypeMap(rootTermType, typeFactory);
-        map.put(BIT_STR, bitType);
         map.put(INT2_STR, map.get(SMALLINT_STR));
         map.put(INT4_STR, map.get(INTEGER_STR));
         map.put(INT8_STR, map.get(BIGINT_STR));
-        map.put(VARBIT_STR, varBitType);
         map.put(FLOAT4_STR, map.get(REAL_STR));
         map.put(FLOAT8_STR, map.get(DOUBLE_PREC_STR));
         map.put(DEFAULT_DECIMAL_STR, defaultDecimalType);
-        /*
-         * <a href='https://www.postgresql.org/docs/current/datatype-numeric.html'>8.1. Numeric Types</a>
-         * The data types smallserial, serial and bigserial are not true types, but merely a notational convenience for
-         * creating unique identifier columns (similar to the AUTO_INCREMENT property supported by some other databases).
-         */
-        map.put(SMALLSERIAL_STR, map.get(SMALLINT_STR));
-        map.put(SERIAL_STR, map.get(INTEGER_STR));
-        map.put(BIGSERIAL_STR, map.get(BIGINT_STR));
         map.put(BPCHAR_STR, bpCharType);
-        map.put(NAME_STR, nameType);
         map.put(TIMESTAMPTZ_STR, timestampTz);
         map.put(TIMETZ_STR, timeTzType);
         map.put(DATE_STR, dateType);
         map.put(BOOL_STR, map.get(BOOLEAN_STR));
-        map.put(UUID_STR, uuidType);
-        map.put(BYTEA_STR, byteAType);
 
         /*
          * POSTGIS types
@@ -112,12 +74,6 @@ public class RedshiftDBTypeFactory extends DefaultSQLDBTypeFactory {
          */
         map.put(GEOMETRY_STR, new NonStringNonNumberNonBooleanNonDatetimeDBTermType(GEOMETRY_STR, rootAncestry, xsdString));
         map.put(GEOGRAPHY_STR, new NonStringNonNumberNonBooleanNonDatetimeDBTermType(GEOGRAPHY_STR, rootAncestry, xsdString));
-
-        /*
-         * JSON
-         */
-        map.put(JSON_STR, new JsonDBTermTypeImpl(JSON_STR, rootAncestry));
-        map.put(JSONB_STR, new JsonDBTermTypeImpl(JSONB_STR, rootAncestry));
 
         return map;
     }
@@ -128,12 +84,7 @@ public class RedshiftDBTypeFactory extends DefaultSQLDBTypeFactory {
         //Redshift does not support some functions to have inputs of type TIMESTAMP WITH TIME ZONE, so we
         //change the default type for TIMESTAMPS to TIMESTAMP (without time zone)
         map.put(DefaultTypeCode.DATETIMESTAMP, TIMESTAMP_STR);
-        map.put(DefaultTypeCode.HEXBINARY, BYTEA_STR);
         map.put(DefaultTypeCode.DECIMAL, DEFAULT_DECIMAL_STR);
-        /*
-         * JSON: JSONB is more efficient than JSON
-         */
-        map.put(DefaultTypeCode.JSON, JSONB_STR);
         /*
          * POSTGIS types
          */
@@ -146,31 +97,26 @@ public class RedshiftDBTypeFactory extends DefaultSQLDBTypeFactory {
 
 
 
-    //TODO-SCAFFOLD change any of these flags, if applicable
     @Override
     public boolean supportsDBGeometryType() {
         return true;
     }
 
-    //TODO-SCAFFOLD change any of these flags, if applicable
     @Override
     public boolean supportsDBGeographyType() {
         return true;
     }
 
-    //TODO-SCAFFOLD change any of these flags, if applicable
     @Override
     public boolean supportsDBDistanceSphere() {
         return false;
     }
 
-    //TODO-SCAFFOLD change any of these flags, if applicable
     @Override
     public boolean supportsJson() {
         return false;
     }
 
-    //TODO-SCAFFOLD change any of these flags, if applicable
     @Override
     public boolean supportsArrayType() {
         return false;

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/TrinoDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/TrinoDBTypeFactory.java
@@ -13,29 +13,18 @@ import static it.unibz.inf.ontop.model.type.impl.NonStringNonNumberNonBooleanNon
 import static it.unibz.inf.ontop.model.type.impl.NonStringNonNumberNonBooleanNonDatetimeDBTermType.StrictEqSupport.SAME_TYPE_NO_CONSTANT;
 
 public class TrinoDBTypeFactory extends DefaultSQLDBTypeFactory {
-    protected static final String VARBIT_STR = "VARBIT";
-    protected static final String BIT_STR = "BIT";
     protected static final String INT2_STR = "INT2";
     protected static final String INT4_STR = "INT4";
     protected static final String INT8_STR = "INT8";
     protected static final String FLOAT4_STR = "FLOAT4";
     protected static final String FLOAT8_STR = "FLOAT8";
-    protected static final String SMALLSERIAL_STR = "SMALLSERIAL";
-    public static final String SERIAL_STR = "SERIAL";
-    protected static final String BIGSERIAL_STR = "BIGSERIAL";
-    protected static final String BPCHAR_STR = "BPCHAR";
-    protected static final String NAME_STR = "NAME";
     public static final String TIMESTAMPTZ_STR = "TIMESTAMP WITH TIME ZONE";
     public static final String TIMETZ_STR = "TIME WITH TIME ZONE";
     public static final String BOOL_STR = "BOOL";
     public static final String UUID_STR = "UUID";
     public static final String JSON_STR = "JSON";
-    public static final String JSONB_STR = "JSONB";
-    public static final String ARRAY_STR = "ARRAY";
-    public static final String BYTEA_STR = "BYTEA";
 
     protected static final String GEOMETRY_STR = "GEOMETRY";
-    protected static final String GEOGRAPHY_STR = "GEOGRAPHY";
 
     private static final String DEFAULT_DECIMAL_STR = "DECIMAL(38, 18)";
 
@@ -52,17 +41,6 @@ public class TrinoDBTypeFactory extends DefaultSQLDBTypeFactory {
         TermTypeAncestry rootAncestry = rootTermType.getAncestry();
         RDFDatatype xsdString = typeFactory.getXsdStringDatatype();
 
-        // TODO: treat it as a proper binary type
-        BooleanDBTermType bitType = new BooleanDBTermType(BIT_STR, rootAncestry,
-                typeFactory.getXsdBooleanDatatype());
-
-        // TODO: treat it as a proper binary type
-        BooleanDBTermType varBitType = new BooleanDBTermType(VARBIT_STR, rootAncestry,
-                typeFactory.getXsdBooleanDatatype());
-
-        StringDBTermType bpCharType = new StringDBTermType(BPCHAR_STR, rootAncestry, xsdString);
-        StringDBTermType nameType = new StringDBTermType(NAME_STR, rootAncestry, xsdString);
-
         // TODO: shall we map it to xsd.datetimeStamp ? (would not follow strictly R2RML but be more precise)
         DatetimeDBTermType timestampTz = new DatetimeDBTermType(TIMESTAMPTZ_STR, rootTermType.getAncestry(),
                 typeFactory.getXsdDatetimeDatatype());
@@ -73,8 +51,6 @@ public class TrinoDBTypeFactory extends DefaultSQLDBTypeFactory {
         DBTermType dateType = new DateDBTermType(DATE_STR, rootAncestry,
                 typeFactory.getDatatype(XSD.DATE));
 
-        DBTermType byteAType = new NonStringNonNumberNonBooleanNonDatetimeDBTermType(BYTEA_STR, rootAncestry,
-                typeFactory.getDatatype(XSD.HEXBINARY), SAME_TYPE_NO_CONSTANT);
 
         DBTermType uuidType = new UUIDDBTermType(UUID_STR, rootTermType.getAncestry(), xsdString);
 
@@ -84,43 +60,27 @@ public class TrinoDBTypeFactory extends DefaultSQLDBTypeFactory {
                 typeFactory.getXsdDecimalDatatype(), DECIMAL);
 
         Map<String, DBTermType> map = createDefaultSQLTypeMap(rootTermType, typeFactory);
-        map.put(BIT_STR, bitType);
         map.put(INT2_STR, map.get(SMALLINT_STR));
         map.put(INT4_STR, map.get(INTEGER_STR));
         map.put(INT8_STR, map.get(BIGINT_STR));
-        map.put(VARBIT_STR, varBitType);
         map.put(FLOAT4_STR, map.get(REAL_STR));
         map.put(FLOAT8_STR, map.get(DOUBLE_PREC_STR));
         map.put(DEFAULT_DECIMAL_STR, defaultDecimalType);
-        /*
-         * <a href='https://www.postgresql.org/docs/current/datatype-numeric.html'>8.1. Numeric Types</a>
-         * The data types smallserial, serial and bigserial are not true types, but merely a notational convenience for
-         * creating unique identifier columns (similar to the AUTO_INCREMENT property supported by some other databases).
-         */
-        map.put(SMALLSERIAL_STR, map.get(SMALLINT_STR));
-        map.put(SERIAL_STR, map.get(INTEGER_STR));
-        map.put(BIGSERIAL_STR, map.get(BIGINT_STR));
-        map.put(BPCHAR_STR, bpCharType);
-        map.put(NAME_STR, nameType);
         map.put(TIMESTAMPTZ_STR, timestampTz);
         map.put(TIMETZ_STR, timeTzType);
         map.put(DATE_STR, dateType);
         map.put(BOOL_STR, map.get(BOOLEAN_STR));
         map.put(UUID_STR, uuidType);
-        map.put(BYTEA_STR, byteAType);
-
         /*
          * POSTGIS types
          *
          */
         map.put(GEOMETRY_STR, new NonStringNonNumberNonBooleanNonDatetimeDBTermType(GEOMETRY_STR, rootAncestry, xsdString));
-        map.put(GEOGRAPHY_STR, new NonStringNonNumberNonBooleanNonDatetimeDBTermType(GEOGRAPHY_STR, rootAncestry, xsdString));
 
         /*
          * JSON
          */
         map.put(JSON_STR, new JsonDBTermTypeImpl(JSON_STR, rootAncestry));
-        map.put(JSONB_STR, new JsonDBTermTypeImpl(JSONB_STR, rootAncestry));
 
         return map;
     }
@@ -129,17 +89,10 @@ public class TrinoDBTypeFactory extends DefaultSQLDBTypeFactory {
         Map<DefaultTypeCode, String> map = createDefaultSQLCodeMap();
         map.put(DefaultTypeCode.DOUBLE, DOUBLE_PREC_STR);
         map.put(DefaultTypeCode.DATETIMESTAMP, TIMESTAMPTZ_STR);
-        map.put(DefaultTypeCode.HEXBINARY, BYTEA_STR);
+        map.put(DefaultTypeCode.HEXBINARY, VARBINARY_STR);
         map.put(DefaultTypeCode.STRING, VARCHAR_STR);
-        /*
-         * POSTGIS types
-         */
-        map.put(DefaultTypeCode.GEOGRAPHY, GEOGRAPHY_STR);
         map.put(DefaultTypeCode.GEOMETRY, GEOMETRY_STR);
-        /*
-         * JSON: JSONB is more efficient than JSON
-         */
-        map.put(DefaultTypeCode.JSON, JSONB_STR);
+        map.put(DefaultTypeCode.JSON, JSON_STR);
         map.put(DefaultTypeCode.DECIMAL, DEFAULT_DECIMAL_STR);
 
         return ImmutableMap.copyOf(map);
@@ -152,16 +105,21 @@ public class TrinoDBTypeFactory extends DefaultSQLDBTypeFactory {
 
     @Override
     public boolean supportsDBGeographyType() {
-        return true;
+        return false;
     }
 
     @Override
     public boolean supportsDBDistanceSphere() {
-        return true;
+        return false;
     }
 
     @Override
     public boolean supportsJson() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsArrayType() {
         return true;
     }
 

--- a/test/lightweight-tests/licenses/ATHENA-LICENSE.txt
+++ b/test/lightweight-tests/licenses/ATHENA-LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test/lightweight-tests/licenses/DUCKDB-LICENSE.txt
+++ b/test/lightweight-tests/licenses/DUCKDB-LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright 2018-2023 Stichting DuckDB Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/test/lightweight-tests/licenses/PRESTO-LICENSE.txt
+++ b/test/lightweight-tests/licenses/PRESTO-LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test/lightweight-tests/licenses/REDSHIFT-LICENSE.txt
+++ b/test/lightweight-tests/licenses/REDSHIFT-LICENSE.txt
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/test/lightweight-tests/licenses/TRINO-LICENSE.txt
+++ b/test/lightweight-tests/licenses/TRINO-LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test/lightweight-tests/src/test/resources/books/duckdb/books-duckdb.properties
+++ b/test/lightweight-tests/src/test/resources/books/duckdb/books-duckdb.properties
@@ -1,4 +1,2 @@
 jdbc.url = jdbc:duckdb:lightweight-db-test-images/duckdb/ontop.db
-jdbc.user =
-jdbc.password =
 jdbc.driver = org.duckdb.DuckDBDriver

--- a/test/lightweight-tests/src/test/resources/dbconstraints/dbconstraints-duckdb.properties
+++ b/test/lightweight-tests/src/test/resources/dbconstraints/dbconstraints-duckdb.properties
@@ -1,4 +1,2 @@
 jdbc.url = jdbc:duckdb:lightweight-db-test-images/duckdb/dbconstraints.db
-jdbc.user =
-jdbc.password =
 jdbc.driver = org.duckdb.DuckDBDriver

--- a/test/lightweight-tests/src/test/resources/prof/duckdb/prof-duckdb.properties
+++ b/test/lightweight-tests/src/test/resources/prof/duckdb/prof-duckdb.properties
@@ -1,5 +1,3 @@
 jdbc.url = jdbc:duckdb:lightweight-db-test-images/duckdb/ontop.db
-jdbc.user =
-jdbc.password =
 jdbc.driver = org.duckdb.DuckDBDriver
 ontop.allowRetrievingBlackBoxViewMetadataFromDB = true

--- a/test/lightweight-tests/src/test/resources/university/university-duckdb.properties
+++ b/test/lightweight-tests/src/test/resources/university/university-duckdb.properties
@@ -1,4 +1,2 @@
 jdbc.url = jdbc:duckdb:lightweight-db-test-images/duckdb/ontop.db
-jdbc.user =
-jdbc.password =
 jdbc.driver = org.duckdb.DuckDBDriver


### PR DESCRIPTION
Changed some parts of the implementations to clean up the code, including:

- added license files for all dialects
- removed unnecessary "user" and "password" lines in duckdb properties files
- removed some types from the type factory that were included even though they are not supported.
- changed some `supports[DATATYPE]()` flags in type factories that previously had incorrect values.
- changed implementation of `createRegularDBConcatFunctionSymbol()` method for trino, duckdb and redshift, as they used the wrong implementation previously.