### PR TITLE
Added lightweight tests for Denodo and fixed some bugs in its implementation

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/AlwaysPushProjectedOrderByTermsNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/AlwaysPushProjectedOrderByTermsNormalizer.java
@@ -1,0 +1,13 @@
+package it.unibz.inf.ontop.generation.normalization.impl;
+
+import com.google.inject.Inject;
+import it.unibz.inf.ontop.injection.CoreSingletons;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+
+public class AlwaysPushProjectedOrderByTermsNormalizer extends PushProjectedOrderByTermsNormalizer {
+
+    @Inject
+    protected AlwaysPushProjectedOrderByTermsNormalizer(IntermediateQueryFactory iqFactory, CoreSingletons coreSingletons) {
+        super(false, iqFactory, coreSingletons);
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/BigQueryExtraNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/BigQueryExtraNormalizer.java
@@ -9,12 +9,12 @@ import it.unibz.inf.ontop.utils.VariableGenerator;
 public class BigQueryExtraNormalizer implements DialectExtraNormalizer {
 
     private final AlwaysProjectOrderByTermsNormalizer alwaysProjectOrderByTermsNormalizer;
-    private final PushProjectedOrderByTermsNormalizer pushProjectedOrderByTermsNormalizer;
+    private final OnlyInPresenceOfDistinctPushProjectedOrderByTermsNormalizer pushProjectedOrderByTermsNormalizer;
     private final ConvertValuesToUnionNormalizer convertValuesToUnionNormalizer;
 
     @Inject
     protected BigQueryExtraNormalizer(AlwaysProjectOrderByTermsNormalizer alwaysProjectOrderByTermsNormalizer,
-                                      PushProjectedOrderByTermsNormalizer pushProjectedOrderByTermsNormalizer,
+                                      OnlyInPresenceOfDistinctPushProjectedOrderByTermsNormalizer pushProjectedOrderByTermsNormalizer,
                                       ConvertValuesToUnionNormalizer convertValuesToUnionNormalizer) {
         this.alwaysProjectOrderByTermsNormalizer = alwaysProjectOrderByTermsNormalizer;
         this.pushProjectedOrderByTermsNormalizer = pushProjectedOrderByTermsNormalizer;

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/DenodoExtraNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/DenodoExtraNormalizer.java
@@ -10,21 +10,34 @@ import javax.inject.Singleton;
 @Singleton
 public class DenodoExtraNormalizer implements DialectExtraNormalizer {
 
+    private final EliminateLimitsFromSubQueriesNormalizer eliminateLimitsFromSubQueriesNormalizer;
+    private final SplitIsNullOverConjunctionDisjunctionNormalizer splitIsNullOverConjunctionDisjunctionNormalizer;
     private final AlwaysProjectOrderByTermsNormalizer alwaysProjectOrderByTermsNormalizer;
     private final ConvertValuesToUnionNormalizer toUnionNormalizer;
-
+    private final AlwaysPushProjectedOrderByTermsNormalizer pushProjectedOrderByTermsNormalizer;
     @Inject
     protected DenodoExtraNormalizer(AlwaysProjectOrderByTermsNormalizer alwaysProjectOrderByTermsNormalizer,
-                                    ConvertValuesToUnionNormalizer toUnionNormalizer) {
+                                    ConvertValuesToUnionNormalizer toUnionNormalizer, AlwaysPushProjectedOrderByTermsNormalizer pushProjectedOrderByTermsNormalizer,
+                                    SplitIsNullOverConjunctionDisjunctionNormalizer splitIsNullOverConjunctionDisjunctionNormalizer,
+                                    EliminateLimitsFromSubQueriesNormalizer eliminateLimitsFromSubQueriesNormalizer) {
         this.alwaysProjectOrderByTermsNormalizer = alwaysProjectOrderByTermsNormalizer;
         this.toUnionNormalizer = toUnionNormalizer;
+        this.pushProjectedOrderByTermsNormalizer = pushProjectedOrderByTermsNormalizer;
+        this.splitIsNullOverConjunctionDisjunctionNormalizer = splitIsNullOverConjunctionDisjunctionNormalizer;
+        this.eliminateLimitsFromSubQueriesNormalizer = eliminateLimitsFromSubQueriesNormalizer;
     }
 
     @Override
     public IQTree transform(IQTree tree, VariableGenerator variableGenerator) {
-        return toUnionNormalizer.transform(
-                alwaysProjectOrderByTermsNormalizer.transform(tree, variableGenerator),
-                variableGenerator);
+        return eliminateLimitsFromSubQueriesNormalizer.transform(
+            splitIsNullOverConjunctionDisjunctionNormalizer.transform(
+                    pushProjectedOrderByTermsNormalizer.transform(
+                            toUnionNormalizer.transform(
+                                    alwaysProjectOrderByTermsNormalizer.transform(tree, variableGenerator),
+                                    variableGenerator),
+                            variableGenerator),
+                    variableGenerator),
+            variableGenerator);
     }
 }
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/EliminateLimitsFromSubQueriesNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/EliminateLimitsFromSubQueriesNormalizer.java
@@ -1,0 +1,95 @@
+package it.unibz.inf.ontop.generation.normalization.impl;
+
+import it.unibz.inf.ontop.generation.normalization.DialectExtraNormalizer;
+import it.unibz.inf.ontop.injection.CoreSingletons;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.UnaryIQTree;
+import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeExtendedTransformer;
+import it.unibz.inf.ontop.model.term.NonGroundTerm;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+import javax.inject.Inject;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/*
+Used to get rid of limits in sub-queries that are not necessary, for dialects like Denodo, that don't allow limits in sub-queries.
+ */
+public class EliminateLimitsFromSubQueriesNormalizer extends DefaultRecursiveIQTreeExtendedTransformer<VariableGenerator> implements DialectExtraNormalizer {
+
+
+    @Inject
+    protected EliminateLimitsFromSubQueriesNormalizer(CoreSingletons coreSingletons) {
+        super(coreSingletons);
+    }
+
+    @Override
+    public IQTree transform(IQTree tree, VariableGenerator variableGenerator) {
+        return tree.acceptTransformer(this, variableGenerator);
+    }
+
+    @Override
+    public IQTree transformSlice(IQTree tree, SliceNode sliceNode, IQTree child, VariableGenerator context) {
+        //We only perform this normalization if there is no OFFSET
+        if(sliceNode.getOffset() != 0 || sliceNode.getLimit().isEmpty())
+            return super.transformSlice(tree, sliceNode, child, context);
+
+        return iqFactory.createUnaryIQTree(sliceNode, normalizeRecursive(child, sliceNode.getLimit().get(), context));
+    }
+
+    protected IQTree normalizeRecursive(IQTree tree, long limit, VariableGenerator variableGenerator) {
+        if(tree.getRootNode() instanceof SliceNode) {
+            var subSlice = (SliceNode)tree.getRootNode();
+
+            //If the child slice has a lower limit than the parent, we cannot drop it
+            //We once again only perform this normalization if there is no OFFSET
+            if(subSlice.getOffset() != 0 || subSlice.getLimit().isEmpty() || subSlice.getLimit().get() < limit)
+                return transform(tree, variableGenerator);
+
+            return normalizeRecursive(tree.getChildren().get(0), limit, variableGenerator);
+
+        }
+
+        //On DISTINCT we have to stop
+        if(tree.getRootNode() instanceof DistinctNode)
+            return transform(tree, variableGenerator);
+        //On LEFT JOIN, we only continue on the left
+        if(tree.getRootNode() instanceof LeftJoinNode) {
+            var leftSubTree = normalizeRecursive(tree.getChildren().get(0), limit, variableGenerator);
+            var rightSubTree = transform(tree.getChildren().get(1), variableGenerator);
+            if(leftSubTree.equals(tree.getChildren().get(0)) && rightSubTree.equals(tree.getChildren().get(1)))
+                return tree;
+            return iqFactory.createBinaryNonCommutativeIQTree((LeftJoinNode)tree.getRootNode(), leftSubTree, rightSubTree);
+        }
+        //On anything else, we continue on each child
+        if(tree.getRootNode() instanceof UnaryOperatorNode) {
+            var newSubTree = normalizeRecursive(tree.getChildren().get(0), limit, variableGenerator);
+            if(newSubTree.equals(tree.getChildren().get(0)))
+                return tree;
+            return iqFactory.createUnaryIQTree((UnaryOperatorNode) tree.getRootNode(), newSubTree);
+        }
+        if(tree.getRootNode() instanceof BinaryNonCommutativeOperatorNode) {
+            var leftSubTree = normalizeRecursive(tree.getChildren().get(0), limit, variableGenerator);
+            var rightSubTree = normalizeRecursive(tree.getChildren().get(1), limit, variableGenerator);
+            if(leftSubTree.equals(tree.getChildren().get(0)) && rightSubTree.equals(tree.getChildren().get(1)))
+                return tree;
+            return iqFactory.createBinaryNonCommutativeIQTree((BinaryNonCommutativeOperatorNode) tree.getRootNode(),
+                    leftSubTree,
+                    rightSubTree);
+        }
+        if(tree.getRootNode() instanceof NaryOperatorNode) {
+            var newChildTrees = tree.getChildren().stream().map(
+                    child -> normalizeRecursive(child, limit, variableGenerator)
+            ).collect(ImmutableCollectors.toList());
+            if(IntStream.range(0, newChildTrees.size()).allMatch(i -> newChildTrees.get(i).equals(tree.getChildren().get(i))))
+                return tree;
+            return iqFactory.createNaryIQTree((NaryOperatorNode) tree.getRootNode(), newChildTrees);
+        }
+
+        //On any remaining edge case
+        return transform(tree, variableGenerator);
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/EliminateLimitsFromSubQueriesNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/EliminateLimitsFromSubQueriesNormalizer.java
@@ -1,5 +1,6 @@
 package it.unibz.inf.ontop.generation.normalization.impl;
 
+import com.google.common.collect.ImmutableList;
 import it.unibz.inf.ontop.generation.normalization.DialectExtraNormalizer;
 import it.unibz.inf.ontop.injection.CoreSingletons;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
@@ -21,9 +22,11 @@ Used to get rid of limits in sub-queries that are not necessary, for dialects li
 public class EliminateLimitsFromSubQueriesNormalizer extends DefaultRecursiveIQTreeExtendedTransformer<VariableGenerator> implements DialectExtraNormalizer {
 
 
+    private SubLimitTransformer subLimitTransformer;
     @Inject
     protected EliminateLimitsFromSubQueriesNormalizer(CoreSingletons coreSingletons) {
         super(coreSingletons);
+        subLimitTransformer = new SubLimitTransformer(this, coreSingletons);
     }
 
     @Override
@@ -37,59 +40,83 @@ public class EliminateLimitsFromSubQueriesNormalizer extends DefaultRecursiveIQT
         if(sliceNode.getOffset() != 0 || sliceNode.getLimit().isEmpty())
             return super.transformSlice(tree, sliceNode, child, context);
 
-        return iqFactory.createUnaryIQTree(sliceNode, normalizeRecursive(child, sliceNode.getLimit().get(), context));
+        return iqFactory.createUnaryIQTree(sliceNode, subLimitTransformer.transform(child, context, sliceNode.getLimit().get()));
     }
 
-    protected IQTree normalizeRecursive(IQTree tree, long limit, VariableGenerator variableGenerator) {
-        if(tree.getRootNode() instanceof SliceNode) {
-            var subSlice = (SliceNode)tree.getRootNode();
+    private class SubLimitTransformer extends DefaultRecursiveIQTreeExtendedTransformer<VariableGenerator> {
 
-            //If the child slice has a lower limit than the parent, we cannot drop it
-            //We once again only perform this normalization if there is no OFFSET
-            if(subSlice.getOffset() != 0 || subSlice.getLimit().isEmpty() || subSlice.getLimit().get() < limit)
-                return transform(tree, variableGenerator);
+        private EliminateLimitsFromSubQueriesNormalizer eliminateLimitsFromSubQueriesNormalizer;
+        private long currentBounds = 0;
 
-            return normalizeRecursive(tree.getChildren().get(0), limit, variableGenerator);
-
+        protected SubLimitTransformer(EliminateLimitsFromSubQueriesNormalizer eliminateLimitsFromSubQueriesNormalizer,
+                                      CoreSingletons coreSingletons) {
+            super(coreSingletons);
+            this.eliminateLimitsFromSubQueriesNormalizer = eliminateLimitsFromSubQueriesNormalizer;
         }
 
-        //On DISTINCT we have to stop
-        if(tree.getRootNode() instanceof DistinctNode)
-            return transform(tree, variableGenerator);
-        //On LEFT JOIN, we only continue on the left
-        if(tree.getRootNode() instanceof LeftJoinNode) {
-            var leftSubTree = normalizeRecursive(tree.getChildren().get(0), limit, variableGenerator);
-            var rightSubTree = transform(tree.getChildren().get(1), variableGenerator);
+        public IQTree transform(IQTree tree, VariableGenerator variableGenerator, long limitBounds) {
+            long rememberOldBounds = currentBounds;
+            currentBounds = limitBounds;
+            IQTree result = transform(tree, variableGenerator);
+            currentBounds = rememberOldBounds;
+            return result;
+        }
+
+        @Override
+        public IQTree transform(IQTree tree, VariableGenerator variableGenerator) {
+            return tree.acceptTransformer(this, variableGenerator);
+        }
+
+        //If the child slice has a lower limit than the parent, we cannot drop it
+        //We once again only perform this normalization if there is no OFFSET
+        @Override
+        public IQTree transformSlice(IQTree tree, SliceNode sliceNode, IQTree child, VariableGenerator context) {
+            if(sliceNode.getOffset() != 0 || sliceNode.getLimit().isEmpty() || sliceNode.getLimit().get() < currentBounds)
+                return eliminateLimitsFromSubQueriesNormalizer.transform(tree, context);
+            return transform(tree.getChildren().get(0), context);
+        }
+
+        //On left joins, we only apply the transformation to the left child
+        @Override
+        public IQTree transformLeftJoin(IQTree tree, LeftJoinNode rootNode, IQTree leftChild, IQTree rightChild, VariableGenerator context) {
+            var leftSubTree = transform(tree.getChildren().get(0), context);
+            var rightSubTree = eliminateLimitsFromSubQueriesNormalizer.transform(tree.getChildren().get(1), context);
             if(leftSubTree.equals(tree.getChildren().get(0)) && rightSubTree.equals(tree.getChildren().get(1)))
                 return tree;
             return iqFactory.createBinaryNonCommutativeIQTree((LeftJoinNode)tree.getRootNode(), leftSubTree, rightSubTree);
         }
-        //On anything else, we continue on each child
-        if(tree.getRootNode() instanceof UnaryOperatorNode) {
-            var newSubTree = normalizeRecursive(tree.getChildren().get(0), limit, variableGenerator);
-            if(newSubTree.equals(tree.getChildren().get(0)))
-                return tree;
-            return iqFactory.createUnaryIQTree((UnaryOperatorNode) tree.getRootNode(), newSubTree);
-        }
-        if(tree.getRootNode() instanceof BinaryNonCommutativeOperatorNode) {
-            var leftSubTree = normalizeRecursive(tree.getChildren().get(0), limit, variableGenerator);
-            var rightSubTree = normalizeRecursive(tree.getChildren().get(1), limit, variableGenerator);
-            if(leftSubTree.equals(tree.getChildren().get(0)) && rightSubTree.equals(tree.getChildren().get(1)))
-                return tree;
-            return iqFactory.createBinaryNonCommutativeIQTree((BinaryNonCommutativeOperatorNode) tree.getRootNode(),
-                    leftSubTree,
-                    rightSubTree);
-        }
-        if(tree.getRootNode() instanceof NaryOperatorNode) {
-            var newChildTrees = tree.getChildren().stream().map(
-                    child -> normalizeRecursive(child, limit, variableGenerator)
-            ).collect(ImmutableCollectors.toList());
-            if(IntStream.range(0, newChildTrees.size()).allMatch(i -> newChildTrees.get(i).equals(tree.getChildren().get(i))))
-                return tree;
-            return iqFactory.createNaryIQTree((NaryOperatorNode) tree.getRootNode(), newChildTrees);
+
+        //On inner joins, unions and constructions, we keep going inside this normalizer.
+        @Override
+        public IQTree transformInnerJoin(IQTree tree, InnerJoinNode rootNode, ImmutableList<IQTree> children, VariableGenerator context) {
+            return super.transformNaryCommutativeNode(tree, rootNode, children, context);
         }
 
-        //On any remaining edge case
-        return transform(tree, variableGenerator);
+        @Override
+        public IQTree transformUnion(IQTree tree, UnionNode rootNode, ImmutableList<IQTree> children, VariableGenerator context) {
+            return super.transformNaryCommutativeNode(tree, rootNode, children, context);
+        }
+
+        @Override
+        public IQTree transformConstruction(IQTree tree, ConstructionNode rootNode, IQTree child, VariableGenerator context) {
+            return super.transformUnaryNode(tree, rootNode, child, context);
+        }
+
+        //All other nodes are not modified and passed back to the original normalizer to continue.
+        //This includes ORDER BY, DISTINCT, FILTER and more
+        @Override
+        protected IQTree transformUnaryNode(IQTree tree, UnaryOperatorNode rootNode, IQTree child, VariableGenerator context) {
+            return eliminateLimitsFromSubQueriesNormalizer.transform(tree, context);
+        }
+
+        @Override
+        protected IQTree transformBinaryNonCommutativeNode(IQTree tree, BinaryNonCommutativeOperatorNode rootNode, IQTree leftChild, IQTree rightChild, VariableGenerator context) {
+            return eliminateLimitsFromSubQueriesNormalizer.transform(tree, context);
+        }
+
+        @Override
+        protected IQTree transformNaryCommutativeNode(IQTree tree, NaryOperatorNode rootNode, ImmutableList<IQTree> children, VariableGenerator context) {
+            return eliminateLimitsFromSubQueriesNormalizer.transform(tree, context);
+        }
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/OnlyInPresenceOfDistinctPushProjectedOrderByTermsNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/OnlyInPresenceOfDistinctPushProjectedOrderByTermsNormalizer.java
@@ -1,0 +1,13 @@
+package it.unibz.inf.ontop.generation.normalization.impl;
+
+import com.google.inject.Inject;
+import it.unibz.inf.ontop.injection.CoreSingletons;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+
+public class OnlyInPresenceOfDistinctPushProjectedOrderByTermsNormalizer extends PushProjectedOrderByTermsNormalizer {
+
+    @Inject
+    protected OnlyInPresenceOfDistinctPushProjectedOrderByTermsNormalizer(IntermediateQueryFactory iqFactory, CoreSingletons coreSingletons) {
+        super(true, iqFactory, coreSingletons);
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SplitIsNullOverConjunctionDisjunctionNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SplitIsNullOverConjunctionDisjunctionNormalizer.java
@@ -1,0 +1,86 @@
+package it.unibz.inf.ontop.generation.normalization.impl;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import it.unibz.inf.ontop.generation.normalization.DialectExtraNormalizer;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.node.ConstructionNode;
+import it.unibz.inf.ontop.iq.node.OrderByNode;
+import it.unibz.inf.ontop.iq.transform.IQTreeTransformer;
+import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeVisitingTransformer;
+import it.unibz.inf.ontop.iq.type.SingleTermTypeExtractor;
+import it.unibz.inf.ontop.iq.type.impl.AbstractExpressionTransformer;
+import it.unibz.inf.ontop.iq.type.impl.PartiallyTypedSimpleCastTransformerImpl;
+import it.unibz.inf.ontop.model.term.*;
+import it.unibz.inf.ontop.model.term.functionsymbol.FunctionSymbol;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.*;
+import it.unibz.inf.ontop.model.term.impl.NonGroundExpressionImpl;
+import it.unibz.inf.ontop.model.type.DBTermType;
+import it.unibz.inf.ontop.substitution.ImmutableSubstitution;
+import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/*
+Translates expressions of the form `(<expr1> OR|AND <expr2>) IS [NOT] NULL` into the expression
+CASE WHEN <expr1> OR|AND <expr2> THEN FALSE[TRUE] WHEN NOT <expr1> OR|AND <expr2> THEN FALSE[TRUE] ELSE FALSE END
+for dialects such as Denodo that do not allow IS [NOT] NULL to be executed on conjunctions/disjunctions.
+ */
+@Singleton
+public class SplitIsNullOverConjunctionDisjunctionNormalizer extends DefaultRecursiveIQTreeVisitingTransformer
+        implements DialectExtraNormalizer {
+
+    private final IQTreeTransformer expressionTransformer;
+
+    @Inject
+    protected SplitIsNullOverConjunctionDisjunctionNormalizer(IntermediateQueryFactory iqFactory,
+                                                              SingleTermTypeExtractor typeExtractor,
+                                                              TermFactory termFactory) {
+        super(iqFactory);
+        this.expressionTransformer = new ExpressionTransformer(iqFactory,
+                typeExtractor,
+                termFactory);
+    }
+
+    @Override
+    public IQTree transform(IQTree tree, VariableGenerator variableGenerator) {
+        return expressionTransformer.transform(tree);
+    }
+
+    protected static class ExpressionTransformer extends AbstractExpressionTransformer {
+
+        protected ExpressionTransformer(IntermediateQueryFactory iqFactory,
+                                        SingleTermTypeExtractor typeExtractor,
+                                        TermFactory termFactory) {
+            super(iqFactory, typeExtractor, termFactory);
+        }
+
+        @Override
+        protected boolean isFunctionSymbolToReplace(FunctionSymbol functionSymbol) {
+            return (functionSymbol instanceof DBIsNullOrNotFunctionSymbol);
+        }
+
+        @Override
+        protected ImmutableFunctionalTerm replaceFunctionSymbol(FunctionSymbol functionSymbol,
+                                                                ImmutableList<ImmutableTerm> newTerms, IQTree tree) {
+            ImmutableTerm subTerm = newTerms.get(0);
+            var isNullOrNotFunctionSymbol = (DBIsNullOrNotFunctionSymbol)functionSymbol;
+            if(!(subTerm instanceof NonGroundExpressionImpl))
+                return termFactory.getImmutableFunctionalTerm(functionSymbol, newTerms);
+            NonGroundExpressionImpl subTermNonGroundExpression = (NonGroundExpressionImpl)subTerm;
+            FunctionSymbol subTermFunctionSymbol = subTermNonGroundExpression.getFunctionSymbol();
+            if(subTermFunctionSymbol == null || !(subTermFunctionSymbol instanceof DBOrFunctionSymbol || subTermFunctionSymbol instanceof DBAndFunctionSymbol))
+                return termFactory.getImmutableFunctionalTerm(functionSymbol, newTerms);
+            var trueTerm = termFactory.getDBBooleanConstant(!isNullOrNotFunctionSymbol.isTrueWhenNull());
+            var falseTerm = termFactory.getDBBooleanConstant(isNullOrNotFunctionSymbol.isTrueWhenNull());
+            var newFunctionSymbol = termFactory.getDBCase(Stream.of(Maps.immutableEntry(subTermNonGroundExpression, trueTerm), Maps.immutableEntry(termFactory.getDBNot(subTermNonGroundExpression), trueTerm)), falseTerm, false);
+            return newFunctionSymbol;
+        }
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SplitIsNullOverConjunctionDisjunctionNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SplitIsNullOverConjunctionDisjunctionNormalizer.java
@@ -77,9 +77,13 @@ public class SplitIsNullOverConjunctionDisjunctionNormalizer extends DefaultRecu
             FunctionSymbol subTermFunctionSymbol = subTermNonGroundExpression.getFunctionSymbol();
             if(subTermFunctionSymbol == null || !(subTermFunctionSymbol instanceof DBOrFunctionSymbol || subTermFunctionSymbol instanceof DBAndFunctionSymbol))
                 return termFactory.getImmutableFunctionalTerm(functionSymbol, newTerms);
-            var trueTerm = termFactory.getDBBooleanConstant(!isNullOrNotFunctionSymbol.isTrueWhenNull());
-            var falseTerm = termFactory.getDBBooleanConstant(isNullOrNotFunctionSymbol.isTrueWhenNull());
-            var newFunctionSymbol = termFactory.getDBCase(Stream.of(Maps.immutableEntry(subTermNonGroundExpression, trueTerm), Maps.immutableEntry(termFactory.getDBNot(subTermNonGroundExpression), trueTerm)), falseTerm, false);
+            var whenNotNullTerm = termFactory.getDBBooleanConstant(!isNullOrNotFunctionSymbol.isTrueWhenNull());
+            var whenNullTerm = termFactory.getDBBooleanConstant(isNullOrNotFunctionSymbol.isTrueWhenNull());
+            var newFunctionSymbol = termFactory.getDBCase(
+                    Stream.of(
+                            Maps.immutableEntry(subTermNonGroundExpression, whenNotNullTerm),
+                            Maps.immutableEntry(termFactory.getDBNot(subTermNonGroundExpression), whenNotNullTerm)
+                    ), whenNullTerm, false);
             return newFunctionSymbol;
         }
     }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SplitIsNullOverConjunctionDisjunctionNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SplitIsNullOverConjunctionDisjunctionNormalizer.java
@@ -27,7 +27,7 @@ import javax.inject.Singleton;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-/*
+/**
 Translates expressions of the form `(<expr1> OR|AND <expr2>) IS [NOT] NULL` into the expression
 CASE WHEN <expr1> OR|AND <expr2> THEN FALSE[TRUE] WHEN NOT <expr1> OR|AND <expr2> THEN FALSE[TRUE] ELSE FALSE END
 for dialects such as Denodo that do not allow IS [NOT] NULL to be executed on conjunctions/disjunctions.

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/DenodoDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/DenodoDBTypeFactory.java
@@ -14,7 +14,7 @@ import static it.unibz.inf.ontop.model.type.impl.NonStringNonNumberNonBooleanNon
 
 public class DenodoDBTypeFactory extends DefaultSQLDBTypeFactory {
 
-    public static final String TIMESTAMPTZ_STR = "TIMESTAMP_WITH_TIMEZONE";
+    public static final String TIMESTAMPTZ_STR = "TIMESTAMP WITH TIME ZONE";
 
     @AssistedInject
     protected DenodoDBTypeFactory(@Assisted TermType rootTermType, @Assisted TypeFactory typeFactory) {
@@ -39,5 +39,15 @@ public class DenodoDBTypeFactory extends DefaultSQLDBTypeFactory {
         map.put(DefaultTypeCode.DOUBLE, DOUBLE_PREC_STR);
         map.put(DefaultTypeCode.DATETIMESTAMP, TIMESTAMPTZ_STR);
         return ImmutableMap.copyOf(map);
+    }
+
+    @Override
+    public String getDBTrueLexicalValue() {
+        return "true";
+    }
+
+    @Override
+    public String getDBFalseLexicalValue() {
+        return "false";
     }
 }

--- a/test/lightweight-tests/lightweight-db-test-images/denodo/README.md
+++ b/test/lightweight-tests/lightweight-db-test-images/denodo/README.md
@@ -1,0 +1,17 @@
+# Testing Denodo using Lightweight Tests
+
+1) Run the _pgsql_ docker image from the lightweight test directory.
+2) Install _Denodo Express Community Edition_.
+3) Start the Denodo Express Virtual DataPort Administration Tool:
+   1) Through the terminal, in the directory `denodo-platform-x.y`, run `-/bin/denodo_platform.sh`.
+   2) In the UI, switch to the tab `Virtual DataPort`.
+   3) Under `Servers` -> `Virtual DataPort Server` press `Start`.
+   4) Press the `LAUNCH` button at the bottom of the window.
+   5) The admin tool will now open up.
+4) Import the `vql` files:
+   1) In the admin tool, go to `File` -> `Import`.
+   2) Next to `VQL file` press `Browse`.
+   3) Select the `vql` file you want to import.
+   4) Press `Ok`.
+   5) Repeat this for all three `vql` files.
+5) The lightweight tests can now be executed.

--- a/test/lightweight-tests/lightweight-db-test-images/denodo/vql/books.vql
+++ b/test/lightweight-tests/lightweight-db-test-images/denodo/vql/books.vql
@@ -1,0 +1,155 @@
+﻿# Generated with Denodo Platform 8.0 update 20220815.
+
+ENTER SINGLE USER MODE;
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+# 0 ====================================================================
+
+# #######################################
+# DATABASE
+# #######################################
+CREATE OR REPLACE DATABASE books '';
+
+CONNECT DATABASE books;
+
+# #######################################
+# LISTENERS JMS
+# #######################################
+# No listeners jms
+# #######################################
+# LISTENERS KAFKA
+# #######################################
+# No listeners kafka
+# #######################################
+# DATASOURCES
+# #######################################
+CREATE OR REPLACE DATASOURCE JDBC books
+    DRIVERCLASSNAME = 'org.postgresql.Driver'
+    DATABASEURI = 'jdbc:postgresql://localhost:7777/books'
+    USERNAME = 'postgres'
+    USERPASSWORD = 'UL0kJUbHA/gMrlXge+0yT12PdrMYK/KWucuzOBmLC/GreajEfRL2g0SsRIPDdOYm0vn4he1Q4+YiYEaLV6AmjDffnQs8dBhx3CGnsXt7XSDGXxVa1jFz5NuAh7fFyvhH' ENCRYPTED
+    CLASSPATH = 'postgresql-8'
+    DATABASENAME = 'postgresql'
+    DATABASEVERSION = '8'
+    FETCHSIZE = 1000
+    VALIDATIONQUERY = 'Select 1'
+    INITIALSIZE = 4
+    MAXIDLE = -1
+    MINIDLE = 0
+    MAXACTIVE = 20
+    EXHAUSTEDACTION = 1
+    TESTONBORROW = true
+    TESTONRETURN = false
+    TESTWHILEIDLE = false
+    TIMEBETWEENEVICTION = -1
+    NUMTESTPEREVICTION = 3
+    MINEVICTABLETIME = 1800000
+    POOLPREPAREDSTATEMENTS = false
+    MAXOPENPREPAREDSTATEMENTS = -1
+    DATA_LOAD_CONFIGURATION (
+        BATCHINSERTSIZE = 200
+    );
+
+# #######################################
+# DATABASE CONFIGURATION
+# #######################################
+ALTER DATABASE books
+  CHARSET DEFAULT;
+
+# #######################################
+# WRAPPERS
+# #######################################
+CREATE OR REPLACE WRAPPER JDBC books_1
+    DATASOURCENAME=books
+    SCHEMANAME='public' ESCAPE
+    RELATIONNAME='books' 
+    OUTPUTSCHEMA (
+        id = 'id' :'java.lang.Integer' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='10', sourcetypeid='4', sourcetypename='int4')  NOT NULL SORTABLE,
+        title = 'title' :'java.lang.String' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='100', sourcetypeid='12', sourcetypename='varchar')  SORTABLE,
+        price = 'price' :'java.lang.Integer' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='10', sourcetypeid='4', sourcetypename='int4')  SORTABLE,
+        discount = 'discount' :'java.math.BigDecimal' (OPT) (sourcetypedecimals='2', sourcetyperadix='10', sourcetypesize='38', sourcetypeid='2', sourcetypename='numeric')  SORTABLE,
+        description = 'description' :'java.lang.String' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='100', sourcetypeid='12', sourcetypename='varchar')  SORTABLE,
+        lang = 'lang' :'java.lang.String' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='100', sourcetypeid='12', sourcetypename='varchar')  SORTABLE,
+        publication_date = 'publication_date' :'java.time.LocalDateTime' (OPT) (sourcetypedecimals='6', sourcetyperadix='10', sourcetypesize='29', sourcetypeid='93', sourcetypename='timestamp')  SORTABLE
+    )
+    CONSTRAINT 'books_pkey' PRIMARY KEY ( 'id' )
+    INDEX 'books_pkey' CLUSTER UNIQUE PRIMARY ( 'id' );
+
+# #######################################
+# STORED PROCEDURES
+# #######################################
+# No stored procedures
+# #######################################
+# TYPES
+# #######################################
+# No types
+# #######################################
+# MAPS
+# #######################################
+# No maps
+# #######################################
+# BASE VIEWS
+# #######################################
+CREATE OR REPLACE TABLE books I18N us_pst (
+        id:int (notnull, sourcetypeid = '4', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '10'),
+        title:text (sourcetypeid = '12', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '100'),
+        price:int (sourcetypeid = '4', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '10'),
+        discount:decimal (sourcetypeid = '2', sourcetyperadix = '10', sourcetypedecimals = '2', sourcetypesize = '38'),
+        description:text (sourcetypeid = '12', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '100'),
+        lang:text (sourcetypeid = '12', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '100'),
+        publication_date:timestamp (sourcetypeid = '93', sourcetyperadix = '10', sourcetypedecimals = '6', sourcetypesize = '29')
+    )
+    CONSTRAINT 'books_pkey' PRIMARY KEY ( 'id' )
+    CACHE OFF
+    TIMETOLIVEINCACHE DEFAULT
+    ADD SEARCHMETHOD books_1(
+        I18N us_pst
+        CONSTRAINTS (
+             ADD id (any) OPT ANY
+             ADD title (any) OPT ANY
+             ADD price (any) OPT ANY
+             ADD discount (any) OPT ANY
+             ADD description (any) OPT ANY
+             ADD lang (any) OPT ANY
+             ADD publication_date (any) OPT ANY
+        )
+        OUTPUTLIST (description, discount, id, lang, price, publication_date, title
+        )
+        WRAPPER (jdbc books_1)
+    );
+
+# #######################################
+# VIEWS
+# #######################################
+# No views
+# #######################################
+# ASSOCIATIONS
+# #######################################
+# No associations
+# #######################################
+# WEBSERVICES
+# #######################################
+# No web services
+# #######################################
+# WIDGETS
+# #######################################
+# No widgets
+# #######################################
+# WEBCONTAINER WEB SERVICE DEPLOYMENTS
+# #######################################
+# No deployed web services
+# #######################################
+# WEBCONTAINER WIDGET DEPLOYMENTS
+# #######################################
+# No deployed widgets
+# #######################################
+# Closing connection with database books
+# #######################################
+CLOSE;
+
+
+
+
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+EXIT SINGLE USER MODE;

--- a/test/lightweight-tests/lightweight-db-test-images/denodo/vql/dbconstr.vql
+++ b/test/lightweight-tests/lightweight-db-test-images/denodo/vql/dbconstr.vql
@@ -1,0 +1,247 @@
+﻿# Generated with Denodo Platform 8.0 update 20220815.
+
+ENTER SINGLE USER MODE;
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+# 0 ====================================================================
+
+# #######################################
+# DATABASE
+# #######################################
+CREATE OR REPLACE DATABASE dbconstr '';
+
+CONNECT DATABASE dbconstr;
+
+# #######################################
+# LISTENERS JMS
+# #######################################
+# No listeners jms
+# #######################################
+# LISTENERS KAFKA
+# #######################################
+# No listeners kafka
+# #######################################
+# DATASOURCES
+# #######################################
+CREATE OR REPLACE DATASOURCE JDBC book
+    DRIVERCLASSNAME = 'org.postgresql.Driver'
+    DATABASEURI = 'jdbc:postgresql://localhost:7777/dbconstraints'
+    USERNAME = 'postgres'
+    USERPASSWORD = '5oaeH7v/+JL2X5263sRQJE/RmrAkA58cC6XdioyvcDMKIlrPc2EQQ0CazII4spvj3hAzqBpoHpKIij2Xc9LG0ClQLy9fl2m9YVMzRPHMs2at55Wm1wqxMKQpPu2Pyms0' ENCRYPTED
+    CLASSPATH = 'postgresql-8'
+    DATABASENAME = 'postgresql'
+    DATABASEVERSION = '8'
+    FETCHSIZE = 1000
+    VALIDATIONQUERY = 'Select 1'
+    INITIALSIZE = 4
+    MAXIDLE = -1
+    MINIDLE = 0
+    MAXACTIVE = 20
+    EXHAUSTEDACTION = 1
+    TESTONBORROW = true
+    TESTONRETURN = false
+    TESTWHILEIDLE = false
+    TIMEBETWEENEVICTION = -1
+    NUMTESTPEREVICTION = 3
+    MINEVICTABLETIME = 1800000
+    POOLPREPAREDSTATEMENTS = false
+    MAXOPENPREPAREDSTATEMENTS = -1
+    DATA_LOAD_CONFIGURATION (
+        BATCHINSERTSIZE = 200
+    );
+
+# #######################################
+# DATABASE CONFIGURATION
+# #######################################
+ALTER DATABASE dbconstr
+  CHARSET DEFAULT;
+
+# #######################################
+# WRAPPERS
+# #######################################
+CREATE OR REPLACE WRAPPER JDBC book
+    DATASOURCENAME=book
+    SCHEMANAME='public' ESCAPE
+    RELATIONNAME='Book' ESCAPE
+    OUTPUTSCHEMA (
+        bk_code = 'bk_code' :'java.lang.Integer' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='10', sourcetypeid='4', sourcetypename='int4')  NOT NULL SORTABLE,
+        bk_title = 'bk_title' :'java.lang.String' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='100', sourcetypeid='12', sourcetypename='varchar')  SORTABLE
+    )
+    CONSTRAINT 'pk_book' PRIMARY KEY ( 'bk_code' )
+    INDEX 'pk_book' OTHER UNIQUE PRIMARY ( 'bk_code' );
+
+CREATE OR REPLACE WRAPPER JDBC bookwriter
+    DATASOURCENAME=book
+    SCHEMANAME='public' ESCAPE
+    RELATIONNAME='BookWriter' ESCAPE
+    OUTPUTSCHEMA (
+        bk_code = 'bk_code' :'java.lang.Integer' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='10', sourcetypeid='4', sourcetypename='int4')  SORTABLE,
+        wr_code = 'wr_code' :'java.lang.Integer' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='10', sourcetypeid='4', sourcetypename='int4')  SORTABLE
+    )
+    CONSTRAINT 'fk_book_writer' FOREIGN KEY ( 'bk_code' ) 
+    REFERENCES 'public'.'Book'( 'bk_code' )  ON UPDATE NO ACTION  ON DELETE NO ACTION NOT DEFERRABLE 
+    CONSTRAINT 'fk_writer_book' FOREIGN KEY ( 'wr_code' ) 
+    REFERENCES 'public'.'Writer'( 'wr_code' )  ON UPDATE NO ACTION  ON DELETE NO ACTION NOT DEFERRABLE ;
+
+CREATE OR REPLACE WRAPPER JDBC edition
+    DATASOURCENAME=book
+    SCHEMANAME='public' ESCAPE
+    RELATIONNAME='Edition' ESCAPE
+    OUTPUTSCHEMA (
+        ed_code = 'ed_code' :'java.lang.Integer' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='10', sourcetypeid='4', sourcetypename='int4')  NOT NULL SORTABLE,
+        ed_year = 'ed_year' :'java.lang.Integer' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='10', sourcetypeid='4', sourcetypename='int4')  SORTABLE,
+        bk_code = 'bk_code' :'java.lang.Integer' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='10', sourcetypeid='4', sourcetypename='int4')  SORTABLE
+    )
+    CONSTRAINT 'pk_edition' PRIMARY KEY ( 'ed_code' )
+    CONSTRAINT 'fk_book_edition' FOREIGN KEY ( 'bk_code' ) 
+    REFERENCES 'public'.'Book'( 'bk_code' )  ON UPDATE NO ACTION  ON DELETE NO ACTION NOT DEFERRABLE 
+    INDEX 'pk_edition' OTHER UNIQUE PRIMARY ( 'ed_code' );
+
+CREATE OR REPLACE WRAPPER JDBC writer
+    DATASOURCENAME=book
+    SCHEMANAME='public' ESCAPE
+    RELATIONNAME='Writer' ESCAPE
+    OUTPUTSCHEMA (
+        wr_code = 'wr_code' :'java.lang.Integer' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='10', sourcetypeid='4', sourcetypename='int4')  NOT NULL SORTABLE,
+        wr_name = 'wr_name' :'java.lang.String' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='100', sourcetypeid='12', sourcetypename='varchar')  SORTABLE
+    )
+    CONSTRAINT 'pk_writer' PRIMARY KEY ( 'wr_code' )
+    INDEX 'pk_writer' OTHER UNIQUE PRIMARY ( 'wr_code' );
+
+# #######################################
+# STORED PROCEDURES
+# #######################################
+# No stored procedures
+# #######################################
+# TYPES
+# #######################################
+# No types
+# #######################################
+# MAPS
+# #######################################
+# No maps
+# #######################################
+# BASE VIEWS
+# #######################################
+CREATE OR REPLACE TABLE book I18N us_pst (
+        bk_code:int (notnull, sourcetypeid = '4', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '10'),
+        bk_title:text (sourcetypeid = '12', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '100')
+    )
+    CONSTRAINT 'pk_book' PRIMARY KEY ( 'bk_code' )
+    CACHE OFF
+    TIMETOLIVEINCACHE DEFAULT
+    ADD SEARCHMETHOD book(
+        I18N us_pst
+        CONSTRAINTS (
+             ADD bk_code (any) OPT ANY
+             ADD bk_title (any) OPT ANY
+        )
+        OUTPUTLIST (bk_code, bk_title
+        )
+        WRAPPER (jdbc book)
+    );
+
+CREATE OR REPLACE TABLE bookwriter I18N us_pst (
+        bk_code:int (sourcetypeid = '4', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '10'),
+        wr_code:int (sourcetypeid = '4', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '10')
+    )
+    CACHE OFF
+    TIMETOLIVEINCACHE DEFAULT
+    ADD SEARCHMETHOD bookwriter(
+        I18N us_pst
+        CONSTRAINTS (
+             ADD bk_code (any) OPT ANY
+             ADD wr_code (any) OPT ANY
+        )
+        OUTPUTLIST (bk_code, wr_code
+        )
+        WRAPPER (jdbc bookwriter)
+    );
+
+CREATE OR REPLACE TABLE edition I18N us_pst (
+        ed_code:int (notnull, sourcetypeid = '4', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '10'),
+        ed_year:int (sourcetypeid = '4', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '10'),
+        bk_code:int (sourcetypeid = '4', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '10')
+    )
+    CONSTRAINT 'pk_edition' PRIMARY KEY ( 'ed_code' )
+    CACHE OFF
+    TIMETOLIVEINCACHE DEFAULT
+    ADD SEARCHMETHOD edition(
+        I18N us_pst
+        CONSTRAINTS (
+             ADD ed_code (any) OPT ANY
+             ADD ed_year (any) OPT ANY
+             ADD bk_code (any) OPT ANY
+        )
+        OUTPUTLIST (bk_code, ed_code, ed_year
+        )
+        WRAPPER (jdbc edition)
+    );
+
+CREATE OR REPLACE TABLE writer I18N us_pst (
+        wr_code:int (notnull, sourcetypeid = '4', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '10'),
+        wr_name:text (sourcetypeid = '12', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '100')
+    )
+    CONSTRAINT 'pk_writer' PRIMARY KEY ( 'wr_code' )
+    CACHE OFF
+    TIMETOLIVEINCACHE DEFAULT
+    ADD SEARCHMETHOD writer(
+        I18N us_pst
+        CONSTRAINTS (
+             ADD wr_code (any) OPT ANY
+             ADD wr_name (any) OPT ANY
+        )
+        OUTPUTLIST (wr_code, wr_name
+        )
+        WRAPPER (jdbc writer)
+    );
+
+# #######################################
+# VIEWS
+# #######################################
+# No views
+# #######################################
+# ASSOCIATIONS
+# #######################################
+CREATE OR REPLACE ASSOCIATION book_bookwriter REFERENTIAL CONSTRAINT 
+    ENDPOINT bookwriter book PRINCIPAL (0,1)
+    ENDPOINT book bookwriter (0,*)
+    ADD MAPPING bk_code=bk_code;
+
+CREATE OR REPLACE ASSOCIATION book_edition REFERENTIAL CONSTRAINT 
+    ENDPOINT edition book PRINCIPAL (0,1)
+    ENDPOINT book edition (0,*)
+    ADD MAPPING bk_code=bk_code;
+
+CREATE OR REPLACE ASSOCIATION writer_bookwriter REFERENTIAL CONSTRAINT 
+    ENDPOINT bookwriter writer PRINCIPAL (0,1)
+    ENDPOINT writer bookwriter (0,*)
+    ADD MAPPING wr_code=wr_code;
+
+# #######################################
+# WEBSERVICES
+# #######################################
+# No web services
+# #######################################
+# WIDGETS
+# #######################################
+# No widgets
+# #######################################
+# WEBCONTAINER WEB SERVICE DEPLOYMENTS
+# #######################################
+# No deployed web services
+# #######################################
+# WEBCONTAINER WIDGET DEPLOYMENTS
+# #######################################
+# No deployed widgets
+# #######################################
+# Closing connection with database dbconstr
+# #######################################
+CLOSE;
+
+
+
+
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+EXIT SINGLE USER MODE;

--- a/test/lightweight-tests/lightweight-db-test-images/denodo/vql/university.vql
+++ b/test/lightweight-tests/lightweight-db-test-images/denodo/vql/university.vql
@@ -1,0 +1,220 @@
+﻿# Generated with Denodo Platform 8.0 update 20220815.
+
+ENTER SINGLE USER MODE;
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
+# 0 ====================================================================
+
+# #######################################
+# DATABASE
+# #######################################
+CREATE OR REPLACE DATABASE university '';
+
+CONNECT DATABASE university;
+
+# #######################################
+# LISTENERS JMS
+# #######################################
+# No listeners jms
+# #######################################
+# LISTENERS KAFKA
+# #######################################
+# No listeners kafka
+# #######################################
+# DATASOURCES
+# #######################################
+CREATE OR REPLACE DATASOURCE JDBC university
+    DRIVERCLASSNAME = 'org.postgresql.Driver'
+    DATABASEURI = 'jdbc:postgresql://localhost:7777/university'
+    USERNAME = 'postgres'
+    USERPASSWORD = '50i/iSxxUTr+hstnmnqOm8RwBZLfb8JzjN3jSsYKpGt3C+G2HwUEwAPMJMwiV6FsXELzcM//KYhOjHShqcO2S3HrWBlpGHp8VKbyizyGZKFBdnVpCp0D4hadKe+eYsbh' ENCRYPTED
+    CLASSPATH = 'postgresql-8'
+    DATABASENAME = 'postgresql'
+    DATABASEVERSION = '8'
+    FETCHSIZE = 1000
+    VALIDATIONQUERY = 'Select 1'
+    INITIALSIZE = 4
+    MAXIDLE = -1
+    MINIDLE = 0
+    MAXACTIVE = 20
+    EXHAUSTEDACTION = 1
+    TESTONBORROW = true
+    TESTONRETURN = false
+    TESTWHILEIDLE = false
+    TIMEBETWEENEVICTION = -1
+    NUMTESTPEREVICTION = 3
+    MINEVICTABLETIME = 1800000
+    POOLPREPAREDSTATEMENTS = false
+    MAXOPENPREPAREDSTATEMENTS = -1
+    DATA_LOAD_CONFIGURATION (
+        BATCHINSERTSIZE = 200
+    );
+
+# #######################################
+# DATABASE CONFIGURATION
+# #######################################
+ALTER DATABASE university
+  CHARSET DEFAULT;
+
+# #######################################
+# WRAPPERS
+# #######################################
+CREATE OR REPLACE WRAPPER JDBC course
+    DATASOURCENAME=university
+    SCHEMANAME='public' ESCAPE
+    RELATIONNAME='course' 
+    OUTPUTSCHEMA (
+        course_id = 'course_id' :'java.lang.String' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='100', sourcetypeid='12', sourcetypename='varchar')  NOT NULL SORTABLE,
+        nb_students = 'nb_students' :'java.lang.Integer' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='10', sourcetypeid='4', sourcetypename='int4')  NOT NULL SORTABLE,
+        duration = 'duration' :'java.math.BigDecimal' (OPT) (sourcetypedecimals='4', sourcetyperadix='10', sourcetypesize='38', sourcetypeid='2', sourcetypename='numeric')  NOT NULL SORTABLE
+    )
+    CONSTRAINT 'course_pkey' PRIMARY KEY ( 'course_id' )
+    INDEX 'course_pkey' OTHER UNIQUE PRIMARY ( 'course_id' );
+
+CREATE OR REPLACE WRAPPER JDBC professors
+    DATASOURCENAME=university
+    SCHEMANAME='public' ESCAPE
+    RELATIONNAME='professors' 
+    OUTPUTSCHEMA (
+        prof_id = 'prof_id' :'java.lang.Integer' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='10', sourcetypeid='4', sourcetypename='int4')  NOT NULL SORTABLE,
+        first_name = 'first_name' :'java.lang.String' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='100', sourcetypeid='12', sourcetypename='varchar')  NOT NULL SORTABLE,
+        last_name = 'last_name' :'java.lang.String' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='100', sourcetypeid='12', sourcetypename='varchar')  NOT NULL SORTABLE,
+        nickname = 'nickname' :'java.lang.String' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='100', sourcetypeid='12', sourcetypename='varchar')  SORTABLE
+    )
+    CONSTRAINT 'professors_pkey' PRIMARY KEY ( 'prof_id' )
+    INDEX 'professors_pkey' OTHER UNIQUE PRIMARY ( 'prof_id' );
+
+CREATE OR REPLACE WRAPPER JDBC teaching
+    DATASOURCENAME=university
+    SCHEMANAME='public' ESCAPE
+    RELATIONNAME='teaching' 
+    OUTPUTSCHEMA (
+        course_id = 'course_id' :'java.lang.String' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='100', sourcetypeid='12', sourcetypename='varchar')  NOT NULL SORTABLE,
+        prof_id = 'prof_id' :'java.lang.Integer' (OPT) (sourcetypedecimals='0', sourcetyperadix='10', sourcetypesize='10', sourcetypeid='4', sourcetypename='int4')  NOT NULL SORTABLE
+    )
+    CONSTRAINT 'teaching_pkey' PRIMARY KEY ( 'course_id' , 'prof_id' )
+    CONSTRAINT 'teaching_course_id_fkey' FOREIGN KEY ( 'course_id' ) 
+    REFERENCES 'public'.'course'( 'course_id' )  ON UPDATE NO ACTION  ON DELETE NO ACTION NOT DEFERRABLE 
+    CONSTRAINT 'teaching_prof_id_fkey' FOREIGN KEY ( 'prof_id' ) 
+    REFERENCES 'public'.'professors'( 'prof_id' )  ON UPDATE NO ACTION  ON DELETE NO ACTION NOT DEFERRABLE 
+    INDEX 'teaching_pkey' OTHER UNIQUE PRIMARY ( 'course_id' , 'prof_id' );
+
+# #######################################
+# STORED PROCEDURES
+# #######################################
+# No stored procedures
+# #######################################
+# TYPES
+# #######################################
+# No types
+# #######################################
+# MAPS
+# #######################################
+# No maps
+# #######################################
+# BASE VIEWS
+# #######################################
+CREATE OR REPLACE TABLE course I18N us_pst (
+        course_id:text (notnull, sourcetypeid = '12', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '100'),
+        nb_students:int (notnull, sourcetypeid = '4', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '10'),
+        duration:decimal (notnull, sourcetypeid = '2', sourcetyperadix = '10', sourcetypedecimals = '4', sourcetypesize = '38')
+    )
+    CONSTRAINT 'course_pkey' PRIMARY KEY ( 'course_id' )
+    CACHE OFF
+    TIMETOLIVEINCACHE DEFAULT
+    ADD SEARCHMETHOD course(
+        I18N us_pst
+        CONSTRAINTS (
+             ADD course_id (any) OPT ANY
+             ADD nb_students (any) OPT ANY
+             ADD duration (any) OPT ANY
+        )
+        OUTPUTLIST (course_id, duration, nb_students
+        )
+        WRAPPER (jdbc course)
+    );
+
+CREATE OR REPLACE TABLE professors I18N us_pst (
+        prof_id:int (notnull, sourcetypeid = '4', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '10'),
+        first_name:text (notnull, sourcetypeid = '12', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '100'),
+        last_name:text (notnull, sourcetypeid = '12', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '100'),
+        nickname:text (sourcetypeid = '12', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '100')
+    )
+    CONSTRAINT 'professors_pkey' PRIMARY KEY ( 'prof_id' )
+    CACHE OFF
+    TIMETOLIVEINCACHE DEFAULT
+    ADD SEARCHMETHOD professors(
+        I18N us_pst
+        CONSTRAINTS (
+             ADD prof_id (any) OPT ANY
+             ADD first_name (any) OPT ANY
+             ADD last_name (any) OPT ANY
+             ADD nickname (any) OPT ANY
+        )
+        OUTPUTLIST (first_name, last_name, nickname, prof_id
+        )
+        WRAPPER (jdbc professors)
+    );
+
+CREATE OR REPLACE TABLE teaching I18N us_pst (
+        course_id:text (notnull, sourcetypeid = '12', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '100'),
+        prof_id:int (notnull, sourcetypeid = '4', sourcetyperadix = '10', sourcetypedecimals = '0', sourcetypesize = '10')
+    )
+    CONSTRAINT 'teaching_pkey' PRIMARY KEY ( 'course_id' , 'prof_id' )
+    CACHE OFF
+    TIMETOLIVEINCACHE DEFAULT
+    ADD SEARCHMETHOD teaching(
+        I18N us_pst
+        CONSTRAINTS (
+             ADD course_id (any) OPT ANY
+             ADD prof_id (any) OPT ANY
+        )
+        OUTPUTLIST (course_id, prof_id
+        )
+        WRAPPER (jdbc teaching)
+    );
+
+# #######################################
+# VIEWS
+# #######################################
+# No views
+# #######################################
+# ASSOCIATIONS
+# #######################################
+CREATE OR REPLACE ASSOCIATION course_teaching REFERENTIAL CONSTRAINT 
+    ENDPOINT teaching course PRINCIPAL (0,1)
+    ENDPOINT course teaching (0,*)
+    ADD MAPPING course_id=course_id;
+
+CREATE OR REPLACE ASSOCIATION professors_teaching REFERENTIAL CONSTRAINT 
+    ENDPOINT teaching professors PRINCIPAL (0,1)
+    ENDPOINT professors teaching (0,*)
+    ADD MAPPING prof_id=prof_id;
+
+# #######################################
+# WEBSERVICES
+# #######################################
+# No web services
+# #######################################
+# WIDGETS
+# #######################################
+# No widgets
+# #######################################
+# WEBCONTAINER WEB SERVICE DEPLOYMENTS
+# #######################################
+# No deployed web services
+# #######################################
+# WEBCONTAINER WIDGET DEPLOYMENTS
+# #######################################
+# No deployed widgets
+# #######################################
+# Closing connection with database university
+# #######################################
+CLOSE;
+
+
+
+
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+EXIT SINGLE USER MODE;

--- a/test/lightweight-tests/pom.xml
+++ b/test/lightweight-tests/pom.xml
@@ -29,6 +29,7 @@
         <snowflake.user>fake</snowflake.user>
         <snowflake.password>fake</snowflake.password>
         <snowflake.warehouse>ontop</snowflake.warehouse>
+        <denodo.password>admin</denodo.password>
 <!--        <junit.version></junit.version>-->
         <junit-jupiter.version>5.9.1</junit-jupiter.version>
     </properties>

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/DenodoLightweightTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/DenodoLightweightTest.java
@@ -1,0 +1,18 @@
+package it.unibz.inf.ontop.docker.lightweight;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+@Target({ TYPE, METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("denodolighttests")
+@Test
+public @interface DenodoLightweightTest {
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/denodo/BindWithFunctionsDenodoTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/denodo/BindWithFunctionsDenodoTest.java
@@ -1,0 +1,130 @@
+package it.unibz.inf.ontop.docker.lightweight.denodo;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractBindTestWithFunctions;
+import it.unibz.inf.ontop.docker.lightweight.DenodoLightweightTest;
+import it.unibz.inf.ontop.docker.lightweight.DuckDBLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Class to test if functions on Strings and Numerics in SPARQL are working properly.
+ *
+ */
+@DenodoLightweightTest
+public class BindWithFunctionsDenodoTest extends AbstractBindTestWithFunctions {
+
+    private static final String PROPERTIES_FILE = "/books/denodo/books-denodo.properties";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Override
+    protected ImmutableSet<String> getAbsExpectedValues() {
+        return ImmutableSet.of("\"8.6000000000000000000000000000000000000000\"^^xsd:decimal", "\"5.7500000000000000000000000000000000000000\"^^xsd:decimal", "\"6.8000000000000000000000000000000000000000\"^^xsd:decimal",
+                "\"1.5000000000000000000000000000000000000000\"^^xsd:decimal");
+    }
+
+    @Disabled("Denodo does not yet support UUIDs")
+    @Test
+    @Override
+    public void testUuid() {
+        super.testUuid();
+    }
+
+    @Disabled("Denodo does not yet support UUIDs")
+    @Test
+    @Override
+    public void testStrUuid() {
+        super.testStrUuid();
+    }
+
+    @Disabled("Denodo does not yet support SHA Hash")
+    @Test
+    @Override
+    public void testHashSHA256() {
+        super.testHashSHA256();
+    }
+
+    @Disabled("Denodo does not yet support SHA Hash")
+    @Test
+    @Override
+    public void testHashSHA1() {
+        super.testHashSHA1();
+    }
+
+    @Disabled("Denodo does not yet support SHA Hash")
+    @Test
+    @Override
+    public void testHashSHA384() {
+        super.testHashSHA384();
+    }
+
+    @Disabled("Denodo does not yet support SHA Hash")
+    @Test
+    @Override
+    public void testHashSHA512() {
+        super.testHashSHA512();
+    }
+
+    @Override
+    protected ImmutableList<String> getConstantIntegerDivideExpectedResults() {
+        return ImmutableList.of("\"0.500000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableList<String> getStrExpectedValues() {
+        return ImmutableList.of("\"1970-11-05 07:50:00.0\"^^xsd:string", "\"2011-12-08 11:30:00.0\"^^xsd:string",
+                "\"2014-06-05 16:47:52.0\"^^xsd:string", "\"2015-09-21 09:23:06.0\"^^xsd:string");
+    }
+
+    @Override
+    protected ImmutableSet<String> getDivideExpectedValues() {
+        return ImmutableSet.of("\"21.50000000000000000000\"^^xsd:decimal", "\"11.50000000000000000000\"^^xsd:decimal",
+                "\"17.00000000000000000000\"^^xsd:decimal", "\"5.00000000000000000000\"^^xsd:decimal");
+    }
+
+    @Disabled("Denodo uses a different timezone depending on the system, so this result is not accurate.")
+    @Test
+    @Override
+    public void testDay() {
+        super.testDay();
+    }
+
+    @Disabled("Denodo uses a different timezone depending on the system, so this result is not accurate.")
+    @Test
+    @Override
+    public void testHours() {
+        super.testHours();
+    }
+
+    @Disabled("Denodo does not allow the use of REGEXP_LIKE in the projection part.")
+    @Test
+    @Override
+    public void testREGEX() {
+        super.testREGEX();
+    }
+
+    @Disabled("Denodo uses a different format for MD5, and does not support conversion to HEX.")
+    @Test
+    @Override
+    public void testHashMd5() {
+        super.testHashMd5();
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/denodo/ConstraintDenodoTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/denodo/ConstraintDenodoTest.java
@@ -1,0 +1,16 @@
+package it.unibz.inf.ontop.docker.lightweight.denodo;
+
+import it.unibz.inf.ontop.docker.lightweight.AbstractConstraintTest;
+import it.unibz.inf.ontop.docker.lightweight.DenodoLightweightTest;
+import it.unibz.inf.ontop.docker.lightweight.DuckDBLightweightTest;
+
+@DenodoLightweightTest
+public class ConstraintDenodoTest extends AbstractConstraintTest {
+
+    private static final String PROPERTIES_FILE = "/dbconstraints/dbconstraints-denodo.properties";
+
+    public ConstraintDenodoTest(String method) {
+        super(method, PROPERTIES_FILE);
+    }
+
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/denodo/DistinctInAggregateDenodoTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/denodo/DistinctInAggregateDenodoTest.java
@@ -1,0 +1,55 @@
+package it.unibz.inf.ontop.docker.lightweight.denodo;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractDistinctInAggregateTest;
+import it.unibz.inf.ontop.docker.lightweight.DenodoLightweightTest;
+import it.unibz.inf.ontop.docker.lightweight.DuckDBLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@DenodoLightweightTest
+public class DistinctInAggregateDenodoTest extends AbstractDistinctInAggregateTest {
+
+    private static final String PROPERTIES_FILE = "/university/university-denodo.properties";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Override
+    protected ImmutableSet<ImmutableMap<String, String>> getTuplesForAvg() {
+        return ImmutableSet.of(
+                ImmutableMap.of(
+                        "p",buildAnswerIRI("1"),
+                        "ad", "\"10.5\"^^xsd:decimal"
+                ),
+                ImmutableMap.of(
+                        "p",buildAnswerIRI("3"),
+                        "ad", "\"12.0\"^^xsd:decimal"
+                ),
+                ImmutableMap.of(
+                        "p",buildAnswerIRI("8"),
+                        "ad", "\"13.0\"^^xsd:decimal"
+                )
+        );
+    }
+
+    @Disabled("Denodo does not support 'DISTINCT' within GROUP_CONCAT")
+    @Test
+    @Override
+    public void testGroupConcatDistinct() throws Exception {
+        super.testGroupConcatDistinct();
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/denodo/LeftJoinProfDenodoTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/denodo/LeftJoinProfDenodoTest.java
@@ -1,0 +1,79 @@
+package it.unibz.inf.ontop.docker.lightweight.denodo;
+
+import com.google.common.collect.ImmutableList;
+import it.unibz.inf.ontop.docker.lightweight.AbstractLeftJoinProfTest;
+import it.unibz.inf.ontop.docker.lightweight.DenodoLightweightTest;
+import it.unibz.inf.ontop.docker.lightweight.DuckDBLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@DenodoLightweightTest
+public class LeftJoinProfDenodoTest extends AbstractLeftJoinProfTest {
+
+    private static final String PROPERTIES_FILE = "/prof/denodo/prof-denodo.properties";
+
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+
+    @Override
+    protected ImmutableList<String> getExpectedValuesDuration1() {
+        return ImmutableList.of("\"0\"^^xsd:integer", "\"0\"^^xsd:integer", "\"0\"^^xsd:integer", "\"0\"^^xsd:integer",
+                "\"0\"^^xsd:integer", "\"18.00000000000000000000\"^^xsd:decimal", "\"20.00000000000000000000\"^^xsd:decimal", "\"84.50000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableList<String> getExpectedValuesMultitypedAvg1() {
+        return ImmutableList.of("\"15.50000000000000000000\"^^xsd:decimal", "\"16.00000000000000000000\"^^xsd:decimal", "\"19.25000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableList<String> getExpectedValuesMultitypedSum1(){
+        return ImmutableList.of("\"31.00000000000000000000\"^^xsd:decimal", "\"32.00000000000000000000\"^^xsd:decimal", "\"115.50000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableList<String> getExpectedValuesAvgStudents2() {
+        return   ImmutableList.of("\"10.333333333333334\"^^xsd:decimal","\"12.0\"^^xsd:decimal", "\"13.0\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableList<String> getExpectedValuesAvgStudents3() {
+        return ImmutableList.of("\"0\"^^xsd:integer", "\"0\"^^xsd:integer", "\"0\"^^xsd:integer", "\"0\"^^xsd:integer",
+                "\"0\"^^xsd:integer", "\"10.333333333333334\"^^xsd:decimal", "\"12.0\"^^xsd:decimal", "\"13.0\"^^xsd:decimal");
+    }
+
+    @Disabled("Denodo does not support DISTINCT in GROUP_CONCAT")
+    @Test
+    @Override
+    public void testGroupConcat3() {
+        super.testGroupConcat3();
+    }
+
+    @Disabled("Denodo does not support DISTINCT in GROUP_CONCAT")
+    @Test
+    @Override
+    public void testGroupConcat5() {
+        super.testGroupConcat5();
+    }
+
+    @Disabled("Denodo does not allow LIMIT inside sub-queries")
+    @Test
+    @Override
+    public void testLimitSubQuery1() {
+        super.testLimitSubQuery1();
+    }
+}

--- a/test/lightweight-tests/src/test/resources/books/denodo/books-denodo.properties
+++ b/test/lightweight-tests/src/test/resources/books/denodo/books-denodo.properties
@@ -1,0 +1,4 @@
+jdbc.url = jdbc:vdb://localhost:9999/books
+jdbc.user = admin
+jdbc.password = ${denodo.password}
+jdbc.driver = com.denodo.vdp.jdbc.Driver

--- a/test/lightweight-tests/src/test/resources/dbconstraints/dbconstraints-denodo.properties
+++ b/test/lightweight-tests/src/test/resources/dbconstraints/dbconstraints-denodo.properties
@@ -1,0 +1,5 @@
+jdbc.url = jdbc:vdb://localhost:9999/dbconstr
+jdbc.user = admin
+jdbc.password = ${denodo.password}
+jdbc.driver = com.denodo.vdp.jdbc.Driver
+ontop.allowRetrievingBlackBoxViewMetadataFromDB = true

--- a/test/lightweight-tests/src/test/resources/prof/denodo/prof-denodo.properties
+++ b/test/lightweight-tests/src/test/resources/prof/denodo/prof-denodo.properties
@@ -1,0 +1,5 @@
+jdbc.url = jdbc:vdb://localhost:9999/university
+jdbc.user = admin
+jdbc.password = ${denodo.password}
+jdbc.driver = com.denodo.vdp.jdbc.Driver
+ontop.allowRetrievingBlackBoxViewMetadataFromDB = true

--- a/test/lightweight-tests/src/test/resources/university/university-denodo.properties
+++ b/test/lightweight-tests/src/test/resources/university/university-denodo.properties
@@ -1,0 +1,4 @@
+jdbc.url = jdbc:vdb://localhost:9999/university
+jdbc.user = admin
+jdbc.password = ${denodo.password}
+jdbc.driver = com.denodo.vdp.jdbc.Driver


### PR DESCRIPTION
- Added lightweight tests
- Did not add it to Github testing CI, because neither the Denodo Docker image, nor the Denodo JDBC are publicly accessible
- The directory lightweight-db-test-images/denodo instead contains database dumps exported from Denodo Express and a short guide on how to import them for testing.
- Added new normalizers because Denodo has the following special restrictions:
    - Order by clauses cannot contain complex expressions => instead use variable references
    - Limits cannot appear in sub-queries => remove them from sub-queries where valid
    - "IS NULL" cannot be called on disjunction/conjunction expressions => replace these expressions with "CASE" instead. 

All lightweight test cases that are not disabled in the corresponding classes passed during local testing.