### PR TITLE
Union Lens Feature

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/UnionLensTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/UnionLensTest.java
@@ -1,0 +1,65 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class UnionLensTest extends AbstractRDF4JTest {
+    private static final String OBDA_FILE = "/union-lens/test.obda";
+    private static final String SQL_SCRIPT = "/union-lens/test.sql";
+    private static final String VIEW_FILE = "/union-lens/lens.json";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE, null, null, VIEW_FILE);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void testCorrectNumberOfUnionEntries() {
+        String query = "PREFIX : <http://www.ontop-vkg.com/union-test#>\n" +
+                "PREFIX  xsd: <http://www.w3.org/2001/XMLSchema#>\n" +
+                "SELECT  ?v \n" +
+                "WHERE {\n" +
+                " ?v a :DayRecord . \n" +
+                "}";
+        assertEquals(20, runQueryAndCount(query));
+    }
+
+    @Test
+    public void testCorrectProvenanceColumn() {
+        String query = "PREFIX : <http://www.ontop-vkg.com/union-test#>\n" +
+                "PREFIX  xsd: <http://www.w3.org/2001/XMLSchema#>\n" +
+                "SELECT  ?v \n" +
+                "WHERE {\n" +
+                " ?y a :BudgetYear . \n" +
+                " ?y :name ?v" +
+                "}";
+        runQueryAndCompare(query, ImmutableSet.of("BUDGETYEAR2020", "BUDGETYEAR2021", "lenses.Year2022"));
+    }
+
+    @Test
+    public void testCorrectProvenanceColumnAssignment() {
+        String query = "PREFIX : <http://www.ontop-vkg.com/union-test#>\n" +
+                "PREFIX  xsd: <http://www.w3.org/2001/XMLSchema#>\n" +
+                "SELECT  (SUM(?e) as ?v) \n" +
+                "WHERE {\n" +
+                " ?y a :BudgetYear . \n" +
+                " ?d :year ?y . \n" +
+                " ?d :earnings ?e .\n" +
+                "} GROUP BY ?y";
+        runQueryAndCompare(query, ImmutableSet.of("285", "360", "575"));
+    }
+}

--- a/binding/rdf4j/src/test/resources/union-lens/lens.json
+++ b/binding/rdf4j/src/test/resources/union-lens/lens.json
@@ -1,0 +1,33 @@
+{
+  "relations": [
+    {
+      "name": ["\"lenses\"", "\"Year2022\""],
+      "baseRelation": ["BudgetYear2022"],
+      "columns": {
+        "added": [],
+        "hidden": ["managerName"]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"all_years\""],
+      "unionRelations": [
+        ["BudgetYear2020"],
+        ["BudgetYear2021"],
+        ["\"lenses\"", "\"Year2022\""]
+      ],
+      "makeDistinct": false,
+      "provenanceColumn": "\"year_name\"",
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    }
+  ]
+}

--- a/binding/rdf4j/src/test/resources/union-lens/test.obda
+++ b/binding/rdf4j/src/test/resources/union-lens/test.obda
@@ -1,0 +1,20 @@
+[PrefixDeclaration]
+:		http://www.ontop-vkg.com/union-test#
+owl:		http://www.w3.org/2002/07/owl#
+rdf:		http://www.w3.org/1999/02/22-rdf-syntax-ns#
+xml:		http://www.w3.org/XML/1998/namespace
+xsd:		http://www.w3.org/2001/XMLSchema#
+obda:		https://w3id.org/obda/vocabulary#
+rdfs:		http://www.w3.org/2000/01/rdf-schema#
+quest:		http://obda.org/quest#
+
+[MappingDeclaration] @collection [[
+mappingId	MAPID-year
+target		:budget-year/{year_name} a :BudgetYear; :name {year_name}^^xsd:string .
+source		SELECT "year_name" FROM "lenses"."all_years";
+
+mappingId	MAPID-day
+target		:day-records/{year_name}/{dayofyear} a :DayRecord; :spendings {spendings}^^xsd:integer; :earnings {earnings}^^xsd:integer; :day {dayofyear}^^xsd:integer; :year :budget-year/{year_name} .
+source		SELECT dayofyear, spendings, earnings, "year_name" FROM "lenses"."all_years";
+]]
+

--- a/binding/rdf4j/src/test/resources/union-lens/test.sql
+++ b/binding/rdf4j/src/test/resources/union-lens/test.sql
@@ -1,0 +1,41 @@
+CREATE TABLE BudgetYear2020(
+    dayOfYear int primary key,
+    spendings int not null,
+    earnings int not null
+);
+
+INSERT INTO BudgetYear2020(dayOfYear, spendings, earnings) VALUES (1, 100, 40);
+INSERT INTO BudgetYear2020(dayOfYear, spendings, earnings) VALUES (2, 0, 45);
+INSERT INTO BudgetYear2020(dayOfYear, spendings, earnings) VALUES (3, 0, 60);
+INSERT INTO BudgetYear2020(dayOfYear, spendings, earnings) VALUES (4, 20, 50);
+INSERT INTO BudgetYear2020(dayOfYear, spendings, earnings) VALUES (5, 200, 40);
+INSERT INTO BudgetYear2020(dayOfYear, spendings, earnings) VALUES (6, 50, 50);
+
+CREATE TABLE BudgetYear2021(
+    dayOfYear int primary key,
+    spendings int not null,
+    earnings int not null
+);
+
+INSERT INTO BudgetYear2021(dayOfYear, spendings, earnings) VALUES (1, 10, 40);
+INSERT INTO BudgetYear2021(dayOfYear, spendings, earnings) VALUES (2, 10, 105);
+INSERT INTO BudgetYear2021(dayOfYear, spendings, earnings) VALUES (3, 40, 50);
+INSERT INTO BudgetYear2021(dayOfYear, spendings, earnings) VALUES (4, 20, 20);
+INSERT INTO BudgetYear2021(dayOfYear, spendings, earnings) VALUES (5, 30, 70);
+INSERT INTO BudgetYear2021(dayOfYear, spendings, earnings) VALUES (6, 50, 30);
+INSERT INTO BudgetYear2021(dayOfYear, spendings, earnings) VALUES (7, 50, 45);
+
+CREATE TABLE BudgetYear2022(
+    dayOfYear int primary key,
+    spendings int not null,
+    earnings int not null,
+    managerName varchar(100)
+);
+
+INSERT INTO BudgetYear2022(dayOfYear, spendings, earnings, managerName) VALUES (1, 30, 80, 'Carl');
+INSERT INTO BudgetYear2022(dayOfYear, spendings, earnings, managerName) VALUES (2, 40, 125, 'Carl');
+INSERT INTO BudgetYear2022(dayOfYear, spendings, earnings, managerName) VALUES (3, 40, 70, 'John');
+INSERT INTO BudgetYear2022(dayOfYear, spendings, earnings, managerName) VALUES (4, 40, 70, 'John');
+INSERT INTO BudgetYear2022(dayOfYear, spendings, earnings, managerName) VALUES (5, 60, 90, 'Amanda');
+INSERT INTO BudgetYear2022(dayOfYear, spendings, earnings, managerName) VALUES (6, 55, 68, 'Carl');
+INSERT INTO BudgetYear2022(dayOfYear, spendings, earnings, managerName) VALUES (7, 40, 72, 'Amanda');

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
@@ -3,6 +3,7 @@ package it.unibz.inf.ontop.iq.node.impl;
 import com.google.common.collect.*;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import it.unibz.inf.ontop.dbschema.UniqueConstraint;
 import it.unibz.inf.ontop.exception.MinorOntopInternalBugException;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
@@ -24,6 +25,7 @@ import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import it.unibz.inf.ontop.utils.VariableGenerator;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -344,6 +346,9 @@ public class UnionNodeImpl extends CompositeQueryNodeImpl implements UnionNode {
 
     /**
      * TODO: generalize it and merge it with the isDistinct() method implementation
+     *
+     * We could infer more constraints by not only checking for equal unique constraints, but also checking if
+     * some unique constraint is a superset of all unique constraints.
      */
     @Override
     public ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(ImmutableList<IQTree> children) {
@@ -352,14 +357,44 @@ public class UnionNodeImpl extends CompositeQueryNodeImpl implements UnionNode {
             throw new InvalidIntermediateQueryException("At least 2 children are expected for a union");
 
         IQTree firstChild = children.get(0);
-        return firstChild.inferUniqueConstraints().stream()
+        ImmutableMap<Boolean, ImmutableList<ImmutableSet<Variable>>> ucsPartitionedByDisjointness = firstChild.inferUniqueConstraints().stream()
                 .filter(uc -> children.stream()
                         .skip(1)
                         .allMatch(c -> c.inferUniqueConstraints().contains(uc)))
-                .filter(uc -> IntStream.range(0, childrenCount)
-                        .allMatch(i -> IntStream.range(i+1, childrenCount)
-                                .allMatch(j -> areDisjoint(children.get(i), children.get(j), uc))))
-                .collect(ImmutableCollectors.toSet());
+                .collect(ImmutableCollectors.partitioningBy(uc -> areDisjoint(children, uc)));
+        if (ucsPartitionedByDisjointness.isEmpty())
+            return ImmutableSet.of();
+        // Not disjoint
+        if (ucsPartitionedByDisjointness.containsKey(false)) {
+            // By definition not parts of the non-disjoint UCs
+            var disjointVariables = firstChild.getVariables().stream()
+                    .filter(v -> areDisjoint(children, ImmutableSet.of(v)))
+                    .collect(ImmutableCollectors.toSet());
+            if (disjointVariables.isEmpty())
+                return ImmutableSet.copyOf(ucsPartitionedByDisjointness.getOrDefault(true, ImmutableList.of()));
+
+            return Stream.concat(
+                    ucsPartitionedByDisjointness.getOrDefault(true, ImmutableList.of()).stream(),
+                    ucsPartitionedByDisjointness.get(false).stream()
+                            .flatMap(uc -> disjointVariables.stream()
+                                            .map(v -> appendVariable(uc, v)))
+                    ).collect(ImmutableCollectors.toSet());
+        }
+        else
+            return ImmutableSet.copyOf(ucsPartitionedByDisjointness.get(true));
+    }
+
+    private ImmutableSet<Variable> appendVariable(ImmutableSet<Variable> uc, Variable v) {
+        return Stream.concat(
+                uc.stream(),
+                Stream.of(v)).collect(ImmutableCollectors.toSet());
+    }
+
+    private boolean areDisjoint(ImmutableList<IQTree> children, ImmutableSet<Variable> uc) {
+        int childrenCount = children.size();
+        return IntStream.range(0, childrenCount)
+                .allMatch(i -> IntStream.range(i + 1, childrenCount)
+                        .allMatch(j -> areDisjoint(children.get(i), children.get(j), uc)));
     }
 
     /**

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
@@ -369,6 +369,7 @@ public class UnionNodeImpl extends CompositeQueryNodeImpl implements UnionNode {
             // By definition not parts of the non-disjoint UCs
             var disjointVariables = firstChild.getVariables().stream()
                     .filter(v -> areDisjoint(children, ImmutableSet.of(v)))
+                    .filter(v -> !ucsPartitionedByDisjointness.get(true).stream().anyMatch(set -> set.size() == 1 && set.stream().findFirst().get().equals(v)))
                     .collect(ImmutableCollectors.toSet());
             if (disjointVariables.isEmpty())
                 return ImmutableSet.copyOf(ucsPartitionedByDisjointness.getOrDefault(true, ImmutableList.of()));

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
@@ -364,6 +364,9 @@ public class UnionNodeImpl extends CompositeQueryNodeImpl implements UnionNode {
                         .allMatch(c -> c.inferUniqueConstraints().contains(uc)))
                 .collect(ImmutableCollectors.partitioningBy(uc -> areDisjoint(children, uc)));
 
+        if(ucsPartitionedByDisjointness.get(false).isEmpty())
+            return ImmutableSet.copyOf(ucsPartitionedByDisjointness.get(true));
+
         // By definition not parts of the non-disjoint UCs
         var disjointVariables = firstChild.getVariables().stream()
                 .filter(v -> areDisjoint(children, ImmutableSet.of(v)))

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
@@ -357,6 +357,7 @@ public class UnionNodeImpl extends CompositeQueryNodeImpl implements UnionNode {
             throw new InvalidIntermediateQueryException("At least 2 children are expected for a union");
 
         IQTree firstChild = children.get(0);
+        // Partitions the unique constraints based on if they are fully disjoint or not. Guaranteed to have two entries: true and false (but they may be empty)
         ImmutableMap<Boolean, ImmutableList<ImmutableSet<Variable>>> ucsPartitionedByDisjointness = firstChild.inferUniqueConstraints().stream()
                 .filter(uc -> children.stream()
                         .skip(1)
@@ -369,8 +370,6 @@ public class UnionNodeImpl extends CompositeQueryNodeImpl implements UnionNode {
                 .filter(v -> ucsPartitionedByDisjointness.get(true).stream().noneMatch(set -> set.size() == 1 && set.stream().findFirst().get().equals(v)))
                 .collect(ImmutableCollectors.toSet());
 
-        // If disjointVariables is empty, the flatMap will result in an empty list
-        // If any of the partition parts are empty, they will also result in an empty list
         return Stream.concat(
                 ucsPartitionedByDisjointness.get(true).stream(),
                 ucsPartitionedByDisjointness.get(false).stream()

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/UniqueConstraintInferenceTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/UniqueConstraintInferenceTest.java
@@ -165,7 +165,7 @@ public class UniqueConstraintInferenceTest {
         IQTree tree = IQ_FACTORY.createNaryIQTree(
                 IQ_FACTORY.createUnionNode(ImmutableSet.of(X, A, B)),
                 ImmutableList.of(child1, child2));
-        assertEquals(ImmutableSet.of(ImmutableSet.of(X), ImmutableSet.of(X, A)), tree.inferUniqueConstraints());
+        assertEquals(ImmutableSet.of(ImmutableSet.of(X)), tree.inferUniqueConstraints());
     }
 
     /**
@@ -208,7 +208,7 @@ public class UniqueConstraintInferenceTest {
         IQTree tree = IQ_FACTORY.createNaryIQTree(
                 IQ_FACTORY.createUnionNode(ImmutableSet.of(X, A, B)),
                 ImmutableList.of(child1, child2));
-        assertEquals(ImmutableSet.of(ImmutableSet.of(X), ImmutableSet.of(A, X)), tree.inferUniqueConstraints());
+        assertEquals(ImmutableSet.of(ImmutableSet.of(X)), tree.inferUniqueConstraints());
     }
 
     @Test
@@ -228,7 +228,7 @@ public class UniqueConstraintInferenceTest {
         IQTree tree = IQ_FACTORY.createNaryIQTree(
                 IQ_FACTORY.createUnionNode(ImmutableSet.of(X, A, B)),
                 ImmutableList.of(child1, child2));
-        assertEquals(ImmutableSet.of(ImmutableSet.of(A, X)), tree.inferUniqueConstraints());
+        assertEquals(ImmutableSet.of(ImmutableSet.of(X, A)), tree.inferUniqueConstraints());
     }
 
     @Test

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/UniqueConstraintInferenceTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/UniqueConstraintInferenceTest.java
@@ -165,7 +165,7 @@ public class UniqueConstraintInferenceTest {
         IQTree tree = IQ_FACTORY.createNaryIQTree(
                 IQ_FACTORY.createUnionNode(ImmutableSet.of(X, A, B)),
                 ImmutableList.of(child1, child2));
-        assertEquals(ImmutableSet.of(ImmutableSet.of(X)), tree.inferUniqueConstraints());
+        assertEquals(ImmutableSet.of(ImmutableSet.of(X), ImmutableSet.of(X, A)), tree.inferUniqueConstraints());
     }
 
     /**
@@ -208,7 +208,7 @@ public class UniqueConstraintInferenceTest {
         IQTree tree = IQ_FACTORY.createNaryIQTree(
                 IQ_FACTORY.createUnionNode(ImmutableSet.of(X, A, B)),
                 ImmutableList.of(child1, child2));
-        assertEquals(ImmutableSet.of(ImmutableSet.of(X)), tree.inferUniqueConstraints());
+        assertEquals(ImmutableSet.of(ImmutableSet.of(X), ImmutableSet.of(A, X)), tree.inferUniqueConstraints());
     }
 
     @Test
@@ -228,7 +228,7 @@ public class UniqueConstraintInferenceTest {
         IQTree tree = IQ_FACTORY.createNaryIQTree(
                 IQ_FACTORY.createUnionNode(ImmutableSet.of(X, A, B)),
                 ImmutableList.of(child1, child2));
-        assertEquals(ImmutableSet.of(), tree.inferUniqueConstraints());
+        assertEquals(ImmutableSet.of(ImmutableSet.of(A, X)), tree.inferUniqueConstraints());
     }
 
     @Test

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
@@ -373,6 +373,9 @@ public abstract class JsonLens extends JsonOpenObject {
                 case "FlattenedViewDefinition":
                     instanceClass = JsonFlattenLens.class;
                     break;
+                case "UnionLens":
+                    instanceClass = JsonUnionLens.class;
+                    break;
                 default:
                     // TODO: throw proper exception
                     throw new RuntimeException("Unsupported type of lens: " + type);

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonUnionLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonUnionLens.java
@@ -1,0 +1,405 @@
+package it.unibz.inf.ontop.dbschema.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import it.unibz.inf.ontop.dbschema.*;
+import it.unibz.inf.ontop.dbschema.impl.LensImpl;
+import it.unibz.inf.ontop.exception.MetadataExtractionException;
+import it.unibz.inf.ontop.exception.MinorOntopInternalBugException;
+import it.unibz.inf.ontop.injection.CoreSingletons;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.IQ;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.node.ConstructionNode;
+import it.unibz.inf.ontop.iq.node.ExtensionalDataNode;
+import it.unibz.inf.ontop.iq.node.UnionNode;
+import it.unibz.inf.ontop.iq.node.normalization.ConstructionSubstitutionNormalizer;
+import it.unibz.inf.ontop.iq.node.normalization.ConstructionSubstitutionNormalizer.ConstructionSubstitutionNormalization;
+import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeVisitingTransformer;
+import it.unibz.inf.ontop.iq.type.NotYetTypedEqualityTransformer;
+import it.unibz.inf.ontop.model.atom.AtomFactory;
+import it.unibz.inf.ontop.model.atom.AtomPredicate;
+import it.unibz.inf.ontop.model.atom.DistinctVariableOnlyDataAtom;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.model.type.DBTermType;
+import it.unibz.inf.ontop.substitution.ImmutableSubstitution;
+import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+@JsonDeserialize(as = JsonUnionLens.class)
+public class JsonUnionLens extends JsonLens {
+    @Nonnull
+    public final List<List<String>> unionRelations;
+
+    @Nonnull
+    public final String provenanceColumn;
+
+    public final boolean makeDistinct;
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(JsonUnionLens.class);
+
+    @JsonCreator
+    public JsonUnionLens(@JsonProperty("name") List<String> name,
+                         @JsonProperty(value = "unionRelations", required = true) List<List<String>> unionRelations,
+                         @JsonProperty(value = "provenanceColumn") String provenanceColumn,
+                         @JsonProperty("makeDistinct") boolean makeDistinct,
+                         @JsonProperty("uniqueConstraints") UniqueConstraints uniqueConstraints,
+                         @JsonProperty("otherFunctionalDependencies") OtherFunctionalDependencies otherFunctionalDependencies,
+                         @JsonProperty("foreignKeys") ForeignKeys foreignKeys,
+                         @JsonProperty("nonNullConstraints") NonNullConstraints nonNullConstraints,
+                         @JsonProperty("iriSafeConstraints") IRISafeConstraints iriSafeConstraints) {
+        super(name, uniqueConstraints, otherFunctionalDependencies, foreignKeys, nonNullConstraints, iriSafeConstraints);
+        this.unionRelations = unionRelations;
+        this.provenanceColumn = provenanceColumn;
+        this.makeDistinct = makeDistinct;
+    }
+
+    @Override
+    public Lens createViewDefinition(DBParameters dbParameters, MetadataLookup parentCacheMetadataLookup)
+            throws MetadataExtractionException {
+
+        QuotedIDFactory quotedIDFactory = dbParameters.getQuotedIDFactory();
+        RelationID relationId = quotedIDFactory.createRelationID(name.toArray(new String[0]));
+
+        IQ iq = createIQ(relationId, dbParameters, parentCacheMetadataLookup);
+
+        int maxParentLevel = extractMaxParentLevel(iq, dbParameters.getCoreSingletons());
+
+        if (maxParentLevel > 0)
+            LOGGER.warn("It is dangerous to build SQLViewDefinitions above OntopViewDefinitions, " +
+                    "because the view definition will fail if the SQL query cannot be parsed by Ontop");
+
+        // For added columns the termtype, quoted ID and nullability all need to come from the IQ
+        RelationDefinition.AttributeListBuilder attributeBuilder = createAttributeBuilder(iq, dbParameters);
+
+        return new LensImpl(
+                ImmutableList.of(relationId),
+                attributeBuilder,
+                iq,
+                maxParentLevel + 1,
+                dbParameters.getCoreSingletons());
+    }
+
+    private int extractMaxParentLevel(IQ iq, CoreSingletons coreSingletons) {
+        LevelExtractor transformer = new LevelExtractor(coreSingletons);
+        // Side-effect (cheap but good enough implementation)
+        transformer.transform(iq.getTree());
+        return transformer.getMaxLevel();
+    }
+
+    @Override
+    public void insertIntegrityConstraints(Lens relation,
+                                           ImmutableList<NamedRelationDefinition> baseRelations,
+                                           MetadataLookup metadataLookupForFK, DBParameters dbParameters) throws MetadataExtractionException {
+        QuotedIDFactory idFactory = metadataLookupForFK.getQuotedIDFactory();
+
+        if (uniqueConstraints != null)
+            insertUniqueConstraints(relation, idFactory, uniqueConstraints.added, baseRelations, dbParameters.getCoreSingletons());
+        else
+            insertUniqueConstraints(relation, idFactory, List.of(), baseRelations, dbParameters.getCoreSingletons());
+
+        if (otherFunctionalDependencies != null)
+            insertFunctionalDependencies(relation, idFactory, otherFunctionalDependencies.added);
+        else
+            insertFunctionalDependencies(relation, idFactory, List.of());
+
+    }
+
+    @Override
+    public ImmutableList<ImmutableList<Attribute>> getAttributesIncludingParentOnes(Lens lens, ImmutableList<Attribute> parentAttributes) {
+        return ImmutableList.of();
+    }
+
+    protected ImmutableMap<String, Variable> extractProjectedVariables(
+            DBParameters dbParameters, MetadataLookup parentCacheMetadataLookup) throws MetadataExtractionException {
+        QuotedIDFactory quotedIDFactory = dbParameters.getQuotedIDFactory();
+        var variableGenerator = dbParameters.getCoreSingletons().getCoreUtilsFactory().createVariableGenerator(ImmutableList.of());
+
+        if (unionRelations.size() < 2)
+            throw new MetadataExtractionException("At least two relations are expected");
+
+        var firstParent = parentCacheMetadataLookup.getRelation(quotedIDFactory.createRelationID(
+                unionRelations.get(0).toArray(new String[0])));
+
+        var parents = getParentRelations(dbParameters, parentCacheMetadataLookup);
+        if(parents.stream().skip(1).anyMatch(
+                parent -> !areAllAttributesEqual(firstParent, parent))
+        )
+            throw new MetadataExtractionException("The relations provided to the union do not have equal attributes");
+
+        var projectedVariables = firstParent.getAttributes().stream().collect(ImmutableCollectors.toMap(
+                attribute -> attribute.getID().getName(),
+                attribute -> variableGenerator.generateNewVariable(attribute.getID().getName())
+        ));
+        return projectedVariables;
+    }
+
+    private boolean areAllAttributesEqual(NamedRelationDefinition a, NamedRelationDefinition b) {
+        if(a.getAttributes().stream().anyMatch(
+                attributeA -> b.getAttributes().stream().allMatch(
+                        attributeB -> !areAttributesEqual(attributeA, attributeB)
+                )
+        ))
+            return false;
+        return !(a.getAttributes().stream().anyMatch(
+                attributeA -> b.getAttributes().stream().allMatch(
+                        attributeB -> !areAttributesEqual(attributeA, attributeB)
+                )
+        ));
+    }
+
+    private boolean areAttributesEqual(Attribute a, Attribute b) {
+        return a.getID().getName().equals(b.getID().getName()) && a.getTermType().equals(b.getTermType());
+    }
+
+    private ImmutableList<NamedRelationDefinition> getParentRelations(
+            DBParameters dbParameters, MetadataLookup parentCacheMetadataLookup) throws MetadataExtractionException {
+        QuotedIDFactory quotedIDFactory = dbParameters.getQuotedIDFactory();
+        return this.unionRelations.stream().map(name -> {
+                try {
+                    return parentCacheMetadataLookup.getRelation(quotedIDFactory.createRelationID(
+                            name.toArray(new String[0])));
+                } catch (MetadataExtractionException e) {
+                    throw new RuntimeException(e);
+                }
+            }).collect(ImmutableCollectors.toList());
+    }
+
+    private IQ createIQ(RelationID relationId, DBParameters dbParameters, MetadataLookup parentCacheMetadataLookup)
+            throws MetadataExtractionException {
+
+
+        CoreSingletons coreSingletons = dbParameters.getCoreSingletons();
+
+        QuotedIDFactory quotedIDFactory = dbParameters.getQuotedIDFactory();
+        TermFactory termFactory = coreSingletons.getTermFactory();
+        IntermediateQueryFactory iqFactory = coreSingletons.getIQFactory();
+        AtomFactory atomFactory = coreSingletons.getAtomFactory();
+
+        ImmutableMap<String, Variable> projectedVariables = this.extractProjectedVariables(dbParameters, parentCacheMetadataLookup);
+        ImmutableSet<Variable> allProjectedVariables;
+        if(includesProvenanceColumn()) {
+            var provenanceVariable = termFactory.getVariable(getProvenanceColumn(quotedIDFactory));
+            if(projectedVariables.values().stream().anyMatch(v -> v.getName().equals(provenanceVariable.getName())))
+                throw new MetadataExtractionException("The provenance column with the name " + provenanceVariable.getName()
+                    + " cannot be added, because a column with this name already exists.");
+            allProjectedVariables = ImmutableSet.<Variable>builder()
+                    .addAll(projectedVariables.values())
+                    .add(provenanceVariable)
+                    .build();
+        } else {
+            allProjectedVariables = projectedVariables.values().stream().collect(ImmutableCollectors.toSet());
+        }
+
+        //Generate children as ExtensionalDataNodes
+        ImmutableList<IQTree> children = getParentRelations(dbParameters, parentCacheMetadataLookup).stream()
+                .map(child -> iqFactory.createExtensionalDataNode(child, IntStream.range(0, projectedVariables.size()).boxed().collect(
+                        ImmutableCollectors.toMap(
+                                i -> i,
+                                i -> projectedVariables.get(child.getAttribute(i + 1).getID().getName())
+                        )
+                ))).collect(ImmutableCollectors.toList());
+
+        //Add provenance column to each child
+        ImmutableList<IQTree> extendedChildren;
+        if(includesProvenanceColumn()) {
+            extendedChildren = children.stream().map(
+                    child -> addConstantColumn(
+                            termFactory.getVariable(getProvenanceColumn(quotedIDFactory)),
+                            String.join(".", quotedIDFactory.createRelationID(unionRelations.get(children.indexOf(child)).toArray(new String[0]))
+                                    .getComponents().stream().map(c -> c.getName()).collect(Collectors.toList())),
+                            child,
+                            coreSingletons
+                    )
+            ).collect(ImmutableCollectors.toList());
+        } else {
+            extendedChildren = children;
+        }
+
+
+        //Create union of children
+        UnionNode union = iqFactory.createUnionNode(allProjectedVariables);
+        IQTree iqTree = iqFactory.createNaryIQTree(union, extendedChildren);
+
+        if(this.makeDistinct)
+            iqTree = iqFactory.createUnaryIQTree(iqFactory.createDistinctNode(), iqTree);
+
+        NotYetTypedEqualityTransformer notYetTypedEqualityTransformer = coreSingletons.getNotYetTypedEqualityTransformer();
+        IQTree transformedTree = notYetTypedEqualityTransformer.transform(iqTree);
+
+        IQTree finalTree = addIRISafeConstraints(transformedTree, dbParameters);
+
+        AtomPredicate tmpPredicate = createTemporaryPredicate(relationId, allProjectedVariables.size(), coreSingletons);
+        DistinctVariableOnlyDataAtom projectionAtom = atomFactory.getDistinctVariableOnlyDataAtom(tmpPredicate, ImmutableList.copyOf(allProjectedVariables));
+
+        //normalization will be done later on when unique constraint information from parents is available
+        return iqFactory.createIQ(projectionAtom, finalTree);
+    }
+
+    private IQTree addConstantColumn(Variable variable, String value, IQTree child, CoreSingletons coreSingletons) {
+        var substitutionFactory = coreSingletons.getSubstitutionFactory();
+        var iqFactory = coreSingletons.getIQFactory();
+        var substitutionNormalizer = coreSingletons.getConstructionSubstitutionNormalizer();
+        var termFactory = coreSingletons.getTermFactory();
+
+        var provenanceValue = termFactory.getDBStringConstant(value);
+        ImmutableMap<Variable, ImmutableTerm> substitutionMap = ImmutableMap.of(variable, provenanceValue);
+        ImmutableSubstitution<ImmutableTerm> substitution = substitutionFactory.getSubstitution(substitutionMap);
+        var allProjectedVariables = ImmutableSet.<Variable>builder()
+                .addAll(child.getKnownVariables())
+                .add(variable)
+                .build();
+        ConstructionSubstitutionNormalizer.ConstructionSubstitutionNormalization normalization =
+                substitutionNormalizer.normalizeSubstitution(substitution,
+                        allProjectedVariables);
+        ConstructionNode constructionNode = normalization.generateTopConstructionNode().get();
+        return iqFactory.createUnaryIQTree(constructionNode, child);
+    }
+
+    private AtomPredicate createTemporaryPredicate(RelationID relationId, int arity, CoreSingletons coreSingletons) {
+        DBTermType dbRootType = coreSingletons.getTypeFactory().getDBTypeFactory().getAbstractRootDBType();
+
+        return new TemporaryLensPredicate(
+                relationId.getSQLRendering(),
+                // No precise base DB type for the temporary predicate
+                IntStream.range(0, arity)
+                        .mapToObj(i -> dbRootType)
+                        .collect(ImmutableCollectors.toList()));
+    }
+
+    protected void insertUniqueConstraints(Lens relation, QuotedIDFactory idFactory,
+                                           List<AddUniqueConstraints> addUniqueConstraints,
+                                           ImmutableList<NamedRelationDefinition> baseRelations,
+                                           CoreSingletons coreSingletons)
+            throws MetadataExtractionException {
+
+        var allAddUniqueConstraints = Stream.concat(
+                    addUniqueConstraints.stream(),
+                    inferUniqueConstraints(relation, idFactory).stream()
+                ).collect(Collectors.toList());
+
+        for (AddUniqueConstraints addUC : allAddUniqueConstraints) {
+            if (addUC.isPrimaryKey != null && addUC.isPrimaryKey) LOGGER.warn("Primary key set in the view file for " + addUC.name);
+            FunctionalDependency.Builder builder = UniqueConstraint.builder(relation, addUC.name);
+            JsonMetadata.deserializeAttributeList(idFactory, addUC.determinants, builder::addDeterminant);
+            builder.build();
+        }
+
+    }
+
+    private ImmutableList<AddUniqueConstraints> inferUniqueConstraints(Lens relation, QuotedIDFactory quotedIDFactory) {
+
+        var iqTree = relation.getIQ().normalizeForOptimization().getTree();
+        var constraints = iqTree.inferUniqueConstraints();
+
+        DistinctVariableOnlyDataAtom projectedAtom = relation.getIQ().getProjectionAtom();
+
+        ImmutableMap<Variable, QuotedID> variableIds = relation.getAttributes().stream()
+                .collect(ImmutableCollectors.toMap(
+                        a -> projectedAtom.getTerm(a.getIndex() - 1),
+                        Attribute::getID));
+
+        return constraints.stream()
+                .map(vs -> new AddUniqueConstraints(
+                        UUID.randomUUID().toString(),
+                        vs.stream()
+                                .map(v -> Optional.ofNullable(variableIds.get(v))
+                                        .orElseThrow(() -> new MinorOntopInternalBugException(
+                                                "The variables of the unique constraints should be projected")))
+                                .map(QuotedID::getSQLRendering)
+                                .collect(ImmutableCollectors.toList()),
+                        // PK by default false
+                        false
+                ))
+                .collect(ImmutableCollectors.toList());
+    }
+
+    private boolean uniqueConstraintEqualOrMoreLenientThan(UniqueConstraint a, UniqueConstraint b) {
+        for(var attribute : a.getDeterminants()) {
+            if(!b.getDeterminants().stream().anyMatch(
+                    attr -> attr.getID().getName().equals(attribute.getID().getName())
+            ))
+                return false;
+        }
+        return true;
+    }
+
+    private void insertFunctionalDependencies(NamedRelationDefinition relation,
+                                              QuotedIDFactory idFactory,
+                                              List<AddFunctionalDependency> addFunctionalDependencies)
+            throws MetadataExtractionException {
+
+        for (AddFunctionalDependency addFD : addFunctionalDependencies) {
+            FunctionalDependency.Builder builder = FunctionalDependency.defaultBuilder(relation);
+
+            try {
+                JsonMetadata.deserializeAttributeList(idFactory, addFD.determinants, builder::addDeterminant);
+                JsonMetadata.deserializeAttributeList(idFactory, addFD.dependents, builder::addDependent);
+                builder.build();
+            }
+            catch (MetadataExtractionException e) {
+                throw new MetadataExtractionException(String.format(
+                        "Cannot find attribute for Functional Dependency %s", addFD.determinants));
+            }
+        }
+
+    }
+
+    private boolean includesProvenanceColumn() {
+        return provenanceColumn != null && provenanceColumn.length() > 0;
+    }
+
+    private String getProvenanceColumn(QuotedIDFactory quotedIDFactory, boolean sqlRendering) {
+        if(sqlRendering)
+            return quotedIDFactory.createAttributeID(this.provenanceColumn).getSQLRendering();
+        return quotedIDFactory.createAttributeID(this.provenanceColumn).getName();
+    }
+
+    private String getProvenanceColumn(QuotedIDFactory quotedIDFactory) {
+        return getProvenanceColumn(quotedIDFactory, false);
+    }
+
+    private static class LevelExtractor extends DefaultRecursiveIQTreeVisitingTransformer {
+        // Non-final
+        int maxLevel;
+
+        public int getMaxLevel() {
+            return maxLevel;
+        }
+
+        public LevelExtractor(CoreSingletons coreSingletons) {
+            super(coreSingletons);
+            maxLevel = 0;
+        }
+
+        @Override
+        public IQTree transformExtensionalData(ExtensionalDataNode dataNode) {
+            RelationDefinition parentRelation = dataNode.getRelationDefinition();
+            int level = (parentRelation instanceof Lens)
+                    ? ((Lens) parentRelation).getLevel()
+                    : 0;
+            maxLevel = Math.max(maxLevel, level);
+            return dataNode;
+        }
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonUnionLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonUnionLens.java
@@ -86,10 +86,6 @@ public class JsonUnionLens extends JsonLens {
 
         int maxParentLevel = extractMaxParentLevel(iq, dbParameters.getCoreSingletons());
 
-        if (maxParentLevel > 0)
-            LOGGER.warn("It is dangerous to build SQLViewDefinitions above OntopViewDefinitions, " +
-                    "because the view definition will fail if the SQL query cannot be parsed by Ontop");
-
         // For added columns the termtype, quoted ID and nullability all need to come from the IQ
         RelationDefinition.AttributeListBuilder attributeBuilder = createAttributeBuilder(iq, dbParameters);
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonUnionLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonUnionLens.java
@@ -130,7 +130,6 @@ public class JsonUnionLens extends JsonLens {
 
     protected ImmutableMap<String, Variable> extractProjectedVariables(
             DBParameters dbParameters, MetadataLookup parentCacheMetadataLookup) throws MetadataExtractionException {
-        QuotedIDFactory quotedIDFactory = dbParameters.getQuotedIDFactory();
         VariableGenerator variableGenerator = dbParameters.getCoreSingletons().getCoreUtilsFactory().createVariableGenerator(ImmutableList.of());
 
         if (unionRelations.size() < 2)

--- a/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/UnionLensTest.java
+++ b/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/UnionLensTest.java
@@ -1,0 +1,92 @@
+package it.unibz.inf.ontop.dbschema;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class UnionLensTest {
+    private static final String VIEW_FILE = "src/test/resources/union/union_lenses.json";
+    private static final String DBMETADATA_FILE = "src/test/resources/union/union.db-extract.json";
+
+    private final ImmutableSet<Lens> viewDefinitions = LensParsingTest.loadLensesH2(VIEW_FILE, DBMETADATA_FILE);
+    private final ImmutableMap<String, Lens> viewMap;
+
+    public UnionLensTest() throws Exception {
+        viewMap = viewDefinitions.stream().collect(ImmutableCollectors.<Lens, String, Lens>toMap(
+                l -> String.join(".", l.getID().getComponents().stream().map(c -> c.getName()).collect(Collectors.toList())),
+                l -> l
+        ));
+    }
+
+    @Test
+    public void testInheritedUniqueConstraint() {
+        var constraints = viewMap.get("l1.lenses").getUniqueConstraints();
+        assertEquals(constraints.size(), 1);
+        assertEquals(ImmutableSet.of("id", "prov"), constraints.get(0).getAttributes().stream().map(a -> a.getID().getName()).collect(ImmutableCollectors.toSet()));
+    }
+
+    @Test
+    public void testDifferentOrder() {
+        var constraints = viewMap.get("differentOrder.lenses").getUniqueConstraints();
+        assertEquals(constraints.size(), 1);
+        assertEquals(ImmutableSet.of("id", "prov"), constraints.get(0).getAttributes().stream().map(a -> a.getID().getName()).collect(ImmutableCollectors.toSet()));
+    }
+
+    @Test
+    public void testInheritedNoUniqueConstraint() {
+        var constraints = viewMap.get("specialized.lenses").getUniqueConstraints();
+        assertEquals(constraints.size(), 0);
+    }
+
+    @Test
+    public void testUniqueConstraintsFromMakeDistinct() {
+        var constraints = viewMap.get("extras.lenses").getUniqueConstraints();
+        assertEquals(constraints.size(), 1);
+        assertEquals(ImmutableSet.of("id", "info", "provenance"), constraints.get(0).getAttributes().stream().map(a -> a.getID().getName()).collect(ImmutableCollectors.toSet()));
+    }
+
+    @Test
+    public void testUniqueNotInferredIfNoProvenanceColumn() {
+        var lens = viewMap.get("l2.lenses");
+        var constraints = lens.getUniqueConstraints();
+        assertEquals(constraints.size(), 0);
+        assertEquals(lens.getAttributes().size(), 2);
+    }
+
+    @Test
+    public void testUniqueNotInferredIfOneChildNotUnique() {
+        var lens = viewMap.get("l3.lenses");
+        var constraints = lens.getUniqueConstraints();
+        assertEquals(constraints.size(), 0);
+        assertEquals(lens.getAttributes().size(), 3);
+    }
+
+    @Test
+    public void testBadUnionDifferentColumnNames() {
+        assertLoadFails("src/test/resources/union/bad_lenses/different_names.json");
+    }
+
+    @Test
+    public void testBadUnionDifferentColumnTypes() {
+        assertLoadFails("src/test/resources/union/bad_lenses/different_types.json");
+    }
+
+    private void assertLoadFails(String path) {
+        try {
+            var viewDefinitions = LensParsingTest.loadLensesH2(path, DBMETADATA_FILE);
+            assert(false); //code should never reach this line
+        } catch (Exception e) {
+            //correct
+        }
+    }
+
+
+
+}

--- a/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/UnionLensTest.java
+++ b/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/UnionLensTest.java
@@ -8,64 +8,110 @@ import org.junit.Test;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class UnionLensTest {
-    private static final String VIEW_FILE = "src/test/resources/union/union_lenses.json";
+    private static final String LENS_FILE = "src/test/resources/union/union_lenses.json";
     private static final String DBMETADATA_FILE = "src/test/resources/union/union.db-extract.json";
 
-    private final ImmutableSet<Lens> viewDefinitions = LensParsingTest.loadLensesH2(VIEW_FILE, DBMETADATA_FILE);
-    private final ImmutableMap<String, Lens> viewMap;
+    private final ImmutableSet<Lens> lensDefinitions = LensParsingTest.loadLensesH2(LENS_FILE, DBMETADATA_FILE);
+    private final ImmutableMap<String, Lens> lensMap;
 
     public UnionLensTest() throws Exception {
-        viewMap = viewDefinitions.stream().collect(ImmutableCollectors.<Lens, String, Lens>toMap(
-                l -> String.join(".", l.getID().getComponents().stream().map(c -> c.getName()).collect(Collectors.toList())),
+        lensMap = lensDefinitions.stream().collect(ImmutableCollectors.<Lens, String, Lens>toMap(
+                l -> String.join(".", l.getID().getComponents().reverse().stream().map(c -> c.getName()).collect(Collectors.toList())),
                 l -> l
         ));
     }
 
     @Test
     public void testInheritedUniqueConstraint() {
-        var constraints = viewMap.get("l1.lenses").getUniqueConstraints();
-        assertEquals(constraints.size(), 1);
+        var constraints = lensMap.get("lenses.l1").getUniqueConstraints();
+        assertEquals(1, constraints.size());
         assertEquals(ImmutableSet.of("id", "prov"), constraints.get(0).getAttributes().stream().map(a -> a.getID().getName()).collect(ImmutableCollectors.toSet()));
     }
 
     @Test
     public void testDifferentOrder() {
-        var constraints = viewMap.get("differentOrder.lenses").getUniqueConstraints();
-        assertEquals(constraints.size(), 1);
+        var constraints = lensMap.get("lenses.differentOrder").getUniqueConstraints();
+        assertEquals(1, constraints.size());
         assertEquals(ImmutableSet.of("id", "prov"), constraints.get(0).getAttributes().stream().map(a -> a.getID().getName()).collect(ImmutableCollectors.toSet()));
     }
 
     @Test
     public void testInheritedNoUniqueConstraint() {
-        var constraints = viewMap.get("specialized.lenses").getUniqueConstraints();
-        assertEquals(constraints.size(), 0);
+        var constraints = lensMap.get("lenses.specialized").getUniqueConstraints();
+        assertEquals(0, constraints.size());
     }
 
     @Test
     public void testUniqueConstraintsFromMakeDistinct() {
-        var constraints = viewMap.get("extras.lenses").getUniqueConstraints();
-        assertEquals(constraints.size(), 1);
+        var constraints = lensMap.get("lenses.extras").getUniqueConstraints();
+        assertEquals(1, constraints.size());
         assertEquals(ImmutableSet.of("id", "info", "provenance"), constraints.get(0).getAttributes().stream().map(a -> a.getID().getName()).collect(ImmutableCollectors.toSet()));
     }
 
     @Test
     public void testUniqueNotInferredIfNoProvenanceColumn() {
-        var lens = viewMap.get("l2.lenses");
+        var lens = lensMap.get("lenses.l2");
         var constraints = lens.getUniqueConstraints();
-        assertEquals(constraints.size(), 0);
-        assertEquals(lens.getAttributes().size(), 2);
+        assertEquals(0, constraints.size());
+        assertEquals(2, lens.getAttributes().size());
     }
 
     @Test
     public void testUniqueNotInferredIfOneChildNotUnique() {
-        var lens = viewMap.get("l3.lenses");
+        var lens = lensMap.get("lenses.l3");
         var constraints = lens.getUniqueConstraints();
-        assertEquals(constraints.size(), 0);
-        assertEquals(lens.getAttributes().size(), 3);
+        assertEquals(0, constraints.size());
+        assertEquals(3, lens.getAttributes().size());
+    }
+
+    @Test
+    public void testProjectedChildrenKeepUnique() {
+        var lens = lensMap.get("lenses.specializedWithX");
+        var constraints = lens.getUniqueConstraints();
+        assertEquals(1, constraints.size());
+        assertEquals(2, constraints.get(0).getDeterminants().size());
+    }
+
+    @Test
+    public void testTripleUnionKeepsUnique() {
+        var lens = lensMap.get("lenses.tripleUnion");
+        var constraints = lens.getUniqueConstraints();
+        assertEquals(1, constraints.size());
+        assertEquals(2, constraints.get(0).getDeterminants().size());
+    }
+
+    @Test
+    public void testUnionOfSameTableLosesUnique() {
+        var lens = lensMap.get("lenses.cloneUnion");
+        var constraints = lens.getUniqueConstraints();
+        assertEquals(0, constraints.size());
+    }
+
+    @Test
+    public void testNullableIsInherited() {
+        var lens = lensMap.get("lenses.nullable");
+        var id = lens.getAttribute(1);
+        assertTrue(id.isNullable());
+    }
+
+    @Test
+    public void testNullableKeepsUniqueConstraints() {
+        var lens = lensMap.get("lenses.nullable");
+        var constraints = lens.getUniqueConstraints();
+        assertEquals(1, constraints.size());
+    }
+
+    @Test
+    public void testAddedConstraints() {
+        var lens = lensMap.get("lenses.added");
+        var constraints = lens.getUniqueConstraints();
+        assertEquals(2, constraints.size());
+        assertEquals(1, lens.getOtherFunctionalDependencies().size());
+        assertEquals(1, lens.getForeignKeys().size());
+        assertFalse(lens.getAttribute(1).isNullable());
     }
 
     @Test
@@ -78,11 +124,17 @@ public class UnionLensTest {
         assertLoadFails("src/test/resources/union/bad_lenses/different_types.json");
     }
 
+    @Test
+    public void testBadUnionDifferentColumnCount() {
+        assertLoadFails("src/test/resources/union/bad_lenses/different_column_count.json");
+    }
+
     private void assertLoadFails(String path) {
         try {
-            var viewDefinitions = LensParsingTest.loadLensesH2(path, DBMETADATA_FILE);
+            var lensDefinitions = LensParsingTest.loadLensesH2(path, DBMETADATA_FILE);
             assert(false); //code should never reach this line
         } catch (Exception e) {
+            System.out.println(e.getMessage());
             //correct
         }
     }

--- a/db/rdb/src/test/resources/union/bad_lenses/different_column_count.json
+++ b/db/rdb/src/test/resources/union/bad_lenses/different_column_count.json
@@ -1,0 +1,42 @@
+{
+  "relations": [
+    {
+      "name": ["\"lenses\"", "\"sX\""],
+      "baseRelation": ["\"specializedAx\""],
+      "columns": {
+        "added": [],
+        "hidden": ["\"a\""]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"sB\""],
+      "baseRelation": ["\"specializedB\""],
+      "columns": {
+        "added": [],
+        "hidden": ["\"b\""]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"l1\""],
+      "unionRelations": [
+        ["\"lenses\"", "\"sB\""],
+        ["\"lenses\"", "\"sX\""],
+        ["\"specializedA\""]
+      ],
+      "makeDistinct": true,
+      "provenanceColumn": "\"prov\"",
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    }
+  ]
+}

--- a/db/rdb/src/test/resources/union/bad_lenses/different_names.json
+++ b/db/rdb/src/test/resources/union/bad_lenses/different_names.json
@@ -1,0 +1,23 @@
+{
+  "relations": [
+    {
+      "name": ["\"lenses\"", "\"l1\""],
+      "unionRelations": [
+        ["\"specializedA\""],
+        ["\"specializedB\""]
+      ],
+      "makeDistinct": true,
+      "provenanceColumn": "\"prov\"",
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    }
+  ]
+}

--- a/db/rdb/src/test/resources/union/bad_lenses/different_types.json
+++ b/db/rdb/src/test/resources/union/bad_lenses/different_types.json
@@ -1,0 +1,23 @@
+{
+  "relations": [
+    {
+      "name": ["\"lenses\"", "\"l1\""],
+      "unionRelations": [
+        ["\"specializedA\""],
+        ["\"specializedAx\""]
+      ],
+      "makeDistinct": true,
+      "provenanceColumn": "\"prov\"",
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    }
+  ]
+}

--- a/db/rdb/src/test/resources/union/union.db-extract.json
+++ b/db/rdb/src/test/resources/union/union.db-extract.json
@@ -1,0 +1,296 @@
+{
+  "relations": [
+    {
+      "uniqueConstraints": [
+        {
+          "name": "CONSTRAINT_1",
+          "determinants": [
+            "\"id\""
+          ],
+          "isPrimaryKey": true
+        }
+      ],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"table1\""
+      ]
+    },
+    {
+      "uniqueConstraints": [
+        {
+          "name": "CONSTRAINT_2",
+          "determinants": [
+            "\"id\""
+          ],
+          "isPrimaryKey": true
+        }
+      ],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"table2\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"table3\""
+      ]
+    },
+    {
+      "uniqueConstraints": [
+        {
+          "name": "CONSTRAINT_4",
+          "determinants": [
+            "\"id\""
+          ],
+          "isPrimaryKey": true
+        }
+      ],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        },
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"tableDifferentOrder\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [
+        {
+          "to": {
+            "columns": [
+              "\"id\""
+            ],
+            "relation": [
+              "\"table1\""
+            ]
+          },
+          "from": {
+            "columns": [
+              "\"id\""
+            ],
+            "relation": [
+              "\"extra1\""
+            ]
+          },
+          "name": "extra1_id_fkey"
+        }
+      ],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"info\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"extra1\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [
+        {
+          "to": {
+            "columns": [
+              "\"id\""
+            ],
+            "relation": [
+              "\"table1\""
+            ]
+          },
+          "from": {
+            "columns": [
+              "\"id\""
+            ],
+            "relation": [
+              "\"extra2\""
+            ]
+          },
+          "name": "extra2_id_fkey"
+        }
+      ],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"info\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"extra2\""
+      ]
+    },
+    {
+      "uniqueConstraints": [
+        {
+          "name": "CONSTRAINT_A",
+          "determinants": [
+            "\"id\""
+          ],
+          "isPrimaryKey": true
+        }
+      ],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"value\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"a\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"specializedA\""
+      ]
+    },
+    {
+      "uniqueConstraints": [
+        {
+          "name": "CONSTRAINT_Ax",
+          "determinants": [
+            "\"id\""
+          ],
+          "isPrimaryKey": true
+        }
+      ],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"value\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"a\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"specializedAx\""
+      ]
+    },
+    {
+      "uniqueConstraints": [
+        {
+          "name": "CONSTRAINT_B",
+          "determinants": [
+            "\"id\"",
+            "\"b\""
+          ],
+          "isPrimaryKey": true
+        }
+      ],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"value\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"b\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"specializedB\""
+      ]
+    }
+  ],
+  "metadata": {
+    "dbmsProductName": "H2",
+    "dbmsVersion": "1.4.199 (2019-03-13)",
+    "driverName": "H2 JDBC Driver",
+    "driverVersion": "1.4.199 (2019-03-13)",
+    "quotationString": "\"",
+    "extractionTime": "2020-11-12T17:24:30"
+  }
+}

--- a/db/rdb/src/test/resources/union/union.db-extract.json
+++ b/db/rdb/src/test/resources/union/union.db-extract.json
@@ -105,6 +105,34 @@
       ]
     },
     {
+      "uniqueConstraints": [
+        {
+          "name": "CONSTRAINT_5",
+          "determinants": [
+            "\"id\""
+          ],
+          "isPrimaryKey": false
+        }
+      ],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": true
+        },
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"tableNullable\""
+      ]
+    },
+    {
       "uniqueConstraints": [],
       "otherFunctionalDependencies": [],
       "foreignKeys": [

--- a/db/rdb/src/test/resources/union/union_lenses.json
+++ b/db/rdb/src/test/resources/union/union_lenses.json
@@ -1,0 +1,135 @@
+{
+  "relations": [
+    {
+      "name": ["\"lenses\"", "\"l1\""],
+      "unionRelations": [
+        ["\"table1\""],
+        ["\"table2\""]
+      ],
+      "makeDistinct": true,
+      "provenanceColumn": "\"prov\"",
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"l2\""],
+      "unionRelations": [
+        ["\"table1\""],
+        ["\"table2\""]
+      ],
+      "makeDistinct": false,
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"l3\""],
+      "unionRelations": [
+        ["\"table1\""],
+        ["\"table3\""]
+      ],
+      "provenanceColumn": "\"prov\"",
+      "makeDistinct": false,
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"differentOrder\""],
+      "unionRelations": [
+        ["\"table1\""],
+        ["\"tableDifferentOrder\""]
+      ],
+      "provenanceColumn": "\"prov\"",
+      "makeDistinct": false,
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"extras\""],
+      "unionRelations": [
+        ["\"extra1\""],
+        ["\"extra2\""]
+      ],
+      "makeDistinct": true,
+      "provenanceColumn": "\"provenance\"",
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"sA\""],
+      "baseRelation": ["\"specializedA\""],
+      "columns": {
+        "added": [],
+        "hidden": ["\"a\""]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"sB\""],
+      "baseRelation": ["\"specializedB\""],
+      "columns": {
+        "added": [],
+        "hidden": ["\"b\""]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"specialized\""],
+      "unionRelations": [
+        ["\"lenses\"", "\"sA\""],
+        ["\"lenses\"", "\"sB\""]
+      ],
+      "makeDistinct": false,
+      "provenanceColumn": "\"provenance\"",
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    }
+  ]
+}

--- a/db/rdb/src/test/resources/union/union_lenses.json
+++ b/db/rdb/src/test/resources/union/union_lenses.json
@@ -104,6 +104,24 @@
       "type": "BasicLens"
     },
     {
+      "name": ["\"lenses\"", "\"sC\""],
+      "baseRelation": ["\"specializedA\""],
+      "columns": {
+        "added": [],
+        "hidden": ["\"a\""]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"sX\""],
+      "baseRelation": ["\"specializedAx\""],
+      "columns": {
+        "added": [],
+        "hidden": ["\"a\""]
+      },
+      "type": "BasicLens"
+    },
+    {
       "name": ["\"lenses\"", "\"sB\""],
       "baseRelation": ["\"specializedB\""],
       "columns": {
@@ -128,6 +146,125 @@
       },
       "nonNullConstraints": {
         "added": []
+      },
+      "type": "UnionLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"specializedWithX\""],
+      "unionRelations": [
+        ["\"lenses\"", "\"sA\""],
+        ["\"lenses\"", "\"sX\""]
+      ],
+      "makeDistinct": false,
+      "provenanceColumn": "\"provenance\"",
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"tripleUnion\""],
+      "unionRelations": [
+        ["\"table1\""],
+        ["\"table2\""],
+        ["\"tableDifferentOrder\""]
+      ],
+      "makeDistinct": false,
+      "provenanceColumn": "\"provenance\"",
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"cloneUnion\""],
+      "unionRelations": [
+        ["\"table1\""],
+        ["\"table1\""]
+      ],
+      "makeDistinct": false,
+      "provenanceColumn": "\"provenance\"",
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"nullable\""],
+      "unionRelations": [
+        ["\"table1\""],
+        ["\"tableNullable\""]
+      ],
+      "makeDistinct": false,
+      "provenanceColumn": "\"provenance\"",
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": []
+      },
+      "nonNullConstraints": {
+        "added": []
+      },
+      "type": "UnionLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"added\""],
+      "unionRelations": [
+        ["\"table1\""],
+        ["\"tableNullable\""]
+      ],
+      "makeDistinct": false,
+      "provenanceColumn": "\"provenance\"",
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "name_is_unique",
+            "determinants": ["\"name\""],
+            "isPrimaryKey": false
+          }
+        ]
+      },
+      "otherFunctionalDependencies": {
+        "added": [
+          {
+            "determinants": ["\"id\""],
+            "dependents": ["\"name\""]
+          }
+        ]
+      },
+      "foreignKeys": {
+        "added": [
+          {
+            "name": "id_foreign_key",
+            "from": "\"id\"",
+            "to": {
+              "columns": ["\"id\""],
+              "relation": ["\"extra1\""]
+            }
+          }
+        ]
+      },
+      "nonNullConstraints": {
+        "added": ["\"id\""]
       },
       "type": "UnionLens"
     }


### PR DESCRIPTION
Added support for the `UnionLens` lens type.

3 additional fields:
`unionRelations`: A set of relations to compute the union of.
`makeDistinct`: Boolean value determining if result should be made distinct.
`provenanceColumn`: If provided, adds an additional column in which the source location of each data row is included.

Also added high-level tests:
- An example usage scenario, testing if provenance columns are included correctly and if all items are included in the union.

And low-level tests:
- Unions of two or more tables or lenses are performed correctly
- "Negative" test cases of union lenses in a format that is not supported (i.e. attributes have different types/names)
- Test cases on the inference of unique constraints (if all union tables have a unique constraint on an attribute and there exists a provenance column, then the full union has one too)
- Other added integrity constraints