### PR TITLE
BigQuery support for ontop

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,6 +118,37 @@ jobs:
           ATHENA_BUCKET: ${{ secrets.ATHENA_BUCKET }}
         run: cd test/lightweight-tests && ../../mvnw install -Dgroups="athenalighttests" -DskipTests=false -Dathena.user=${ATHENA_USER} -Dathena.password=${ATHENA_PASSWORD} -Dathena.bucket=${ATHENA_BUCKET} --fail-at-end
 
+#  run-bigquery:
+#    # Checks if secrets are available
+#    if: needs.check-secrets.outputs.have_secrets == 'true'
+#    needs: [ build-run-non-docker-tests , check-secrets ]
+#    # The type of runner that the job will run on
+#    runs-on: ubuntu-latest
+#    strategy:
+#      # The java versions the job will run on
+#      matrix:
+#        jdk: [ 11 ]
+#
+#    steps:
+#      # Checks-out ontop repository under $GITHUB_WORKSPACE
+#      - uses: actions/checkout@v3
+#      # Set up the java versions
+#      - name: Set up Java
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'corretto'
+#          java-version: ${{ matrix.jdk }}
+#          cache: maven
+#      - name: Set maven opts
+#        run: set MAVEN_OPTS="-Xms6000m -Xmx8000m"
+#      - name: Run CI for BigQuery lightweight tests
+#        env:
+#          BIGQUERY_USER: ${{ secrets.BIGQUERY_USER }}
+#          BIGQUERY_PASSWORD: ${{ secrets.BIGQUERY_PASSWORD }}
+#          BIGQUERY_PROJECT: ${{ secrets.BIGQUERY_PROJECT }}
+#          BIGQUERY_DOMAIN: ${{ secrets.BIGQUERY_DOMAIN }}
+#        run: cd test/lightweight-tests && ../../mvnw install -Dgroups="bigquerylighttests" -DskipTests=false -Dbigquery.user=${BIGQUERY_USER} -Dbigquery.password=${BIGQUERY_PASSWORD} -Dbigquery.project=${BIGQUERY_PROJECT} -Dbigquery.domain=${BIGQUERY_DOMAIN} --fail-at-end
+
 #  run-redshift:
 #    # Checks if secrets are available
 #    if: needs.check-secrets.outputs.have_secrets == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
 #  run-bigquery:
 #    # Checks if secrets are available
 #    if: needs.check-secrets.outputs.have_secrets == 'true'
-#    needs: [ build-run-non-docker-tests , check-secrets ]
+#    needs: [ build-run-non-docker-tests , run-athena ]
 #    # The type of runner that the job will run on
 #    runs-on: ubuntu-latest
 #    strategy:

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/BigQueryDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/BigQueryDBMetadataProvider.java
@@ -1,0 +1,31 @@
+package it.unibz.inf.ontop.dbschema.impl;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
+import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.RelationID;
+import it.unibz.inf.ontop.exception.MetadataExtractionException;
+import it.unibz.inf.ontop.injection.CoreSingletons;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+
+import static it.unibz.inf.ontop.dbschema.RelationID.TABLE_INDEX;
+
+public class BigQueryDBMetadataProvider extends DefaultSchemaCatalogDBMetadataProvider {
+
+    @AssistedInject
+    BigQueryDBMetadataProvider(@Assisted Connection connection, CoreSingletons coreSingletons) throws MetadataExtractionException {
+        super(connection, metadata -> new BigQueryQuotedIDFactory(), coreSingletons);
+    }
+
+    @Override
+    protected ResultSet getRelationIDsResultSet() throws SQLException {
+        return metadata.getTables(null, null, null, new String[] { "TABLE", "VIEW", "MATERIALIZED VIEW" });
+    }
+
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/BigQueryQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/BigQueryQuotedIDFactory.java
@@ -1,0 +1,31 @@
+package it.unibz.inf.ontop.dbschema.impl;
+
+import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.RelationID;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class BigQueryQuotedIDFactory extends SQLStandardQuotedIDFactory {
+
+    private static final String SQL_QUOTATION_STRING = "`";
+
+    @Override
+    protected QuotedID createFromString(@Nonnull String s) {
+        Objects.requireNonNull(s);
+
+        if (s.startsWith(SQL_QUOTATION_STRING) && s.endsWith(SQL_QUOTATION_STRING))
+            return new QuotedIDImpl(s.substring(1, s.length() - 1), SQL_QUOTATION_STRING, true);
+
+        return new QuotedIDImpl(s, SQL_QUOTATION_STRING, true);
+    }
+
+    @Override
+    public String getIDQuotationString() {
+        return SQL_QUOTATION_STRING;
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/BigQueryExtraNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/BigQueryExtraNormalizer.java
@@ -8,12 +8,15 @@ import it.unibz.inf.ontop.utils.VariableGenerator;
 
 public class BigQueryExtraNormalizer implements DialectExtraNormalizer {
 
+    private final AlwaysProjectOrderByTermsNormalizer alwaysProjectOrderByTermsNormalizer;
     private final PushProjectedOrderByTermsNormalizer pushProjectedOrderByTermsNormalizer;
     private final ConvertValuesToUnionNormalizer convertValuesToUnionNormalizer;
 
     @Inject
-    protected BigQueryExtraNormalizer(PushProjectedOrderByTermsNormalizer pushProjectedOrderByTermsNormalizer,
+    protected BigQueryExtraNormalizer(AlwaysProjectOrderByTermsNormalizer alwaysProjectOrderByTermsNormalizer,
+                                      PushProjectedOrderByTermsNormalizer pushProjectedOrderByTermsNormalizer,
                                       ConvertValuesToUnionNormalizer convertValuesToUnionNormalizer) {
+        this.alwaysProjectOrderByTermsNormalizer = alwaysProjectOrderByTermsNormalizer;
         this.pushProjectedOrderByTermsNormalizer = pushProjectedOrderByTermsNormalizer;
         this.convertValuesToUnionNormalizer = convertValuesToUnionNormalizer;
     }
@@ -21,7 +24,9 @@ public class BigQueryExtraNormalizer implements DialectExtraNormalizer {
     @Override
     public IQTree transform(IQTree tree, VariableGenerator variableGenerator) {
               return pushProjectedOrderByTermsNormalizer.transform(
-                      convertValuesToUnionNormalizer.transform(tree, variableGenerator),
+                      alwaysProjectOrderByTermsNormalizer.transform(
+                              convertValuesToUnionNormalizer.transform(tree, variableGenerator),
+                              variableGenerator),
                       variableGenerator);
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/BigQueryExtraNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/BigQueryExtraNormalizer.java
@@ -1,0 +1,27 @@
+package it.unibz.inf.ontop.generation.normalization.impl;
+
+import com.google.inject.Inject;
+import it.unibz.inf.ontop.generation.normalization.DialectExtraNormalizer;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeExtendedTransformer;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+public class BigQueryExtraNormalizer implements DialectExtraNormalizer {
+
+    private final PushProjectedOrderByTermsNormalizer pushProjectedOrderByTermsNormalizer;
+    private final ConvertValuesToUnionNormalizer convertValuesToUnionNormalizer;
+
+    @Inject
+    protected BigQueryExtraNormalizer(PushProjectedOrderByTermsNormalizer pushProjectedOrderByTermsNormalizer,
+                                      ConvertValuesToUnionNormalizer convertValuesToUnionNormalizer) {
+        this.pushProjectedOrderByTermsNormalizer = pushProjectedOrderByTermsNormalizer;
+        this.convertValuesToUnionNormalizer = convertValuesToUnionNormalizer;
+    }
+
+    @Override
+    public IQTree transform(IQTree tree, VariableGenerator variableGenerator) {
+              return pushProjectedOrderByTermsNormalizer.transform(
+                      convertValuesToUnionNormalizer.transform(tree, variableGenerator),
+                      variableGenerator);
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/ProjectOrderByTermsNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/ProjectOrderByTermsNormalizer.java
@@ -248,7 +248,7 @@ public class ProjectOrderByTermsNormalizer extends DefaultRecursiveIQTreeExtende
      * Some nodes may be missing but the order must be respected. There are no multiple instances of the same kind of node.
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private static class Decomposition {
+    protected static class Decomposition {
         final Optional<SliceNode> sliceNode;
         final Optional<DistinctNode> distinctNode;
         final Optional<ConstructionNode> constructionNode;

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/PushProjectedOrderByTermsNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/PushProjectedOrderByTermsNormalizer.java
@@ -1,0 +1,87 @@
+package it.unibz.inf.ontop.generation.normalization.impl;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import it.unibz.inf.ontop.generation.normalization.DialectExtraNormalizer;
+import it.unibz.inf.ontop.injection.CoreSingletons;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.node.ConstructionNode;
+import it.unibz.inf.ontop.iq.node.DistinctNode;
+import it.unibz.inf.ontop.iq.node.OrderByNode;
+import it.unibz.inf.ontop.iq.node.impl.OrderComparatorImpl;
+import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeExtendedTransformer;
+import it.unibz.inf.ontop.model.term.NonGroundTerm;
+import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+import java.util.stream.Collectors;
+
+/*
+Used when an ORDER BY node accesses variables that are defined in a CONSTRUCT above it. Some dialects (like GoogleSQL) do
+not support that, so instead we push the CONSTRUCT down into the ORDER BY.
+ */
+public class PushProjectedOrderByTermsNormalizer extends DefaultRecursiveIQTreeExtendedTransformer<VariableGenerator> implements DialectExtraNormalizer {
+
+    private AlwaysProjectOrderByTermsNormalizer alwaysProjectOrderByTermsNormalizer;
+    private IntermediateQueryFactory iqFactory;
+    private final SubstitutionFactory substitutionFactory;
+
+    @Inject
+    protected PushProjectedOrderByTermsNormalizer(IntermediateQueryFactory iqFactory, SubstitutionFactory substitutionFactory,
+                                                  AlwaysProjectOrderByTermsNormalizer alwaysProjectOrderByTermsNormalizer, CoreSingletons coreSingletons) {
+        super(coreSingletons);
+        this.iqFactory = iqFactory;
+        this.substitutionFactory = substitutionFactory;
+        this.alwaysProjectOrderByTermsNormalizer = alwaysProjectOrderByTermsNormalizer;
+    }
+
+
+    @Override
+    public IQTree transform(IQTree tree, VariableGenerator context) {
+
+        //Run `AlwaysProjectOrderByTermsNormalizer` to prepare transformation.
+        IQTree projectedOrderByTerms = alwaysProjectOrderByTermsNormalizer.transform(tree, context);
+
+        //We only change trees of the form DISTINCT -> CONSTRUCT -> ORDER BY. Make sure our tree has that exact form,
+        //else we return the results of the `AlwaysProjectOrderByTermsNormalizer`
+        if(!(projectedOrderByTerms.getRootNode() instanceof DistinctNode) || projectedOrderByTerms.getChildren().size() == 0)
+            return projectedOrderByTerms;
+        DistinctNode distinct = (DistinctNode) projectedOrderByTerms.getRootNode();
+        var distinctSubtree = projectedOrderByTerms.getChildren().get(0);
+
+        if(!(distinctSubtree.getRootNode() instanceof ConstructionNode) || distinctSubtree.getChildren().size() == 0)
+            return projectedOrderByTerms;
+        ConstructionNode construct = (ConstructionNode) distinctSubtree.getRootNode();
+        var constructSubtree = distinctSubtree.getChildren().get(0);
+
+        if(!(constructSubtree.getRootNode() instanceof OrderByNode) || constructSubtree.getChildren().size() == 0)
+            return projectedOrderByTerms;
+        OrderByNode orderBy = (OrderByNode) constructSubtree.getRootNode();
+        var orderBySubtree = constructSubtree.getChildren().get(0);
+
+        //DISTINCT, CONSTRUCT, and ORDER BY nodes + their subtrees have been fetched
+
+        //Get map of terms used in ORDER BY that are defined in CONSTRUCT
+        var orderByTerms = orderBy.getComparators().stream().map(comp -> comp.getTerm()).collect(ImmutableCollectors.toSet());
+        var definedInConstruct = orderByTerms.stream().filter(
+                term -> construct.getSubstitution().getImmutableMap().values().stream().anyMatch(t -> t.equals(term))
+        ).collect(ImmutableCollectors.toMap(
+                term -> term,
+                term -> (NonGroundTerm) construct.getSubstitution().getImmutableMap().keySet().stream().filter(t -> construct.getSubstitution().get(t).equals(term)).findFirst().get()
+        ));
+
+        //Define new ORDER BY node that uses variables from CONSTRUCT instead, where possible
+        var newOrderBy = iqFactory.createOrderByNode(orderBy.getComparators().stream().map(
+                comp -> iqFactory.createOrderComparator(definedInConstruct.getOrDefault(comp.getTerm(), comp.getTerm()), comp.isAscending())
+        ).collect(ImmutableCollectors.toList()));
+
+        //Change order from DISTINCT -> CONSTRUCT -> ORDER BY to DISTINCT -> ORDER BY -> CONSTRUCT
+        var newOrderBySubtree = iqFactory.createUnaryIQTree(construct, orderBySubtree);
+        var newDistinctSubtree = iqFactory.createUnaryIQTree(newOrderBy, newOrderBySubtree);
+        var newFullTree = iqFactory.createUnaryIQTree(distinct, newDistinctSubtree);
+
+        return newFullTree;
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/PushProjectedOrderByTermsNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/PushProjectedOrderByTermsNormalizer.java
@@ -1,63 +1,60 @@
 package it.unibz.inf.ontop.generation.normalization.impl;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
+import it.unibz.inf.ontop.exception.MinorOntopInternalBugException;
 import it.unibz.inf.ontop.generation.normalization.DialectExtraNormalizer;
 import it.unibz.inf.ontop.injection.CoreSingletons;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.IQTree;
-import it.unibz.inf.ontop.iq.node.ConstructionNode;
-import it.unibz.inf.ontop.iq.node.DistinctNode;
-import it.unibz.inf.ontop.iq.node.OrderByNode;
-import it.unibz.inf.ontop.iq.node.impl.OrderComparatorImpl;
+import it.unibz.inf.ontop.iq.UnaryIQTree;
+import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeExtendedTransformer;
 import it.unibz.inf.ontop.model.term.NonGroundTerm;
-import it.unibz.inf.ontop.substitution.SubstitutionFactory;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import it.unibz.inf.ontop.utils.VariableGenerator;
 
-import java.util.stream.Collectors;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /*
-Used when an ORDER BY node accesses variables that are defined in a CONSTRUCT above it. Some dialects (like GoogleSQL) do
-not support that, so instead we push the CONSTRUCT down into the ORDER BY.
-Generally, a `AlwaysProjectOrderByTerms` normalizer is expected to be run before calling this normalizer.
+Used when an ORDER BY node accesses expressions that are defined in a CONSTRUCT above it. Some dialects (like GoogleSQL) do
+not support that, so instead we push the CONSTRUCT down into the ORDER BY so the ORDER BY can use the variables defined by
+the CONSTRUCT.
+Generally, an `AlwaysProjectOrderByTerms` normalizer is expected to be run before calling this normalizer.
  */
 public class PushProjectedOrderByTermsNormalizer extends DefaultRecursiveIQTreeExtendedTransformer<VariableGenerator> implements DialectExtraNormalizer {
 
     private IntermediateQueryFactory iqFactory;
-    private final SubstitutionFactory substitutionFactory;
 
     @Inject
-    protected PushProjectedOrderByTermsNormalizer(IntermediateQueryFactory iqFactory, SubstitutionFactory substitutionFactory,
+    protected PushProjectedOrderByTermsNormalizer(IntermediateQueryFactory iqFactory,
                                                   CoreSingletons coreSingletons) {
         super(coreSingletons);
         this.iqFactory = iqFactory;
-        this.substitutionFactory = substitutionFactory;
     }
 
+    @Override
+    public IQTree transform(IQTree tree, VariableGenerator variableGenerator) {
+        return tree.acceptTransformer(this, variableGenerator);
+    }
 
     @Override
-    public IQTree transform(IQTree tree, VariableGenerator context) {
+    public IQTree transformDistinct(IQTree tree, DistinctNode rootNode, IQTree child, VariableGenerator variableGenerator) {
+        var decomposition = ProjectOrderByTermsNormalizer.Decomposition.decomposeTree(tree);
+        if(decomposition.constructionNode.isEmpty() || decomposition.distinctNode.isEmpty() || decomposition.orderByNode.isEmpty()) {
+            var newDescendantTree = transform(decomposition.descendantTree, variableGenerator);
+            return decomposition.descendantTree.equals(newDescendantTree)
+                    ? tree
+                    : decomposition.rebuildWithNewDescendantTree(newDescendantTree, iqFactory);
+        }
+        return normalize(decomposition, variableGenerator);
+    }
 
-        //We only change trees of the form DISTINCT -> CONSTRUCT -> ORDER BY. Make sure our tree has that exact form,
-        //else we return the results of the `AlwaysProjectOrderByTermsNormalizer`
-        if(!(tree.getRootNode() instanceof DistinctNode) || tree.getChildren().size() == 0)
-            return tree;
-        DistinctNode distinct = (DistinctNode) tree.getRootNode();
-        var distinctSubtree = tree.getChildren().get(0);
-
-        if(!(distinctSubtree.getRootNode() instanceof ConstructionNode) || distinctSubtree.getChildren().size() == 0)
-            return tree;
-        ConstructionNode construct = (ConstructionNode) distinctSubtree.getRootNode();
-        var constructSubtree = distinctSubtree.getChildren().get(0);
-
-        if(!(constructSubtree.getRootNode() instanceof OrderByNode) || constructSubtree.getChildren().size() == 0)
-            return tree;
-        OrderByNode orderBy = (OrderByNode) constructSubtree.getRootNode();
-        var orderBySubtree = constructSubtree.getChildren().get(0);
-
-        //DISTINCT, CONSTRUCT, and ORDER BY nodes + their subtrees have been fetched
+    protected IQTree normalize(ProjectOrderByTermsNormalizer.Decomposition decomposition, VariableGenerator context) {
+        var distinct = decomposition.distinctNode.get();
+        var construct = decomposition.constructionNode.get();
+        var orderBy = decomposition.orderByNode.get();
+        var remainingSubtree = transform(decomposition.descendantTree, context);
 
         //Get map of terms used in ORDER BY that are defined in CONSTRUCT
         var orderByTerms = orderBy.getComparators().stream().map(comp -> comp.getTerm()).collect(ImmutableCollectors.toSet());
@@ -74,10 +71,9 @@ public class PushProjectedOrderByTermsNormalizer extends DefaultRecursiveIQTreeE
         ).collect(ImmutableCollectors.toList()));
 
         //Change order from DISTINCT -> CONSTRUCT -> ORDER BY to DISTINCT -> ORDER BY -> CONSTRUCT
-        var newOrderBySubtree = iqFactory.createUnaryIQTree(construct, orderBySubtree);
+        var newOrderBySubtree = iqFactory.createUnaryIQTree(construct, remainingSubtree);
         var newDistinctSubtree = iqFactory.createUnaryIQTree(newOrderBy, newOrderBySubtree);
         var newFullTree = iqFactory.createUnaryIQTree(distinct, newDistinctSubtree);
-
         return newFullTree;
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/BigQuerySelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/BigQuerySelectFromWhereSerializer.java
@@ -1,0 +1,49 @@
+package it.unibz.inf.ontop.generation.serializer.impl;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import it.unibz.inf.ontop.dbschema.DBParameters;
+import it.unibz.inf.ontop.dbschema.RelationID;
+import it.unibz.inf.ontop.generation.algebra.SelectFromWhereWithModifiers;
+import it.unibz.inf.ontop.generation.serializer.SelectFromWhereSerializer;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.type.DBTermType;
+
+@Singleton
+public class BigQuerySelectFromWhereSerializer extends DefaultSelectFromWhereSerializer implements SelectFromWhereSerializer {
+
+    @Inject
+    private BigQuerySelectFromWhereSerializer(TermFactory termFactory) {
+        super(new DefaultSQLTermSerializer(termFactory) {
+            @Override
+            protected String serializeDatetimeConstant(String datetime, DBTermType dbType) {
+                return String.format("TIMESTAMP %s", serializeStringConstant(datetime));
+            }
+        });
+    }
+
+    @Override
+    public QuerySerialization serialize(SelectFromWhereWithModifiers selectFromWhere, DBParameters dbParameters) {
+        return selectFromWhere.acceptVisitor(
+                new DefaultRelationVisitingSerializer(dbParameters.getQuotedIDFactory()) {
+
+                    private static final String VIEW_PREFIX = "r";
+
+                    @Override
+                    protected String serializeLimitOffset(long limit, long offset, boolean noSortCondition) {
+                        return String.format("LIMIT %d OFFSET %d", limit, offset);
+                    }
+
+                    @Override
+                    protected String serializeOffset(long offset, boolean noSortCondition) {
+                        //OFFSET is not available without LIMIT, so we add a very large LIMIT
+                        return String.format("LIMIT 9999999999 OFFSET %d", offset);
+                    }
+
+                    @Override
+                    protected RelationID generateFreshViewAlias() {
+                        return idFactory.createRelationID(VIEW_PREFIX + viewCounter.incrementAndGet());
+                    }
+                });
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/BigQueryDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/BigQueryDBFunctionSymbolFactory.java
@@ -1,0 +1,248 @@
+package it.unibz.inf.ontop.model.term.functionsymbol.db.impl;
+
+import com.google.common.collect.*;
+import com.google.inject.Inject;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.*;
+import it.unibz.inf.ontop.model.type.DBTermType;
+import it.unibz.inf.ontop.model.type.DBTypeFactory;
+import it.unibz.inf.ontop.model.type.TypeFactory;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+public class BigQueryDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFactory {
+
+    private static final String NOT_YET_SUPPORTED_MSG = "Not yet supported for BigQuery";
+
+    private static final String REGEXP_CONTAINS_STR = "REGEXP_CONTAINS";
+    private DBBooleanFunctionSymbol regexpContains;
+
+    @Inject
+    protected BigQueryDBFunctionSymbolFactory(TypeFactory typeFactory) {
+        super(createBigQueryRegularFunctionTable(typeFactory), typeFactory);
+
+        regexpContains = new DefaultSQLSimpleDBBooleanFunctionSymbol(REGEXP_CONTAINS_STR, 2, dbBooleanType,
+                abstractRootDBType);
+    }
+
+    protected static ImmutableTable<String, Integer, DBFunctionSymbol> createBigQueryRegularFunctionTable(
+            TypeFactory typeFactory) {
+        DBTypeFactory dbTypeFactory = typeFactory.getDBTypeFactory();
+        DBTermType abstractRootDBType = dbTypeFactory.getAbstractRootDBType();
+        DBTermType dbBooleanType = dbTypeFactory.getDBBooleanType();
+
+        Table<String, Integer, DBFunctionSymbol> table = HashBasedTable.create(
+                createDefaultRegularFunctionTable(typeFactory));
+
+        table.remove(REGEXP_LIKE_STR, 2);
+        table.remove(REGEXP_LIKE_STR, 3);
+        DBBooleanFunctionSymbol regexpContains = new DefaultSQLSimpleDBBooleanFunctionSymbol(REGEXP_CONTAINS_STR, 2, dbBooleanType,
+                abstractRootDBType);
+        table.put(REGEXP_CONTAINS_STR, 2, regexpContains);
+
+        return ImmutableTable.copyOf(table);
+    }
+
+
+    @Override
+    protected String serializeContains(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return String.format("(STRPOS(%s, %s) > 0)",
+                termConverter.apply(terms.get(0)),
+                termConverter.apply(terms.get(1)));
+    }
+
+    @Override
+    protected String serializeStrBefore(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String str = termConverter.apply(terms.get(0));
+        String before = termConverter.apply(terms.get(1));
+
+        return String.format("CASE STRPOS(%s, %s) WHEN 0 THEN '' ELSE SUBSTRING(%s,1,STRPOS(%s, %s)-1) END", str, before, str, str, before);
+    }
+
+    @Override
+    protected String serializeStrAfter(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String str = termConverter.apply(terms.get(0));
+        String after = termConverter.apply(terms.get(1));
+        return String.format("CASE STRPOS(%s, %s) WHEN 0 THEN '' ELSE SUBSTRING(%s, STRPOS(%s, %s) + LENGTH(%s)) END", str, after, str, str, after, after);
+    }
+
+    @Override
+    protected String serializeMD5(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return serializeHashingFunction("MD5", terms, termConverter, termFactory);
+    }
+
+    @Override
+    protected String serializeSHA1(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return serializeHashingFunction("SHA1", terms, termConverter, termFactory);
+    }
+
+    @Override
+    protected String serializeSHA256(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return serializeHashingFunction("SHA256", terms, termConverter, termFactory);
+    }
+
+    @Override
+    protected String serializeSHA384(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("SHA384: " + NOT_YET_SUPPORTED_MSG);
+    }
+
+    @Override
+    protected String serializeSHA512(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return serializeHashingFunction("SHA512", terms, termConverter, termFactory);
+    }
+
+    private String serializeHashingFunction(String functionName, ImmutableList<? extends ImmutableTerm> terms,
+                                            Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return String.format("TO_HEX(%s(%s))", functionName, termConverter.apply(terms.get(0)));
+
+    }
+
+    @Override
+    protected String serializeTz(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String str = termConverter.apply(terms.get(0));
+        return String.format("(LPAD(EXTRACT(TIMEZONE_HOUR FROM %s)::text,2,'0') || ':' || LPAD(EXTRACT(TIMEZONE_MINUTE FROM %s)::text,2,'0'))", str, str);
+    }
+
+
+
+
+    @Override
+    protected DBConcatFunctionSymbol createNullRejectingDBConcat(int arity) {
+        return createDBConcatOperator(arity);
+    }
+
+    @Override
+    protected DBConcatFunctionSymbol createDBConcatOperator(int arity) {
+        return new NullRejectingDBConcatFunctionSymbol(CONCAT_OP_STR, arity, dbStringType, abstractRootDBType,
+                Serializers.getOperatorSerializer(CONCAT_OP_STR));
+    }
+
+    @Override
+    protected DBConcatFunctionSymbol createRegularDBConcat(int arity) {
+        return new NullToleratingDBConcatFunctionSymbol("CONCAT", arity, dbStringType, abstractRootDBType, false);
+    }
+
+    @Override
+    protected String serializeDateTimeNorm(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return String.format("FORMAT_TIMESTAMP(\"%%Y-%%m-%%dT%%X%%Ez\", %s)", termConverter.apply(terms.get(0)));
+    }
+
+    @Override
+    protected String getUUIDNameInDialect() {
+        return "GENERATE_UUID";
+    }
+
+
+    /**
+     * BigQuery uses 'True/False' for SQL queries, but '1/0' for results, so we need a way to parse these results.
+     */
+    @Override
+    protected DBIsTrueFunctionSymbol createDBIsTrue(DBTermType dbBooleanType) {
+        return new OneDigitDBIsTrueFunctionSymbolImpl(dbBooleanType);
+    }
+
+    /**
+     * BigQuery uses 'True/False' for SQL queries, but '1/0' for results, so we need a way to parse these results.
+     */
+    @Override
+    protected DBTypeConversionFunctionSymbol createBooleanNormFunctionSymbol(DBTermType booleanType) {
+        return new OneDigitBooleanNormFunctionSymbolImpl(booleanType, dbStringType);
+    }
+
+
+    //BigQuery does not support week as a unit for timestamp_diff
+    @Override
+    protected String serializeWeeksBetween(ImmutableList<? extends ImmutableTerm> terms,
+                                           Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("TIMESTAMP_DIFF(week): " + NOT_YET_SUPPORTED_MSG);
+    }
+
+
+    @Override
+    protected String serializeDaysBetween(ImmutableList<? extends ImmutableTerm> terms,
+                                          Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return serializeTimeBetween("day", terms, termConverter, termFactory);
+    }
+
+    @Override
+    protected String serializeHoursBetween(ImmutableList<? extends ImmutableTerm> terms,
+                                           Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return serializeTimeBetween("hour", terms, termConverter, termFactory);
+    }
+
+    @Override
+    protected String serializeMinutesBetween(ImmutableList<? extends ImmutableTerm> terms,
+                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return serializeTimeBetween("minute", terms, termConverter, termFactory);
+    }
+
+    @Override
+    protected String serializeSecondsBetween(ImmutableList<? extends ImmutableTerm> terms,
+                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return serializeTimeBetween("second", terms, termConverter, termFactory);
+    }
+
+    @Override
+    protected String serializeMillisBetween(ImmutableList<? extends ImmutableTerm> terms,
+                                            Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return serializeTimeBetween("millisecond", terms, termConverter, termFactory);
+    }
+
+    private String serializeTimeBetween(String timeUnit, ImmutableList<? extends ImmutableTerm> terms,
+                                        Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return String.format("TIMESTAMP_DIFF(%s, %s, %s)",
+                termConverter.apply(terms.get(0)),
+                termConverter.apply(terms.get(1)),
+                timeUnit);
+    }
+
+    @Override
+    public DBBooleanFunctionSymbol getDBRegexpMatches2() {
+        return this.regexpContains;
+    }
+
+    @Override
+    protected Optional<DBFunctionSymbol> createRoundFunctionSymbol(DBTermType dbTermType) {
+        // TODO: taken from H2SQLDBFunctionSymbolFactory, so same TODO applies
+        return Optional.of(new UnaryDBFunctionSymbolWithSerializerImpl(ROUND_STR, dbTermType, dbTermType, false,
+                (terms, termConverter, termFactory) -> String.format(
+                        "CAST(ROUND(%s) AS %s)", termConverter.apply(terms.get(0)), dbTermType.getCastName())));
+    }
+
+    @Override
+    protected Optional<DBFunctionSymbol> createFloorFunctionSymbol(DBTermType dbTermType) {
+        // TODO: taken from H2SQLDBFunctionSymbolFactory, so same TODO applies
+        return Optional.of(new UnaryDBFunctionSymbolWithSerializerImpl(FLOOR_STR, dbTermType, dbTermType, false,
+                (terms, termConverter, termFactory) -> String.format(
+                        "CAST(FLOOR(%s) AS %s)", termConverter.apply(terms.get(0)), dbTermType.getCastName())));
+    }
+
+    @Override
+    protected Optional<DBFunctionSymbol> createCeilFunctionSymbol(DBTermType dbTermType) {
+        // TODO: taken from H2SQLDBFunctionSymbolFactory, so same TODO applies
+        return Optional.of(new UnaryDBFunctionSymbolWithSerializerImpl(CEIL_STR, dbTermType, dbTermType, false,
+                (terms, termConverter, termFactory) -> String.format(
+                        "CAST(CEIL(%s) AS %s)", termConverter.apply(terms.get(0)), dbTermType.getCastName())));
+    }
+
+    @Override
+    protected DBFunctionSymbol createDBGroupConcat(DBTermType dbStringType, boolean isDistinct) {
+        return new NullIgnoringDBGroupConcatFunctionSymbol(dbStringType, isDistinct,
+                (terms, termConverter, termFactory) -> String.format(
+                        "STRING_AGG(%s%s,%s ORDER BY %s)",
+                        isDistinct ? "DISTINCT " : "",
+                        termConverter.apply(terms.get(0)),
+                        termConverter.apply(terms.get(1)),
+                        termConverter.apply(terms.get(0))
+                ));
+    }
+
+    @Override
+    protected DBFunctionSymbol createEncodeURLorIRI(boolean preserveInternationalChars) {
+        return new BigQuerySQLEncodeURLorIRIFunctionSymbolImpl(dbStringType, preserveInternationalChars);
+    }
+
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/BigQuerySQLEncodeURLorIRIFunctionSymbolImpl.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/BigQuerySQLEncodeURLorIRIFunctionSymbolImpl.java
@@ -1,0 +1,27 @@
+package it.unibz.inf.ontop.model.term.functionsymbol.db.impl;
+
+import com.google.common.collect.ImmutableMap;
+import it.unibz.inf.ontop.model.type.DBTermType;
+import it.unibz.inf.ontop.utils.StringUtils;
+
+/*
+ * Backslash character is an escape symbol in SparkSQL dialect. Replace '\' --> '\\' to avoid malformed queries
+ */
+public class BigQuerySQLEncodeURLorIRIFunctionSymbolImpl extends DefaultSQLEncodeURLorIRIFunctionSymbol {
+
+    protected BigQuerySQLEncodeURLorIRIFunctionSymbolImpl(DBTermType dbStringType, boolean preserveInternationalChars) {
+        super(dbStringType, preserveInternationalChars);
+    }
+
+    private static final ImmutableMap<Character, String> BACKSLASH = ImmutableMap.of('\\', "\\\\");
+
+    @Override
+    protected String getEscapedSingleQuote() {
+        return "\\\\'";
+    }
+
+    @Override
+    protected String encodeSQLStringConstant(String constant) {
+        return super.encodeSQLStringConstant(StringUtils.encode(constant, BACKSLASH));
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/TrinoDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/TrinoDBFunctionSymbolFactory.java
@@ -24,7 +24,7 @@ public class TrinoDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
 
     private static final String RANDOM_STR = "RANDOM";
     private static final String UUID_STRING_STR = "UUID";
-    private static final String NOT_YET_SUPPORTED_MSG = "Not yet supported for Denodo";
+    private static final String NOT_YET_SUPPORTED_MSG = "Not yet supported for Trino";
 
     private DBFunctionSymbol dbRight;
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/BigQueryDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/BigQueryDBTypeFactory.java
@@ -1,0 +1,118 @@
+package it.unibz.inf.ontop.model.type.impl;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
+import it.unibz.inf.ontop.model.type.*;
+import it.unibz.inf.ontop.model.vocabulary.XSD;
+
+import java.util.Map;
+
+import static it.unibz.inf.ontop.model.type.DBTermType.Category.*;
+import static it.unibz.inf.ontop.model.type.impl.NonStringNonNumberNonBooleanNonDatetimeDBTermType.StrictEqSupport.NOTHING;
+import static it.unibz.inf.ontop.model.type.impl.NonStringNonNumberNonBooleanNonDatetimeDBTermType.StrictEqSupport.SAME_TYPE_NO_CONSTANT;
+
+public class BigQueryDBTypeFactory extends DefaultSQLDBTypeFactory {
+    private static final String INT64_STR = "INT64";
+    private static final String FLOAT64_STR = "FLOAT64";
+    private static final String STRING_STR = "STRING";
+
+    protected static final String GEOGRAPHY_STR = "GEOGRAPHY";
+    protected static final String JSON_STR = "JSON";
+    protected static final String BYTES_STR = "BYTES";
+
+    protected BigQueryDBTypeFactory(Map<String, DBTermType> typeMap, ImmutableMap<DefaultTypeCode, String> defaultTypeCodeMap) {
+        super(typeMap, defaultTypeCodeMap);
+    }
+    @AssistedInject
+    protected BigQueryDBTypeFactory(@Assisted TermType rootTermType, @Assisted TypeFactory typeFactory) {
+        super(createBigQueryTypeMap(rootTermType, typeFactory), createBigQueryCodeMap());
+    }
+
+    protected static Map<String, DBTermType> createBigQueryTypeMap(TermType rootTermType, TypeFactory typeFactory) {
+        TermTypeAncestry rootAncestry = rootTermType.getAncestry();
+        RDFDatatype xsdInteger = typeFactory.getXsdIntegerDatatype();
+        RDFDatatype xsdDouble = typeFactory.getXsdDoubleDatatype();
+        RDFDatatype xsdString = typeFactory.getXsdStringDatatype();
+        RDFDatatype xsdBoolean = typeFactory.getXsdBooleanDatatype();
+        RDFDatatype hexBinary = typeFactory.getDatatype(XSD.HEXBINARY);
+
+        Map<String, DBTermType> map = createDefaultSQLTypeMap(rootTermType, typeFactory);
+
+        DBTermType dateType = new DateDBTermType(DATE_STR, rootAncestry,
+                typeFactory.getDatatype(XSD.DATE));
+
+        NumberDBTermType int64Type = new NumberDBTermType(INT64_STR, rootAncestry,
+                xsdInteger, INTEGER);
+
+        NumberDBTermType float64Type = new NumberDBTermType(FLOAT64_STR, rootAncestry,
+                xsdDouble, FLOAT_DOUBLE);
+
+        StringDBTermType stringType = new StringDBTermType(STRING_STR, rootAncestry, xsdString);
+
+        NonStringNonNumberNonBooleanNonDatetimeDBTermType bytesType = new NonStringNonNumberNonBooleanNonDatetimeDBTermType(BYTES_STR, rootAncestry, hexBinary);
+                
+        /*  TODO-SCAFFOLD: Add to or modify the type map:
+         *-------------------------------------------------------------------
+         *      map.put("TYPE_NAME", DBTermType);
+         */
+
+        map.put(DATE_STR, dateType);
+        map.put(INT64_STR, int64Type);
+        map.put(FLOAT64_STR, float64Type);
+        map.put(STRING_STR, stringType);
+        map.put(BYTES_STR, bytesType);
+
+        map.put(GEOGRAPHY_STR, new NonStringNonNumberNonBooleanNonDatetimeDBTermType(GEOGRAPHY_STR, rootAncestry, xsdString));
+        map.put(JSON_STR, new JsonDBTermTypeImpl(JSON_STR, rootAncestry));
+
+        map.remove(DOUBLE_PREC_STR);
+        map.remove(VARCHAR_STR);
+        map.remove(NVARCHAR_STR);
+        map.remove(BINARY_LARGE_STR);
+        map.remove(BINARY_STR);
+        map.remove(BINARY_VAR_STR);
+
+        return map;
+    }
+
+    protected static ImmutableMap<DefaultTypeCode, String> createBigQueryCodeMap() {
+        Map<DefaultTypeCode, String> map = createDefaultSQLCodeMap();
+        map.put(DefaultTypeCode.DOUBLE, FLOAT64_STR);
+        map.put(DefaultTypeCode.STRING, STRING_STR);
+        map.put(DefaultTypeCode.GEOGRAPHY, GEOGRAPHY_STR);
+        map.put(DefaultTypeCode.JSON, JSON_STR);
+        map.put(DefaultTypeCode.HEXBINARY, BYTES_STR);
+
+        return ImmutableMap.copyOf(map);
+    }
+
+
+
+
+    @Override
+    public boolean supportsDBGeometryType() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsDBGeographyType() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsDBDistanceSphere() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsJson() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsArrayType() {
+        return true;
+    }
+
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/BigQueryDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/BigQueryDBTypeFactory.java
@@ -52,11 +52,6 @@ public class BigQueryDBTypeFactory extends DefaultSQLDBTypeFactory {
 
         NonStringNonNumberNonBooleanNonDatetimeDBTermType bytesType = new NonStringNonNumberNonBooleanNonDatetimeDBTermType(BYTES_STR, rootAncestry, hexBinary);
                 
-        /*  TODO-SCAFFOLD: Add to or modify the type map:
-         *-------------------------------------------------------------------
-         *      map.put("TYPE_NAME", DBTermType);
-         */
-
         map.put(DATE_STR, dateType);
         map.put(INT64_STR, int64Type);
         map.put(FLOAT64_STR, float64Type);

--- a/db/rdb/src/main/resources/it/unibz/inf/ontop/injection/sql-default.properties
+++ b/db/rdb/src/main/resources/it/unibz/inf/ontop/injection/sql-default.properties
@@ -168,6 +168,12 @@ org.duckdb.DuckDBDriver-symbolFactory = it.unibz.inf.ontop.model.term.functionsy
 org.duckdb.DuckDBDriver-typeFactory = it.unibz.inf.ontop.model.type.impl.DuckDBDBTypeFactory
 org.duckdb.DuckDBDriver-serializer = it.unibz.inf.ontop.generation.serializer.impl.DuckDBSelectFromWhereSerializer
 org.duckdb.DuckDBDriver-metadataProvider = it.unibz.inf.ontop.dbschema.impl.DuckDBDBMetadataProvider
+#BigQuery
+com.simba.googlebigquery.jdbc.Driver-symbolFactory = it.unibz.inf.ontop.model.term.functionsymbol.db.impl.BigQueryDBFunctionSymbolFactory
+com.simba.googlebigquery.jdbc.Driver-typeFactory = it.unibz.inf.ontop.model.type.impl.BigQueryDBTypeFactory
+com.simba.googlebigquery.jdbc.Driver-serializer = it.unibz.inf.ontop.generation.serializer.impl.BigQuerySelectFromWhereSerializer
+com.simba.googlebigquery.jdbc.Driver-metadataProvider = it.unibz.inf.ontop.dbschema.impl.BigQueryDBMetadataProvider
+com.simba.googlebigquery.jdbc.Driver-normalizer =  it.unibz.inf.ontop.generation.normalization.impl.BigQueryExtraNormalizer
 
 
 # Default factories

--- a/test/lightweight-tests/lightweight-db-test-images/bigquery/sql/books.sql
+++ b/test/lightweight-tests/lightweight-db-test-images/bigquery/sql/books.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS books.books;
+CREATE TABLE books.books (
+    id integer NOT NULL,
+    title STRING(100),
+    price integer,
+    discount NUMERIC,
+    description STRING(100),
+    lang STRING(100),
+    publication_date timestamp
+) as SELECT * from (
+  (select 1, 'SPARQL Tutorial', 43, NUMERIC '0.2', 'good', 'en', TIMESTAMP '2014-06-05 16:47:52') UNION ALL
+  (select 2, 'The Semantic Web', 23, NUMERIC '0.25', 'bad', 'en', TIMESTAMP '2011-12-08 11:30:00') UNION ALL
+  (select 3, 'Crime and Punishment', 34, NUMERIC '0.2', 'good', 'en', TIMESTAMP '2015-09-21 09:23:06') UNION ALL
+  (select 4, 'The Logic Book: Introduction, Second Edition', 10, NUMERIC '0.15', 'good', 'en', TIMESTAMP '1970-11-05 07:50:00')
+);

--- a/test/lightweight-tests/lightweight-db-test-images/bigquery/sql/university.sql
+++ b/test/lightweight-tests/lightweight-db-test-images/bigquery/sql/university.sql
@@ -1,0 +1,42 @@
+DROP TABLE IF EXISTS university.professors;
+DROP TABLE IF EXISTS university.course;
+DROP TABLE IF EXISTS university.teaching;
+
+CREATE TABLE university.professors (
+    prof_id int not null,
+	first_name string(100) NOT NULL,
+	last_name string(100) NOT NULL,
+    nickname string(100)
+) AS SELECT * FROM (
+    (SELECT 1, 'Roger', 'Smith', 'Rog') UNION ALL
+    (SELECT 2, 'Frank', 'Pitt', 'Frankie') UNION ALL
+    (SELECT 3, 'John', 'Depp', 'Johnny') UNION ALL
+    (SELECT 4, 'Michael', 'Jackson', 'King of Pop') UNION ALL
+    (SELECT 5, 'Diego', 'Gamper', null) UNION ALL
+    (SELECT 6, 'Johann', 'Helmer', null) UNION ALL
+    (SELECT 7, 'Barbara', 'Dodero', null) UNION ALL
+    (SELECT 8, 'Mary', 'Poppins', null)
+);
+
+CREATE TABLE university.course (
+	course_id STRING(100) NOT NULL,
+	nb_students int NOT NULL,
+	duration numeric NOT NULL
+) AS SELECT * FROM (
+    (SELECT 'LinearAlgebra', 10, NUMERIC '24.5') UNION ALL
+    (SELECT 'DiscreteMathematics', 11, NUMERIC '30') UNION ALL
+    (SELECT 'AdvancedDatabases', 12, NUMERIC '20') UNION ALL
+    (SELECT 'ScientificWriting', 13, NUMERIC '18') UNION ALL
+    (SELECT 'OperatingSystems', 10, NUMERIC '30')
+);
+
+CREATE TABLE university.teaching (
+	course_id STRING(100) NOT NULL,
+	prof_id int NOT NULL,
+) AS SELECT * FROM (
+    (SELECT 'LinearAlgebra', 1) UNION ALL
+    (SELECT 'DiscreteMathematics', 1) UNION ALL
+    (SELECT 'AdvancedDatabases', 3) UNION ALL
+    (SELECT 'ScientificWriting', 8) UNION ALL
+    (SELECT 'OperatingSystems', 1)
+);

--- a/test/lightweight-tests/pom.xml
+++ b/test/lightweight-tests/pom.xml
@@ -547,6 +547,11 @@
             <version>1.12.251</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-bigquery</artifactId>
+            <version>2.23.0</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/test/lightweight-tests/pom.xml
+++ b/test/lightweight-tests/pom.xml
@@ -551,6 +551,7 @@
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquery</artifactId>
             <version>2.23.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/test/lightweight-tests/pom.xml
+++ b/test/lightweight-tests/pom.xml
@@ -547,12 +547,6 @@
             <version>1.12.251</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-bigquery</artifactId>
-            <version>2.23.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <repositories>

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/AbstractBindTestWithFunctions.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/AbstractBindTestWithFunctions.java
@@ -1354,7 +1354,7 @@ public abstract class AbstractBindTestWithFunctions extends AbstractDockerRDF4JT
                 + "   BIND (ofn:secondsBetween(?start, ?year) AS ?v)\n"
                 + "}";
 
-        executeAndCompareValues(query, ImmutableList.of("\"1492154272\"^^xsd:long", "\"1413511200\"^^xsd:long",
+        executeAndCompareValues(query, ImmutableSet.of("\"1492154272\"^^xsd:long", "\"1413511200\"^^xsd:long",
                 "\"1532994786\"^^xsd:long", "\"116806800\"^^xsd:long"));
     }
 

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/AbstractLeftJoinProfTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/AbstractLeftJoinProfTest.java
@@ -14,7 +14,6 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
     protected static final String OWL_FILE = "/prof/prof.owl";
     protected static final String OBDA_FILE = "/prof/prof.obda";
 
-
     @Test
     public void testMinusNickname() {
 
@@ -31,7 +30,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(ontopSQLtranslation.toUpperCase().contains("LEFT"), LEFT_JOIN_NOT_OPTIMIZED_MSG);
+        Assertions.assertFalse(supportsIntegrityConstraints() && ontopSQLtranslation.toUpperCase().contains("LEFT"), LEFT_JOIN_NOT_OPTIMIZED_MSG);
         executeAndCompareValues(query, ImmutableList.of("\"Barbara\"^^xsd:string", "\"Diego\"^^xsd:string",
                 "\"Johann\"^^xsd:string", "\"Mary\"^^xsd:string"));
     }
@@ -54,7 +53,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(ontopSQLtranslation.toUpperCase().contains("LEFT"), LEFT_JOIN_NOT_OPTIMIZED_MSG);
+        Assertions.assertFalse(supportsIntegrityConstraints() && ontopSQLtranslation.toUpperCase().contains("LEFT"), LEFT_JOIN_NOT_OPTIMIZED_MSG);
         executeAndCompareValues(query, ImmutableList.of("\"Barbara\"^^xsd:string", "\"Johann\"^^xsd:string",
                 "\"Mary\"^^xsd:string"));
     }
@@ -92,9 +91,9 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(containsMoreThanOneOccurrence(ontopSQLtranslation, "\"professors\""),
+        Assertions.assertFalse(supportsIntegrityConstraints() && containsMoreThanOneOccurrence(ontopSQLtranslation, "\"professors\""),
                 NO_SELF_LJ_OPTIMIZATION_MSG);
-        Assertions.assertFalse(containsMoreThanOneOccurrence(ontopSQLtranslation, "\"PROFESSORS\""),
+        Assertions.assertFalse(supportsIntegrityConstraints() && containsMoreThanOneOccurrence(ontopSQLtranslation, "\"PROFESSORS\""),
                 NO_SELF_LJ_OPTIMIZATION_MSG);
         executeAndCompareValues(query, ImmutableSet.of("\"Roger\"^^xsd:string", "\"Frank\"^^xsd:string",
                 "\"John\"^^xsd:string", "\"Michael\"^^xsd:string", "\"Diego\"^^xsd:string", "\"Johann\"^^xsd:string",
@@ -119,7 +118,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(ontopSQLtranslation.toUpperCase().contains("LEFT"), LEFT_JOIN_NOT_OPTIMIZED_MSG);
+        Assertions.assertFalse(supportsIntegrityConstraints() && ontopSQLtranslation.toUpperCase().contains("LEFT"), LEFT_JOIN_NOT_OPTIMIZED_MSG);
         executeAndCompareValues(query, ImmutableList.of("\"Johnny\"^^xsd:string", "\"Rog\"^^xsd:string"));
     }
 
@@ -139,9 +138,9 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(containsMoreThanOneOccurrence(ontopSQLtranslation, "\"professors\""),
+        Assertions.assertFalse(supportsIntegrityConstraints() && containsMoreThanOneOccurrence(ontopSQLtranslation, "\"professors\""),
                 NO_SELF_LJ_OPTIMIZATION_MSG);
-        Assertions.assertFalse(containsMoreThanOneOccurrence(ontopSQLtranslation, "\"PROFESSORS\""),
+        Assertions.assertFalse(supportsIntegrityConstraints() && containsMoreThanOneOccurrence(ontopSQLtranslation, "\"PROFESSORS\""),
                 NO_SELF_LJ_OPTIMIZATION_MSG);
         executeAndCompareValues(query, ImmutableSet.of("\"Roger\"^^xsd:string", "\"Frank\"^^xsd:string",
                 "\"John\"^^xsd:string", "\"Michael\"^^xsd:string", "\"Diego\"^^xsd:string", "\"Johann\"^^xsd:string",
@@ -166,9 +165,9 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(containsMoreThanOneOccurrence(ontopSQLtranslation, "\"professors\""),
+        Assertions.assertFalse(supportsIntegrityConstraints() && containsMoreThanOneOccurrence(ontopSQLtranslation, "\"professors\""),
                 NO_SELF_LJ_OPTIMIZATION_MSG);
-        Assertions.assertFalse(containsMoreThanOneOccurrence(ontopSQLtranslation, "\"PROFESSORS\""),
+        Assertions.assertFalse(supportsIntegrityConstraints() && containsMoreThanOneOccurrence(ontopSQLtranslation, "\"PROFESSORS\""),
                 NO_SELF_LJ_OPTIMIZATION_MSG);
         executeAndCompareValues(query, ImmutableSet.of("\"Roger\"^^xsd:string", "\"Frank\"^^xsd:string",
                 "\"John\"^^xsd:string", "\"Michael\"^^xsd:string", "\"Diego\"^^xsd:string", "\"Johann\"^^xsd:string",
@@ -191,7 +190,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(ontopSQLtranslation.toUpperCase().contains("LEFT"));
+        Assertions.assertFalse(supportsIntegrityConstraints() && ontopSQLtranslation.toUpperCase().contains("LEFT"));
         executeAndCompareValues(query, ImmutableSet.of("\"Roger\"^^xsd:string", "\"Frank\"^^xsd:string",
                 "\"John\"^^xsd:string", "\"Michael\"^^xsd:string"));
     }
@@ -211,7 +210,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(containsMoreThanOneOccurrence(ontopSQLtranslation.toLowerCase(), "\"professors\""),
+        Assertions.assertFalse(supportsIntegrityConstraints() && containsMoreThanOneOccurrence(ontopSQLtranslation.toLowerCase(), "\"professors\""),
                 NO_SELF_LJ_OPTIMIZATION_MSG);
         executeAndCompareValues(query, ImmutableSet.of("\"Rog\"^^xsd:string", "\"Frankie\"^^xsd:string",
                 "\"Johnny\"^^xsd:string", "\"King of Pop\"^^xsd:string"));
@@ -235,7 +234,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(containsMoreThanOneOccurrence(ontopSQLtranslation.toLowerCase(), "\"professors\""),
+        Assertions.assertFalse(supportsIntegrityConstraints() && containsMoreThanOneOccurrence(ontopSQLtranslation.toLowerCase(), "\"professors\""),
                 NO_SELF_LJ_OPTIMIZATION_MSG);
         executeAndCompareValues(query, getExpectedValuesNicknameAndCourse());
     }
@@ -261,7 +260,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(ontopSQLtranslation.toUpperCase().contains("LEFT"));
+        Assertions.assertFalse(supportsIntegrityConstraints() && ontopSQLtranslation.toUpperCase().contains("LEFT"));
         executeAndCompareValues(query, ImmutableList.of("\"Smith\"^^xsd:string", "\"Poppins\"^^xsd:string",
                 "\"Depp\"^^xsd:string"));
     }
@@ -284,7 +283,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(ontopSQLtranslation.toUpperCase().contains("LEFT"));
+        Assertions.assertFalse(supportsIntegrityConstraints() && ontopSQLtranslation.toUpperCase().contains("LEFT"));
         executeAndCompareValues(query, ImmutableList.of("\"Smith\"^^xsd:string", "\"Poppins\"^^xsd:string",
                 "\"Depp\"^^xsd:string"));
     }
@@ -306,7 +305,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(ontopSQLtranslation.toUpperCase().contains("LEFT"));
+        Assertions.assertFalse(supportsIntegrityConstraints() && ontopSQLtranslation.toUpperCase().contains("LEFT"));
         executeAndCompareValues(query, ImmutableList.of("\"John\"^^xsd:string", "\"Mary\"^^xsd:string",
                 "\"Roger\"^^xsd:string"));
     }
@@ -349,7 +348,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(ontopSQLtranslation.toUpperCase().contains("LEFT"));
+        Assertions.assertFalse(supportsIntegrityConstraints() && ontopSQLtranslation.toUpperCase().contains("LEFT"));
         executeAndCompareValues(query, ImmutableList.of("\"Dodero\"^^xsd:string", "\"Frankie\"^^xsd:string",
                 "\"Gamper\"^^xsd:string", "\"Helmer\"^^xsd:string", "\"Johnny\"^^xsd:string",
                 "\"King of Pop\"^^xsd:string", "\"Poppins\"^^xsd:string", "\"Rog\"^^xsd:string"));
@@ -374,7 +373,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(ontopSQLtranslation.toUpperCase().contains("LEFT"));
+        Assertions.assertFalse(supportsIntegrityConstraints() && ontopSQLtranslation.toUpperCase().contains("LEFT"));
         executeAndCompareValues(query, ImmutableList.of("\"Depp\"^^xsd:string", "\"Dodero\"^^xsd:string",
                 "\"Gamper\"^^xsd:string", "\"Helmer\"^^xsd:string", "\"Jackson\"^^xsd:string", "\"Pitt\"^^xsd:string",
                 "\"Poppins\"^^xsd:string", "\"Smith\"^^xsd:string"));
@@ -398,7 +397,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(ontopSQLtranslation.toUpperCase().contains("LEFT"));
+        Assertions.assertFalse(supportsIntegrityConstraints() && ontopSQLtranslation.toUpperCase().contains("LEFT"));
         executeAndCompareValues(query, ImmutableList.of("\"Depp\"^^xsd:string", "\"Poppins\"^^xsd:string",
                 "\"Smith\"^^xsd:string"));
     }
@@ -421,7 +420,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertFalse(ontopSQLtranslation.toUpperCase().contains("LEFT"));
+        Assertions.assertFalse(supportsIntegrityConstraints() && ontopSQLtranslation.toUpperCase().contains("LEFT"));
         executeAndCompareValues(query, ImmutableList.of("\"Depp\"^^xsd:string", "\"Poppins\"^^xsd:string",
                 "\"Smith\"^^xsd:string"));
     }
@@ -1106,7 +1105,7 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
 
         String ontopSQLtranslation = reformulate(query);
 
-        Assertions.assertTrue(ontopSQLtranslation.toUpperCase().contains("LEFT"));
+        Assertions.assertTrue(!supportsIntegrityConstraints() || ontopSQLtranslation.toUpperCase().contains("LEFT"));
         executeAndCompareValues(query, getExpectedValuesNonOptimizableLJAndJoinMix());
     }
 
@@ -1155,6 +1154,10 @@ public abstract class AbstractLeftJoinProfTest extends AbstractDockerRDF4JTest {
             return query.substring(firstOccurrenceIndex + 1).contains(pattern);
         }
         return false;
+    }
+
+    protected boolean supportsIntegrityConstraints() {
+        return true;
     }
 
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/BigQueryLightweightTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/BigQueryLightweightTest.java
@@ -1,0 +1,18 @@
+package it.unibz.inf.ontop.docker.lightweight;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+@Target({ TYPE, METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("bigquerylighttests")
+@Test
+public @interface BigQueryLightweightTest {
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/BindWithFunctionsBigQueryTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/BindWithFunctionsBigQueryTest.java
@@ -1,0 +1,172 @@
+package it.unibz.inf.ontop.docker.lightweight.bigquery;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractBindTestWithFunctions;
+import it.unibz.inf.ontop.docker.lightweight.BigQueryLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+/**
+ * Class to test if functions on Strings and Numerics in SPARQL are working properly.
+ *
+ */
+@BigQueryLightweightTest
+public class BindWithFunctionsBigQueryTest extends AbstractBindTestWithFunctions {
+
+    private static final String PROPERTIES_FILE = "/books/bigquery/books-bigquery.properties";
+    private static final String OBDA_FILE = "/books/bigquery/books-bigquery.obda";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Disabled("BigQuery does not support SHA384.")
+    @Test
+    @Override
+    public void testHashSHA384() {
+        super.testHashSHA384();
+    }
+
+    @Disabled("BigQuery does not support week-based timestamp diffs.")
+    @Test
+    @Override
+    public void testWeeksBetweenDate() {
+        super.testWeeksBetweenDate();
+    }
+
+    @Disabled("BigQuery does not support week-based timestamp diffs.")
+    @Test
+    @Override
+    public void testWeeksBetweenDateTime() {
+        super.testWeeksBetweenDateTime();
+    }
+
+    @Override
+    protected ImmutableSet<String> getAbsExpectedValues() {
+        return ImmutableSet.of("\"8.600000000\"^^xsd:decimal", "\"5.750000000\"^^xsd:decimal", "\"6.800000000\"^^xsd:decimal",
+                "\"1.500000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableList<String> getConstantIntegerDivideExpectedResults() {
+        return ImmutableList.of("\"0.500000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getDivideExpectedValues() {
+        return ImmutableSet.of("\"21.500000000\"^^xsd:decimal", "\"11.500000000\"^^xsd:decimal",
+                "\"17.000000000\"^^xsd:decimal", "\"5.000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableList<String> getFloorExpectedValues() {
+        return ImmutableList.of("\"0.000000000\"^^xsd:decimal", "\"0.000000000\"^^xsd:decimal", "\"0.000000000\"^^xsd:decimal", "\"0.000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getDatatypeExpectedValues() {
+        return ImmutableMultiset.of("\"0.200000000\"^^xsd:decimal", "\"0.250000000\"^^xsd:decimal", "\"0.200000000\"^^xsd:decimal",
+                "\"0.150000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableList<String> getCeilExpectedValues() {
+        return ImmutableList.of("\"1.000000000\"^^xsd:decimal", "\"1.000000000\"^^xsd:decimal", "\"1.000000000\"^^xsd:decimal", "\"1.000000000\"^^xsd:decimal");
+    }
+
+
+    @Test
+    public void testIn1() {
+
+        String query = "PREFIX  ns:  <http://example.org/ns#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  \n"
+                + "   ?x ns:discount ?v .\n"
+                + "   VALUES (?w) { \n"
+                + "         (\"0.15\"^^xsd:decimal) \n"
+                + "         (\"0.25\"^^xsd:decimal) } \n"
+                + "   FILTER(?v IN (?w)) \n"
+                + "   } ORDER BY ?v";
+
+        executeAndCompareValues(query, ImmutableList.of("\"0.150000000\"^^xsd:decimal",
+                "\"0.250000000\"^^xsd:decimal"));
+    }
+
+    @Test
+    public void testIn2() {
+
+        String query = "PREFIX  ns:  <http://example.org/ns#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  \n"
+                + "   ?x ns:discount ?v .\n"
+                + "   FILTER(?v IN (\"0.15\"^^xsd:decimal, \n"
+                + "                     \"0.25\"^^xsd:decimal)) \n"
+                + "   } ORDER BY ?v";
+
+        executeAndCompareValues(query, ImmutableList.of("\"0.150000000\"^^xsd:decimal",
+                "\"0.250000000\"^^xsd:decimal"));
+    }
+
+    @Test
+    public void testNotIn1() {
+
+        String query = "PREFIX  ns:  <http://example.org/ns#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  \n"
+                + "   ?x ns:discount ?v .\n"
+                + "   VALUES (?w) { \n"
+                + "         (\"0.20\"^^xsd:decimal) } \n"
+                + "   FILTER(?v NOT IN (?w)) \n"
+                + "   } ORDER BY ?v";
+
+        executeAndCompareValues(query, ImmutableList.of( "\"0.150000000\"^^xsd:decimal", "\"0.250000000\"^^xsd:decimal"));
+    }
+
+    @Test
+    public void testNotIn2() {
+
+        String query = "PREFIX  ns:  <http://example.org/ns#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  \n"
+                + "   ?x ns:discount ?v .\n"
+                + "   FILTER(?v NOT IN (\"0.20\"^^xsd:decimal)) \n"
+                + "   } ORDER BY ?v";
+
+        executeAndCompareValues(query, ImmutableList.of("\"0.150000000\"^^xsd:decimal", "\"0.250000000\"^^xsd:decimal"));
+    }
+
+    @Override
+    protected ImmutableList<String> getStrExpectedValues() {
+        return ImmutableList.of("\"1970-11-05T07:50:00+00:00\"^^xsd:string",
+                "\"2011-12-08T11:30:00+00:00\"^^xsd:string",
+                "\"2014-06-05T16:47:52+00:00\"^^xsd:string",
+                "\"2015-09-21T09:23:06+00:00\"^^xsd:string");
+    }
+
+    @Override
+    protected ImmutableSet<String> getRoundExpectedValues() {
+        //Round leaves entries in same data type, so discount of type DECIMAL remains decimal with 18 digits in the
+        //fractional part
+        return ImmutableSet.of("\"0.000000000, 43\"^^xsd:string", "\"0.000000000, 23\"^^xsd:string", "\"0.000000000, 34\"^^xsd:string",
+                "\"0.000000000, 10\"^^xsd:string");
+    }
+
+    @Disabled("Argument have incorrect types, causing a problem.")
+    @Override
+    public void testDaysBetweenDateMappingInput() {
+        super.testDaysBetweenDateMappingInput();
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/ConstraintBigQueryTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/ConstraintBigQueryTest.java
@@ -1,0 +1,22 @@
+package it.unibz.inf.ontop.docker.lightweight.bigquery;
+
+import it.unibz.inf.ontop.dbschema.RelationID;
+import it.unibz.inf.ontop.docker.lightweight.AbstractConstraintTest;
+import it.unibz.inf.ontop.docker.lightweight.BigQueryLightweightTest;
+import it.unibz.inf.ontop.exception.MetadataExtractionException;
+import org.junit.jupiter.api.Disabled;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@Disabled("BigQuery does not support integrity constraints")
+@BigQueryLightweightTest
+public class ConstraintBigQueryTest extends AbstractConstraintTest {
+
+    private static final String PROPERTIES_FILE = "/dbconstraints/dbconstraints-bigquery.properties";
+
+    public ConstraintBigQueryTest(String method) {
+        super(method, PROPERTIES_FILE);
+    }
+
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/DistinctInAggregateBigQueryTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/DistinctInAggregateBigQueryTest.java
@@ -1,0 +1,49 @@
+package it.unibz.inf.ontop.docker.lightweight.bigquery;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractDistinctInAggregateTest;
+import it.unibz.inf.ontop.docker.lightweight.BigQueryLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@BigQueryLightweightTest
+public class DistinctInAggregateBigQueryTest extends AbstractDistinctInAggregateTest {
+
+    private static final String PROPERTIES_FILE = "/university/university-bigquery.properties";
+    protected static final String OBDA_FILE = "/university/university-athena.obda";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Override
+    protected ImmutableSet<ImmutableMap<String, String>> getTuplesForAvg() {
+        return ImmutableSet.of(
+                ImmutableMap.of(
+                        "p",buildAnswerIRI("1"),
+                        "ad", "\"10.5\"^^xsd:decimal"
+                ),
+                ImmutableMap.of(
+                        "p",buildAnswerIRI("3"),
+                        "ad", "\"12.0\"^^xsd:decimal"
+                ),
+                ImmutableMap.of(
+                        "p",buildAnswerIRI("8"),
+                        "ad", "\"13.0\"^^xsd:decimal"
+                )
+        );
+    }
+
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/LeftJoinProfBigQueryTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/LeftJoinProfBigQueryTest.java
@@ -54,18 +54,4 @@ public class LeftJoinProfBigQueryTest extends AbstractLeftJoinProfTest {
     protected boolean supportsIntegrityConstraints() {
         return false;
     }
-
-    @Disabled("Currently disabled because this test causes an issue in the translation of the query (Only DBFunctionSymbols must be provided to a SQLTermSerializer)")
-    @Test
-    @Override
-    public void testMinusMultitypedSum() {
-        super.testMinusMultitypedSum();
-    }
-
-    @Disabled("Currently disabled because this test causes an issue in the translation of the query (Only DBFunctionSymbols must be provided to a SQLTermSerializer)")
-    @Test
-    @Override
-    public void testMinusMultitypedAvg() {
-        super.testMinusMultitypedAvg();
-    }
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/LeftJoinProfBigQueryTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/LeftJoinProfBigQueryTest.java
@@ -1,0 +1,71 @@
+package it.unibz.inf.ontop.docker.lightweight.bigquery;
+
+import com.google.common.collect.ImmutableList;
+import it.unibz.inf.ontop.docker.lightweight.AbstractLeftJoinProfTest;
+import it.unibz.inf.ontop.docker.lightweight.BigQueryLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@BigQueryLightweightTest
+public class LeftJoinProfBigQueryTest extends AbstractLeftJoinProfTest {
+
+    private static final String PROPERTIES_FILE = "/prof/bigquery/prof-bigquery.properties";
+    private static final String OBDA_FILE = "/prof/bigquery/prof-bigquery.obda";
+
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Override
+    protected ImmutableList<String> getExpectedValuesAvgStudents2() {
+        return ImmutableList.of("\"10.333333333333334\"^^xsd:decimal","\"12.0\"^^xsd:decimal", "\"13.0\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableList<String> getExpectedValuesAvgStudents3() {
+        return ImmutableList.of("\"0\"^^xsd:integer", "\"0\"^^xsd:integer", "\"0\"^^xsd:integer", "\"0\"^^xsd:integer",
+                "\"0\"^^xsd:integer", "\"10.333333333333334\"^^xsd:decimal", "\"12.0\"^^xsd:decimal", "\"13.0\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableList<String> getExpectedValuesDuration1() {
+        return ImmutableList.of("\"0\"^^xsd:integer", "\"0\"^^xsd:integer", "\"0\"^^xsd:integer", "\"0\"^^xsd:integer",
+                "\"0\"^^xsd:integer", "\"18.000000000\"^^xsd:decimal", "\"20.000000000\"^^xsd:decimal", "\"84.500000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableList<String> getExpectedValuesMultitypedAvg1() {
+        return ImmutableList.of("\"15.500000000\"^^xsd:decimal", "\"16.000000000\"^^xsd:decimal", "\"19.250000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected boolean supportsIntegrityConstraints() {
+        return false;
+    }
+
+    @Disabled("Currently disabled because this test causes an issue in the translation of the query (Only DBFunctionSymbols must be provided to a SQLTermSerializer)")
+    @Test
+    @Override
+    public void testMinusMultitypedSum() {
+        super.testMinusMultitypedSum();
+    }
+
+    @Disabled("Currently disabled because this test causes an issue in the translation of the query (Only DBFunctionSymbols must be provided to a SQLTermSerializer)")
+    @Test
+    @Override
+    public void testMinusMultitypedAvg() {
+        super.testMinusMultitypedAvg();
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/redshift/BindWithFunctionsRedshiftTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/redshift/BindWithFunctionsRedshiftTest.java
@@ -64,6 +64,7 @@ public class BindWithFunctionsRedshiftTest extends AbstractBindTestWithFunctions
                 "\"2015-09-21T09:23:06+00\"^^xsd:string");
     }
 
+    @Override
     protected ImmutableSet<String> getRoundExpectedValues() {
         //Round leaves entries in same data type, so discount of type DECIMAL remains decimal with 18 digits in the
         //fractional part

--- a/test/lightweight-tests/src/test/resources/books/bigquery/books-bigquery.obda
+++ b/test/lightweight-tests/src/test/resources/books/bigquery/books-bigquery.obda
@@ -1,0 +1,11 @@
+[PrefixDeclaration]
+dc:  http://purl.org/dc/elements/1.1/
+:   http://example.org/book
+ns:  http://example.org/ns#
+
+
+[MappingDeclaration] @collection [[
+mappingId	mapping1
+target	:{id} a :Book ; dc:title {title}@en ; ns:price {price} ; ns:discount {discount} ; ns:pubYear {publication_date} ; dc:description {description}@en .
+source	SELECT id, title, price, discount, publication_date, description, lang FROM books.books WHERE lang = 'en'
+]]

--- a/test/lightweight-tests/src/test/resources/books/bigquery/books-bigquery.properties
+++ b/test/lightweight-tests/src/test/resources/books/bigquery/books-bigquery.properties
@@ -1,0 +1,4 @@
+jdbc.url = jdbc:bigquery://${bigquery.domain}:443;ProjectId=${bigquery.project};OAuthType=0
+jdbc.property.OAuthServiceAcctEmail = ${bigquery.user}
+jdbc.property.OAuthPvtKey = ${bigquery.password}
+jdbc.driver = com.simba.googlebigquery.jdbc.Driver

--- a/test/lightweight-tests/src/test/resources/dbconstraints/dbconstraints-bigquery.properties
+++ b/test/lightweight-tests/src/test/resources/dbconstraints/dbconstraints-bigquery.properties
@@ -1,0 +1,4 @@
+jdbc.url = jdbc:bigquery://${bigquery.domain}:443;ProjectId=${bigquery.project};OAuthType=0
+jdbc.property.OAuthServiceAcctEmail = ${bigquery.user}
+jdbc.property.OAuthPvtKey = ${bigquery.password}
+jdbc.driver = com.simba.googlebigquery.jdbc.Driver

--- a/test/lightweight-tests/src/test/resources/prof/bigquery/prof-bigquery.obda
+++ b/test/lightweight-tests/src/test/resources/prof/bigquery/prof-bigquery.obda
@@ -1,0 +1,48 @@
+[PrefixDeclaration]
+owl:		http://www.w3.org/2002/07/owl#
+rdf:		http://www.w3.org/1999/02/22-rdf-syntax-ns#
+xsd:		http://www.w3.org/2001/XMLSchema#
+:		http://www.semanticweb.org/user/ontologies/2016/8/untitled-ontology-84#
+xml:		http://www.w3.org/XML/1998/namespace
+quest:		http://obda.org/quest#
+rdfs:		http://www.w3.org/2000/01/rdf-schema#
+
+[MappingDeclaration] @collection [[
+mappingId	MAPID-professor
+target		:professor/{prof_id} a :Professor . 
+source		SELECT prof_id, last_name FROM university.professors;
+
+mappingId	MAPID-fname
+target		:professor/{prof_id} :firstName {first_name} .
+source		SELECT prof_id, first_name FROM university.professors;
+
+mappingId	MAPID-lname
+target		:professor/{prof_id} :lastName {last_name} .
+source		SELECT prof_id, last_name FROM university.professors;
+
+mappingId	MAPID-nickname
+target		:professor/{prof_id} :nickname {nickname} .
+source		SELECT prof_id, nickname FROM university.professors;
+
+mappingId	MAPID-teaches
+target		:professor/{prof_id} :teaches :course/{course_id} . 
+source		SELECT prof_id, course_id FROM university.teaching;
+
+mappingId	MAPID-teachesAt
+target		:professor/{prof_id} :teachesAt :university/Bolzano .
+source		SELECT prof_id FROM university.teaching;
+
+mappingId	MAPID-teacherID
+target		:professor/{prof_id} :teacherID {prof_id} .
+source		SELECT prof_id FROM university.teaching;
+
+mappingId	MAPID-course
+target		:course/{course_id} a :Course ; :duration {duration} ; :nbStudents {nb_students} .
+source		SELECT * FROM university.course;
+
+mappingId	MAPID-prof-student-count
+target		:professor/{prof_id} :nbStudents {count} .
+source		SELECT t.prof_id, sum(c.nb_students) AS count FROM university.teaching t, university.course c WHERE t.course_id = c.course_id GROUP BY prof_id
+
+]]
+

--- a/test/lightweight-tests/src/test/resources/prof/bigquery/prof-bigquery.properties
+++ b/test/lightweight-tests/src/test/resources/prof/bigquery/prof-bigquery.properties
@@ -1,0 +1,5 @@
+jdbc.url = jdbc:bigquery://${bigquery.domain}:443;ProjectId=${bigquery.project};OAuthType=0
+jdbc.property.OAuthServiceAcctEmail = ${bigquery.user}
+jdbc.property.OAuthPvtKey = ${bigquery.password}
+jdbc.driver = com.simba.googlebigquery.jdbc.Driver
+ontop.allowRetrievingBlackBoxViewMetadataFromDB = true

--- a/test/lightweight-tests/src/test/resources/university/university-bigquery.properties
+++ b/test/lightweight-tests/src/test/resources/university/university-bigquery.properties
@@ -1,0 +1,4 @@
+jdbc.url = jdbc:bigquery://${bigquery.domain}:443;ProjectId=${bigquery.project};OAuthType=0
+jdbc.property.OAuthServiceAcctEmail = ${bigquery.user}
+jdbc.property.OAuthPvtKey = ${bigquery.password}
+jdbc.driver = com.simba.googlebigquery.jdbc.Driver


### PR DESCRIPTION
Added support for BigQuery.
BigQuery does not support integrity constraints, so tests for them were disabled.
Implemented new normalizer that pushes construct nodes into order by nodes if necessary.

Currently, the Simba BigQuery JDBC is not available in the maven central repository. Furthermore, their license does not allow us to publish it on the ontop maven repository. Therefore, tests for it have been commented out in the workflow, but may be run locally. 