### PR TITLE
Replaced the UUID constant function call with RAND

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DremioNonSimplifiableTypedNullFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DremioNonSimplifiableTypedNullFunctionSymbol.java
@@ -31,7 +31,7 @@ public class DremioNonSimplifiableTypedNullFunctionSymbol extends NonSimplifiabl
 
 
         var constant = castingType.getCategory() == DBTermType.Category.BOOLEAN ? termFactory.getDBBooleanConstant(false) :
-                termFactory.getDBCastFunctionalTerm(castingType, termFactory.getDBUUID(UUID.randomUUID()));
+                termFactory.getDBCastFunctionalTerm(castingType, termFactory.getDBRand(UUID.randomUUID()));
 
         var caseTerm = termFactory.getDBCaseElseNull(
                 Stream.of(Maps.immutableEntry(comparison, constant)),


### PR DESCRIPTION
We need to use some constant value cast to the target type as a workaround, so that Dremio does not optimize away the cast on NULL constants.
Previously, we used the UUID() function to get this constant value, as Dremio is less likely to optimize that compared to just using 0. 
However, UUID() is not supported by all Dremio versions. We now use RAND() instead to achieve the same goal.