### PR TITLE
Changed implementation of FlattenLens to no longer support extracting object elements

### DIFF
--- a/db/rdb/src/test/resources/person/nested_lenses.json
+++ b/db/rdb/src/test/resources/person/nested_lenses.json
@@ -1,11 +1,11 @@
 {
   "relations": [
     {
-      "name": ["\"hr\"","\"person-tags\""],
+      "name": ["\"hr\"","\"person-tags-flattened\""],
       "baseRelation": ["\"hr\"","\"person-xt\""],
       "flattenedColumn": {
         "name": "\"tags\"",
-        "datatype": "json"
+        "datatype": "jsonb"
       },
       "columns": {
         "kept": [
@@ -13,74 +13,70 @@
           "\"ssn\"",
           "\"fullName\""
         ],
-        "position": "\"pos\"",
-        "extracted": [
-          {
-            "name": "\"tag_str\"",
-            "datatype": "text"
-          },
-          {
-            "name": "\"tag_int\"",
-            "datatype": "integer"
-          }
-        ]
-      },
-      "uniqueConstraints": {
-        "added": []
-      },
-      "otherFunctionalDependencies": {
-        "added": []
-      },
-      "foreignKeys": {
-        "added": []
+        "new": "\"tag\"",
+        "position": "\"pos\""
       },
       "type": "FlattenLens"
     },
     {
-      "name": ["\"hr\"","\"persons-friends\""],
+      "name": ["\"hr\"","\"person-tags\""],
+      "baseRelation": ["\"hr\"","\"person-tags-flattened\""],
+      "columns": {
+        "added": [
+          {
+            "name": "\"tag_str\"",
+            "expression": "CASE WHEN jsonb_typeof(\"tag\") in ('boolean', 'string', 'number') THEN \"tag\"::text ELSE NULL END"
+          },
+          {
+            "name": "\"tag_int\"",
+            "expression": "CASE WHEN jsonb_typeof(\"tag\") = 'number' THEN \"tag\"::integer ELSE NULL END"
+          }
+        ],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"hr\"","\"persons-friends-flattened\""],
       "baseRelation": ["\"hr\"","\"person-xt\""],
       "flattenedColumn": {
         "name": "\"friends\"",
-        "datatype": "json"
+        "datatype": "jsonb"
       },
       "columns": {
         "kept": [
           "\"id\""
         ],
-        "position": "\"pos\"",
-        "extracted": [
+        "new": "\"friend\"",
+        "position": "\"pos\""
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["\"hr\"","\"persons-friends\""],
+      "baseRelation": ["\"hr\"","\"persons-friends-flattened\""],
+      "columns": {
+        "added": [
           {
             "name": "\"firstName\"",
-            "key": ["fName"],
-            "datatype": "text"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"friend\", 'fName')) in ('boolean', 'string', 'number') THEN jsonb_extract_path_text(\"friend\", 'fName')::text ELSE NULL END"
           },
           {
             "name": "\"nickNames\"",
-            "key": ["nickname"],
-            "datatype": "jsonb"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"friend\", 'nickname')) in ('boolean', 'string', 'number') THEN jsonb_extract_path(\"friend\", 'nickname') ELSE NULL END"
           },
           {
             "name": "\"nickName_str\"",
-            "key": ["nickname"],
-            "datatype": "text"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"friend\", 'nickname')) in ('boolean', 'string', 'number') THEN jsonb_extract_path_text(\"friend\", 'nickname')::text ELSE NULL END"
           },
           {
             "name": "\"city\"",
-            "key": ["address", "city"],
-            "datatype": "text"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"friend\", 'address', 'city')) in ('boolean', 'string', 'number') THEN jsonb_extract_path_text(\"friend\", 'address', 'city')::text ELSE NULL END"
           }
-        ]
+        ],
+        "hidden": []
       },
-      "uniqueConstraints": {
-        "added": []
-      },
-      "otherFunctionalDependencies": {
-        "added": []
-      },
-      "foreignKeys": {
-        "added": []
-      },
-      "type": "FlattenLens"
+      "type": "BasicLens"
     }
   ]
 }

--- a/test/docker-tests/src/test/resources/pgsql/nested/hr/hr_lenses_json.json
+++ b/test/docker-tests/src/test/resources/pgsql/nested/hr/hr_lenses_json.json
@@ -20,7 +20,7 @@
       "type": "BasicLens"
     },
     {
-      "name": ["\"hr\"","\"person-tags\""],
+      "name": ["\"hr\"","\"person-tags-flattened\""],
       "baseRelation": ["\"hr\"","\"person-json\""],
       "flattenedColumn": {
         "name": "\"tags\"",
@@ -33,31 +33,31 @@
           "\"fullname\"",
           "\"tags\""
         ],
-        "position": "\"pos\"",
-        "extracted": [
-          {
-            "name": "\"tag_str\"",
-            "datatype": "text"
-          },
-          {
-            "name": "\"tag_int\"",
-            "datatype": "integer"
-          }
-        ]
-      },
-      "uniqueConstraints": {
-        "added": []
-      },
-      "otherFunctionalDependencies": {
-        "added": []
-      },
-      "foreignKeys": {
-        "added": []
+        "new": "\"tag\"",
+        "position": "\"pos\""
       },
       "type": "FlattenLens"
     },
     {
-      "name": ["\"hr\"","\"persons-friends\""],
+      "name": ["\"hr\"","\"person-tags\""],
+      "baseRelation": ["\"hr\"","\"person-tags-flattened\""],
+      "columns": {
+        "added": [
+          {
+            "name": "\"tag_str\"",
+            "expression": "CASE WHEN json_typeof(\"tag\") in ('boolean', 'string', 'number') THEN \"tag\"::text ELSE NULL END"
+          },
+          {
+            "name": "\"tag_int\"",
+            "expression": "CASE WHEN json_typeof(\"tag\") = 'number' THEN \"tag\"::integer ELSE NULL END"
+          }
+        ],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"hr\"","\"persons-friends-flattened\""],
       "baseRelation": ["\"hr\"","\"person-json\""],
       "flattenedColumn": {
         "name": "\"friends\"",
@@ -67,40 +67,36 @@
         "kept": [
           "\"id\""
         ],
-        "position": "\"pos\"",
-        "extracted": [
+        "new": "\"friend\"",
+        "position": "\"pos\""
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["\"hr\"","\"persons-friends\""],
+      "baseRelation": ["\"hr\"","\"persons-friends-flattened\""],
+      "columns": {
+        "added": [
           {
             "name": "\"firstName\"",
-            "key": ["fName"],
-            "datatype": "text"
+            "expression": "CASE WHEN json_typeof(json_extract_path(\"friend\", 'fName')) in ('boolean', 'string', 'number') THEN json_extract_path_text(\"friend\", 'fName')::text ELSE NULL END"
           },
           {
             "name": "\"nickNames\"",
-            "key": ["nickname"],
-            "datatype": "json"
+            "expression": "CASE WHEN json_typeof(json_extract_path(\"friend\", 'nickname')) in ('boolean', 'string', 'number') THEN json_extract_path(\"friend\", 'nickname') ELSE NULL END"
           },
           {
             "name": "\"nickName_str\"",
-            "key": ["nickname"],
-            "datatype": "text"
+            "expression": "CASE WHEN json_typeof(json_extract_path(\"friend\", 'nickname')) in ('boolean', 'string', 'number') THEN json_extract_path_text(\"friend\", 'nickname')::text ELSE NULL END"
           },
           {
             "name": "\"city\"",
-            "key": ["address", "city"],
-            "datatype": "text"
+            "expression": "CASE WHEN json_typeof(json_extract_path(\"friend\", 'address', 'city')) in ('boolean', 'string', 'number') THEN json_extract_path_text(\"friend\", 'address', 'city')::text ELSE NULL END"
           }
-        ]
+        ],
+        "hidden": []
       },
-      "uniqueConstraints": {
-        "added": []
-      },
-      "otherFunctionalDependencies": {
-        "added": []
-      },
-      "foreignKeys": {
-        "added": []
-      },
-      "type": "FlattenLens"
+      "type": "BasicLens"
     }
   ]
 }

--- a/test/docker-tests/src/test/resources/pgsql/nested/hr/hr_lenses_jsonb.json
+++ b/test/docker-tests/src/test/resources/pgsql/nested/hr/hr_lenses_jsonb.json
@@ -1,7 +1,7 @@
 {
   "relations": [
     {
-      "name": ["\"hr\"","\"person-tags\""],
+      "name": ["\"hr\"","\"person-tags-flattened\""],
       "baseRelation": ["\"hr\"","\"person-xt\""],
       "flattenedColumn": {
         "name": "\"tags\"",
@@ -14,31 +14,31 @@
           "\"fullname\"",
           "\"tags\""
         ],
-        "position": "\"pos\"",
-        "extracted": [
-          {
-            "name": "\"tag_str\"",
-            "datatype": "text"
-          },
-          {
-            "name": "\"tag_int\"",
-            "datatype": "integer"
-          }
-        ]
-      },
-      "uniqueConstraints": {
-        "added": []
-      },
-      "otherFunctionalDependencies": {
-        "added": []
-      },
-      "foreignKeys": {
-        "added": []
+        "new": "\"tag\"",
+        "position": "\"pos\""
       },
       "type": "FlattenLens"
     },
     {
-      "name": ["\"hr\"","\"persons-friends\""],
+      "name": ["\"hr\"","\"person-tags\""],
+      "baseRelation": ["\"hr\"","\"person-tags-flattened\""],
+      "columns": {
+        "added": [
+          {
+            "name": "\"tag_str\"",
+            "expression": "CASE WHEN jsonb_typeof(\"tag\") in ('boolean', 'string', 'number') THEN \"tag\"::text ELSE NULL END"
+          },
+          {
+            "name": "\"tag_int\"",
+            "expression": "CASE WHEN jsonb_typeof(\"tag\") = 'number' THEN \"tag\"::integer ELSE NULL END"
+          }
+        ],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"hr\"","\"persons-friends-flattened\""],
       "baseRelation": ["\"hr\"","\"person-xt\""],
       "flattenedColumn": {
         "name": "\"friends\"",
@@ -48,40 +48,36 @@
         "kept": [
           "\"id\""
         ],
-        "position": "\"pos\"",
-        "extracted": [
+        "new": "\"friend\"",
+        "position": "\"pos\""
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["\"hr\"","\"persons-friends\""],
+      "baseRelation": ["\"hr\"","\"persons-friends-flattened\""],
+      "columns": {
+        "added": [
           {
             "name": "\"firstName\"",
-            "key": ["fName"],
-            "datatype": "text"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"friend\", 'fName')) in ('boolean', 'string', 'number') THEN jsonb_extract_path_text(\"friend\", 'fName')::text ELSE NULL END"
           },
           {
             "name": "\"nickNames\"",
-            "key": ["nickname"],
-            "datatype": "jsonb"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"friend\", 'nickname')) in ('boolean', 'string', 'number') THEN jsonb_extract_path(\"friend\", 'nickname') ELSE NULL END"
           },
           {
             "name": "\"nickName_str\"",
-            "key": ["nickname"],
-            "datatype": "text"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"friend\", 'nickname')) in ('boolean', 'string', 'number') THEN jsonb_extract_path_text(\"friend\", 'nickname')::text ELSE NULL END"
           },
           {
             "name": "\"city\"",
-            "key": ["address", "city"],
-            "datatype": "text"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"friend\", 'address', 'city')) in ('boolean', 'string', 'number') THEN jsonb_extract_path_text(\"friend\", 'address', 'city')::text ELSE NULL END"
           }
-        ]
+        ],
+        "hidden": []
       },
-      "uniqueConstraints": {
-        "added": []
-      },
-      "otherFunctionalDependencies": {
-        "added": []
-      },
-      "foreignKeys": {
-        "added": []
-      },
-      "type": "FlattenLens"
+      "type": "BasicLens"
     }
   ]
 }

--- a/test/docker-tests/src/test/resources/pgsql/nested/pub/debug.json
+++ b/test/docker-tests/src/test/resources/pgsql/nested/pub/debug.json
@@ -1,7 +1,7 @@
 {
   "relations": [
     {
-      "name": ["\"pub\"","\"author-pub\""],
+      "name": ["\"pub\"","\"author-pub-flattened\""],
       "baseRelation": ["\"pub\"","\"person\""],
       "flattenedColumn": {
         "name": "\"publication\"",
@@ -22,11 +22,6 @@
       },
       "uniqueConstraints": {
         "added": [
-          {
-            "name": "\"author_pub_pk\"",
-            "determinants" : [ "\"id\"", "\"id_pub\""],
-            "isPrimaryKey" : true
-          }
         ]
       },
       "otherFunctionalDependencies": {
@@ -41,7 +36,37 @@
               "columns": ["\"id\""],
               "relation": ["\"person\""]
             }
-          },
+          }
+      ]
+    },
+    "type": "FlattenLens"
+    },
+    {
+      "name": ["\"pub\"","\"author-pub\""],
+      "baseRelation": ["\"pub\"","\"author-pub-flattened\""],
+      "columns": {
+        "added": [
+          {
+            "name": "\"id_pub\"",
+            "expression": "CASE WHEN json_typeof(json_extract_path(\"publ\", 'id')) = 'number' THEN json_extract_path_text(\"publ\", 'id')::integer ELSE NULL END"
+          }
+        ],
+        "hidden": ["\"publ\""]
+      },
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "\"author_pub_pk\"",
+            "determinants" : [ "\"id\"", "\"id_pub\""],
+            "isPrimaryKey" : true
+          }
+        ]
+      },
+      "otherFunctionalDependencies": {
+        "added": []
+      },
+      "foreignKeys": {
+        "added": [
           {
             "name": "author_pub_fk_pub",
             "from": "\"id_pub\"",
@@ -50,9 +75,9 @@
               "relation": ["\"publication\""]
             }
           }
-      ]
-    },
-    "type": "FlattenLens"
+        ]
+      },
+      "type": "BasicLens"
     }
   ]
 }

--- a/test/docker-tests/src/test/resources/pgsql/nested/pub/er/pub_lenses_er.json
+++ b/test/docker-tests/src/test/resources/pgsql/nested/pub/er/pub_lenses_er.json
@@ -1,22 +1,52 @@
 {
   "relations": [
     {
-      "name": ["\"pub\"","\"author-pub\""],
+      "name": ["\"pub\"","\"publication-flattened\""],
       "baseRelation": ["\"pub\"","\"person\""],
       "flattenedColumn": {
         "name": "\"publication\"",
-        "datatype": "json"
+        "datatype": "jsonb"
       },
       "columns": {
         "kept": [
           "\"id\""
         ],
-        "extracted": [
+        "new": "\"publ\""
+      },
+      "uniqueConstraints": {
+        "added": [
+        ]
+      },
+      "otherFunctionalDependencies": {
+        "added": [
+        ]
+      },
+      "foreignKeys": {
+        "added": [
+          {
+            "name": "pub_fk_author",
+            "from": "\"id\"",
+            "to": {
+              "columns": ["\"id\""],
+              "relation": ["\"person\""]
+            }
+          }
+        ]
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["\"pub\"","\"author-pub\""],
+      "baseRelation": ["\"pub\"","\"publication-flattened\""],
+      "columns": {
+        "added": [
           {
             "name": "\"id_pub\"",
-            "key": ["id"],
-            "datatype": "integer"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"publ\", 'id')) = 'number' THEN jsonb_extract_path_text(\"publ\", 'id')::integer ELSE NULL END"
           }
+        ],
+        "hidden": [
+          "\"publ\""
         ]
       },
       "uniqueConstraints": {
@@ -32,56 +62,38 @@
         "added": []
       },
       "foreignKeys": {
-        "added": [
-          {
-            "name": "author_pub_fk_author",
-            "from": "\"id\"",
-            "to": {
-              "columns": ["\"id\""],
-              "relation": ["\"person\""]
-            }
-          }
-      ]
+        "added": []
+      },
+      "type": "BasicLens"
     },
-    "type": "FlattenLens"
-    },
-
     {
       "name": ["\"pub\"","\"publication\""],
-      "baseRelation": ["\"pub\"","\"person\""],
-      "flattenedColumn": {
-        "name": "\"publication\"",
-        "datatype": "json"
-      },
+      "baseRelation": ["\"pub\"","\"publication-flattened\""],
       "columns": {
-        "kept": [
-        ],
-        "extracted": [
+        "added": [
           {
             "name": "\"id_pub\"",
-            "key": ["id"],
-            "datatype": "integer"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"publ\", 'id')) = 'number' THEN jsonb_extract_path_text(\"publ\", 'id')::integer ELSE NULL END"
           },
           {
             "name": "\"title\"",
-            "key": ["title"],
-            "datatype": "text"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"publ\", 'title')) in ('boolean', 'string', 'number') THEN jsonb_extract_path_text(\"publ\", 'title')::text ELSE NULL END"
           },
           {
             "name": "\"year\"",
-            "key": ["year"],
-            "datatype": "integer"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"publ\", 'year')) = 'number' THEN jsonb_extract_path_text(\"publ\", 'year')::integer ELSE NULL END"
           },
           {
             "name": "\"venue\"",
-            "key": ["venue"],
-            "datatype": "text"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"publ\", 'venue')) in ('boolean', 'string', 'number') THEN jsonb_extract_path_text(\"publ\", 'venue')::text ELSE NULL END"
           },
           {
             "name": "\"editor\"",
-            "key": ["editor"],
-            "datatype": "json"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"publ\", 'editor')) = 'object' THEN jsonb_extract_path(\"publ\", 'editor')::jsonb ELSE NULL END"
           }
+        ],
+        "hidden": [
+          "\"publ\""
         ]
       },
       "uniqueConstraints": {
@@ -99,7 +111,7 @@
       "foreignKeys": {
         "added": []
       },
-      "type": "FlattenLens"
+      "type": "Basic"
     }
   ]
 }

--- a/test/docker-tests/src/test/resources/pgsql/nested/pub/pub_lenses.json
+++ b/test/docker-tests/src/test/resources/pgsql/nested/pub/pub_lenses.json
@@ -1,7 +1,7 @@
 {
   "relations": [
     {
-      "name": ["\"pub\"","\"publication\""],
+      "name": ["\"pub\"","\"publication-flattened\""],
       "baseRelation": ["\"pub\"","\"person\""],
       "flattenedColumn": {
         "name": "\"publication\"",
@@ -11,32 +11,58 @@
         "kept": [
           "\"id\""
         ],
-        "extracted": [
+        "new": "\"publ\""
+      },
+      "uniqueConstraints": {
+        "added": [
+        ]
+      },
+      "otherFunctionalDependencies": {
+        "added": [
+        ]
+      },
+      "foreignKeys": {
+        "added": [
+          {
+            "name": "pub_fk_author",
+            "from": "\"id\"",
+            "to": {
+              "columns": ["\"id\""],
+              "relation": ["\"person\""]
+            }
+          }
+      ]
+    },
+    "type": "FlattenLens"
+    },
+    {
+      "name": ["\"pub\"","\"publication\""],
+      "baseRelation": ["\"pub\"","\"publication-flattened\""],
+      "columns": {
+        "added": [
           {
             "name": "\"id_pub\"",
-            "key": ["id"],
-            "datatype": "integer"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"publ\", 'id')) = 'number' THEN jsonb_extract_path_text(\"publ\", 'id')::integer ELSE NULL END"
           },
           {
             "name": "\"title\"",
-            "key": ["title"],
-            "datatype": "text"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"publ\", 'title')) in ('boolean', 'string', 'number') THEN jsonb_extract_path_text(\"publ\", 'title')::text ELSE NULL END"
           },
           {
             "name": "\"year\"",
-            "key": ["year"],
-            "datatype": "integer"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"publ\", 'year')) = 'number' THEN jsonb_extract_path_text(\"publ\", 'year')::integer ELSE NULL END"
           },
           {
             "name": "\"venue\"",
-            "key": ["venue"],
-            "datatype": "text"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"publ\", 'venue')) in ('boolean', 'string', 'number') THEN jsonb_extract_path_text(\"publ\", 'venue')::text ELSE NULL END"
           },
           {
             "name": "\"editor\"",
-            "key": ["editor"],
-            "datatype": "jsonb"
+            "expression": "CASE WHEN jsonb_typeof(jsonb_extract_path(\"publ\", 'editor')) = 'object' THEN jsonb_extract_path(\"publ\", 'editor')::jsonb ELSE NULL END"
           }
+        ],
+        "hidden": [
+          "\"publ\""
         ]
       },
       "uniqueConstraints": {
@@ -54,17 +80,9 @@
       },
       "foreignKeys": {
         "added": [
-          {
-            "name": "pub_fk_author",
-            "from": "\"id\"",
-            "to": {
-              "columns": ["\"id\""],
-              "relation": ["\"person\""]
-            }
-          }
-      ]
-    },
-    "type": "FlattenLens"
+        ]
+      },
+      "type": "BasicLens"
     }
   ]
 }


### PR DESCRIPTION
If new columns are to be added from JSON object elements, this should now be done using a BasicLens above the FlattenLens. Instead, the FlattenLens now just adds one new column (name given in definition) that contains the flattened entries.

Also changed all existing test cases so that they conform to the new way of defining FlattenLenses.