### PR TITLE
XSD Cast Functions

### DIFF
--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/BindTest.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/BindTest.java
@@ -336,27 +336,23 @@ public class BindTest extends AbstractOWLAPITest {
     }
 
 
-    //CAST function not supported
-    //The builtin function http://www.w3.org/2001/XMLSchema#string is not supported yet!
-    @Test(expected = OntopReformulationException.class)
+    // NOTE: In H2 v2, we are forced to use DECIMAL(20, 6) because DECIMAL implies DECIMAL(*,0)
+    // Hence the result looks quite unusual having several 0-s before the concatenated string
+    @Test
     public void testBindWithCast() throws Throwable {
 
 		String queryBind = "PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
                 + "PREFIX  ns:  <http://example.org/ns#>\n"
                 + "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> \n"
-                + "SELECT  ?title ?price WHERE \n"
+                + "SELECT  ?title ?w WHERE \n"
                 + "{  ?x ns:price ?p .\n"
                 + "   ?x ns:discount ?discount\n"
-                + "   BIND (CONCAT(xsd:string(?p*(1-?discount)), xsd:string(?p)) AS ?price)\n"
+                + "   BIND (CONCAT(xsd:string(?p*(1-?discount)), xsd:string(?p)) AS ?w)\n"
                 + "   ?x dc:title ?title .\n"
                 + "}";
 
-        try {
-            checkReturnedValues(queryBind, "w", ImmutableList.of());
-        }
-        catch (OntopOWLException e) {
-            throw e.getCause();
-        }
+        checkReturnedValues(queryBind, "w", ImmutableList.of(
+                "\"33.60000000000042\"^^xsd:string", "\"17.25000000000023\"^^xsd:string"));
     }
 
     @Test

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/CastPrimitiveDatatypesTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/CastPrimitiveDatatypesTest.java
@@ -540,7 +540,7 @@ public class CastPrimitiveDatatypesTest extends AbstractRDF4JTest {
                 + "{  BIND(xsd:decimal(\"2E10\"^^xsd:double) AS ?v )\n"
                 + "}";
 
-        runQueryAndCompare(queryBind, ImmutableList.of("20000000000.000000"));
+        runQueryAndCompare(queryBind, ImmutableList.of());
     }
 
     @Test

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/CastPrimitiveDatatypesTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/CastPrimitiveDatatypesTest.java
@@ -1,0 +1,1729 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+/***
+ * Class to test if cast functions in SPARQL are working properly.
+ */
+public class CastPrimitiveDatatypesTest extends AbstractRDF4JTest {
+
+    private static final String OBDA_FILE = "/cast/cast.obda";
+    private static final String SQL_SCRIPT = "/cast/cast-schema.sql";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void testCastFloatFromFloat1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:float_label ?rating . "
+                + " BIND(xsd:float(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.1", "0.2", "0.3", "0.04", "5.05", "6.66"));
+    }
+
+    @Test
+    public void testCastFloatFromFloat2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"2.0654\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.0654"));
+    }
+
+    @Test
+    public void testCastFloatFromDouble1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:double_label ?rating . "
+                + " BIND(xsd:float(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.1", "0.2", "0.3", "0.04", "5.05", "6.66"));
+    }
+
+    @Test
+    public void testCastFloatFromDouble2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"0.0\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.0"));
+    }
+
+    @Test
+    public void testCastFloatFromDouble4() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"1.0E500\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("Infinity"));
+    }
+
+    @Test
+    public void testCastFloatFromDecimal1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:decimal_label ?rating . "
+                + " BIND(xsd:float(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.1", "0.2", "0.3", "0.04", "5.05", "6.66"));
+    }
+
+    @Test
+    public void testCastFloatFromDecimal2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"0.0\"^^xsd:decimal) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.0"));
+    }
+
+    @Test
+    public void testCastFloatFromInteger1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:integer_label ?rating . "
+                + " BIND(xsd:float(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.0", "0.0", "0.0", "0.0", "5.0", "7.0"));
+    }
+
+    @Test
+    public void testCastFloatFromInteger2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"91214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("91214.0"));
+    }
+
+    @Test
+    public void testCastFloatFromDateTime1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:datetime_label ?rating . "
+                + " BIND(xsd:float(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastFloatFromDateTime2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastFloatFromDate1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:date_label ?rating . "
+                + " BIND(xsd:float(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastFloatFromDate2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastFloatFromBoolean1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:boolean_label ?rating . "
+                + " BIND(xsd:float(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.0", "0.0", "0.0", "0.0", "1.0", "1.0"));
+    }
+
+    @Test
+    public void testCastFloatFromBoolean2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"true\"^^xsd:boolean) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1.0"));
+    }
+
+    @Test
+    public void testCastFloatFromString1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:string_label ?rating . "
+                + " BIND(xsd:float(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1.0", "2.0", "3.0"));
+    }
+
+    @Test
+    public void testCastFloatFromString2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"2.0654\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.0654"));
+    }
+
+    @Test
+    public void testCastFloatFromString3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"2\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.0"));
+    }
+
+    @Test
+    public void testCastFloatFromString4() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"abc\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDoubleFromFloat1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:float_label ?rating . "
+                + " BIND(xsd:double(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.1", "0.2", "0.3", "0.04", "5.05", "6.66"));
+    }
+
+    @Test
+    public void testCastDoubleFromFloat2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"2.6\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.6"));
+    }
+
+    @Test
+    public void testCastDoubleFromDouble1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:double_label ?rating . "
+                + " BIND(xsd:double(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.1", "0.2", "0.3", "0.04", "5.05", "6.66"));
+    }
+
+    @Test
+    public void testCastDoubleFromDouble2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"0.0\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.0"));
+    }
+
+    @Test
+    public void testCastDoubleFromDecimal1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:decimal_label ?rating . "
+                + " BIND(xsd:double(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.1", "0.2", "0.3", "0.04", "5.05", "6.66"));
+    }
+
+    @Test
+    public void testCastDoubleFromDecimal2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"0.0\"^^xsd:decimal) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.0"));
+    }
+
+    @Test
+    public void testCastDoubleFromInteger1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:integer_label ?rating . "
+                + " BIND(xsd:double(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.0", "0.0", "0.0", "0.0", "5.0", "7.0"));
+    }
+
+    @Test
+    public void testCastDoubleFromInteger2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"91214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("91214.0"));
+    }
+
+    @Test
+    public void testCastDoubleFromDateTime1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:datetime_label ?rating . "
+                + " BIND(xsd:double(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDoubleFromDateTime2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDoubleFromDate1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:date_label ?rating . "
+                + " BIND(xsd:double(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDoubleFromDate2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDoubleFromBoolean1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:boolean_label ?rating . "
+                + " BIND(xsd:double(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.0", "0.0", "0.0", "0.0", "1.0", "1.0"));
+    }
+
+    @Test
+    public void testCastDoubleFromBoolean2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"true\"^^xsd:boolean) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1.0"));
+    }
+
+    @Test
+    public void testCastDoubleFromString1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:string_label ?rating . "
+                + " BIND(xsd:double(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1.0", "2.0", "3.0"));
+    }
+
+    @Test
+    public void testCastDoubleFromString2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"2.0654\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.0654"));
+    }
+
+    @Test
+    public void testCastDoubleFromString3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"2\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.0"));
+    }
+
+    @Test
+    public void testCastDoubleFromString4() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"abc\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDecimalFromFloat1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:float_label ?rating . "
+                + " BIND(xsd:decimal(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.100000", "0.200000", "0.300000", "0.040000", "5.050000", "6.660000"));
+    }
+
+    @Test
+    public void testCastDecimalFromFloat2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"2.6\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.600000"));
+    }
+
+    @Test
+    public void testCastDecimalFromDouble1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:double_label ?rating . "
+                + " BIND(xsd:decimal(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.100000", "0.200000", "0.300000", "0.040000", "5.050000", "6.660000"));
+    }
+
+    @Test
+    public void testCastDecimalFromDouble2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"2.0654\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.065400"));
+    }
+
+    @Test
+    public void testCastDecimalFromDouble3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"2E10\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("20000000000.000000"));
+    }
+
+    @Test
+    public void testCastDecimalFromDecimal1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:decimal_label ?rating . "
+                + " BIND(xsd:decimal(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.100000", "0.200000", "0.300000", "0.040000", "5.050000", "6.660000"));
+    }
+
+    @Test
+    public void testCastDecimalFromDecimal2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"0.0\"^^xsd:decimal) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.0"));
+    }
+
+
+    @Test
+    public void testCastDecimalFromInteger1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:integer_label ?rating . "
+                + " BIND(xsd:decimal(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.000000", "0.000000", "0.000000", "0.000000", "5.000000", "7.000000"));
+    }
+
+    @Test
+    public void testCastDecimalFromInteger2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"19991214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("19991214.000000"));
+    }
+
+    @Test
+    public void testCastDecimalFromDateTime1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:datetime_label ?rating . "
+                + " BIND(xsd:decimal(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDecimalFromDateTime2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDecimalFromDate1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:date_label ?rating . "
+                + " BIND(xsd:decimal(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDecimalFromDate2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDecimalFromBoolean1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:boolean_label ?rating . "
+                + " BIND(xsd:decimal(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.0", "0.0", "0.0", "0.0", "1.0", "1.0"));
+    }
+
+    @Test
+    public void testCastDecimalFromBoolean2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"true\"^^xsd:boolean) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1.0"));
+    }
+
+    @Test
+    public void testCastDecimalFromString1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:string_label ?rating . "
+                + " BIND(xsd:decimal(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1.000000", "2.000000", "3.000000"));
+    }
+
+    @Test
+    public void testCastDecimalFromString2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"2.0654\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.065400"));
+    }
+
+    @Test
+    public void testCastDecimalFromString3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"2\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.000000"));
+    }
+
+    @Test
+    public void testCastDecimalFromString4() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"abc\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastIntegerFromFloat1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:float_label ?rating . "
+                + " BIND(xsd:integer(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0", "0", "0", "0", "5", "6"));
+    }
+
+    @Test
+    public void testCastIntegerFromFloat2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"2.0654\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2"));
+    }
+
+    @Test
+    public void testCastIntegerFromFloat3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"2.6\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2"));
+    }
+
+    @Test
+    public void testCastIntegerFromFloat4() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"-2.6\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("-2"));
+    }
+
+    @Test
+    public void testCastIntegerFromDouble1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:double_label ?rating . "
+                + " BIND(xsd:integer(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0", "0", "0", "0", "5", "6"));
+    }
+
+    @Test
+    public void testCastIntegerFromDouble2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"0.0\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0"));
+    }
+
+    @Test
+    public void testCastIntegerFromDouble3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"0\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0"));
+    }
+
+    @Test
+    public void testCastIntegerFromDecimal1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:decimal_label ?rating . "
+                + " BIND(xsd:integer(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0", "0", "0", "0", "5", "6"));
+    }
+
+    @Test
+    public void testCastIntegerFromDecimal2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"0.0\"^^xsd:decimal) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0"));
+    }
+
+    @Test
+    public void testCastIntegerFromInteger1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:integer_label ?rating . "
+                + " BIND(xsd:integer(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0", "0", "0", "0", "5", "7"));
+    }
+
+    @Test
+    public void testCastIntegerFromInteger2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"19991214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("19991214"));
+    }
+
+    @Test
+    public void testCastIntegerFromDateTime1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:datetime_label ?rating . "
+                + " BIND(xsd:integer(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastIntegerFromDateTime2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastIntegerFromDate1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:date_label ?rating . "
+                + " BIND(xsd:integer(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastIntegerFromDate2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastIntegerFromBoolean1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:boolean_label ?rating . "
+                + " BIND(xsd:integer(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0", "0", "0", "0", "1", "1"));
+    }
+
+    @Test
+    public void testCastIntegerFromBoolean2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"true\"^^xsd:boolean) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1"));
+    }
+
+    @Test
+    public void testCastIntegerFromString1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:string_label ?rating . "
+                + " BIND(xsd:integer(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1", "2", "3"));
+    }
+
+    @Test
+    public void testCastIntegerFromString2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"2.0654\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2"));
+    }
+
+    @Test
+    public void testCastIntegerFromString3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"2.5\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2"));
+    }
+
+    @Test
+    public void testCastIntegerFromString4() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"abc\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastBooleanFromFloat1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:float_label ?rating . "
+                + " BIND(xsd:boolean(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("true", "true", "true", "true", "true", "true"));
+    }
+
+    @Test
+    public void testCastBooleanFromFloat2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"2.0654\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("true"));
+    }
+
+    @Test
+    public void testCastBooleanFromDouble1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:double_label ?rating . "
+                + " BIND(xsd:boolean(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("true", "true", "true", "true", "true", "true"));
+    }
+
+    @Test
+    public void testCastBooleanFromDouble2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"0.0\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("false"));
+    }
+
+    @Test
+    public void testCastBooleanFromDecimal1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:decimal_label ?rating . "
+                + " BIND(xsd:boolean(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("true", "true", "true", "true", "true", "true"));
+    }
+
+    @Test
+    public void testCastBooleanFromDecimal2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"0.0\"^^xsd:decimal) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("false"));
+    }
+
+    @Test
+    public void testCastBooleanFromInteger1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:integer_label ?rating . "
+                + " BIND(xsd:boolean(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("false", "false", "false", "false", "true", "true"));
+    }
+
+    @Test
+    public void testCastBooleanFromInteger2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"19991214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("true"));
+    }
+
+    @Test
+    public void testCastBooleanFromDateTime1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:datetime_label ?rating . "
+                + " BIND(xsd:integer(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastBooleanFromDateTime2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastBooleanFromDate1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:date_label ?rating . "
+                + " BIND(xsd:integer(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastBooleanFromDate2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastBooleanFromBoolean1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:boolean_label ?rating . "
+                + " BIND(xsd:boolean(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("false", "false", "false", "false", "true", "true"));
+    }
+
+    @Test
+    public void testCastBooleanFromBoolean2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"true\"^^xsd:boolean) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("true"));
+    }
+
+    @Test
+    public void testCastBooleanFromString1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:string_label ?rating . "
+                + " BIND(xsd:boolean(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("true"));
+    }
+
+
+    @Test
+    public void testCastBooleanFromString2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"2.0654\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastBooleanFromString3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"1\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("true"));
+    }
+
+
+    @Test
+    public void testCastBooleanFromString4() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"false\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("false"));
+    }
+
+    @Test
+    public void testCastStringFromFloat1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:float_label ?rating . "
+                + " BIND(xsd:string(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.1", "0.2", "0.3", "0.04", "5.05", "6.66"));
+    }
+
+    @Test
+    public void testCastStringFromFloat2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"2.0654\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.0654"));
+    }
+
+    @Test
+    public void testCastStringFromDouble1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:double_label ?rating . "
+                + " BIND(xsd:string(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.1", "0.2", "0.3", "0.04", "5.05", "6.66"));
+    }
+
+    @Test
+    public void testCastStringFromDouble2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"0.0\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.0"));
+    }
+
+    //NOTE: H2 does not support the Mantissa
+    @Test
+    public void testCastStringFromDouble3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"1000001.0\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1000001.0"));
+    }
+
+    @Test
+    public void testCastStringFromDecimal1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:decimal_label ?rating . "
+                + " BIND(xsd:string(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.1", "0.2", "0.3", "0.04", "5.05", "6.66"));
+    }
+
+    @Test
+    public void testCastStringFromDecimal2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"2.0\"^^xsd:decimal) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.0"));
+    }
+
+    @Test
+    public void testCastStringFromDecimal3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"1.5\"^^xsd:decimal) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1.5"));
+    }
+
+    @Test
+    public void testCastStringFromInteger1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:integer_label ?rating . "
+                + " BIND(xsd:string(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0", "0", "0", "0", "5", "7"));
+    }
+
+    @Test
+    public void testCastStringFromInteger2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"19991214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("19991214"));
+    }
+
+    @Ignore("Handling of timezones varies based on local system")
+    @Test
+    public void testCastStringFromDateTime1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:datetime_label ?rating . "
+                + " BIND(xsd:string(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-10T09:00:00.000+01:00", "1998-12-10T09:15:00.000+01:00",
+                "1997-12-13T11:00:06.000+01:00"));
+    }
+
+    @Test
+    public void testCastStringFromDateTime2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-14T09:30:00"));
+    }
+
+    @Test
+    public void testCastStringFromDate() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:date_label ?rating . "
+                + " BIND(xsd:string(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-10", "1998-12-10", "1997-12-13"));
+    }
+
+    @Test
+    public void testCastStringFromDate2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-14"));
+    }
+
+    @Test
+    public void testCastStringFromBoolean1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:boolean_label ?rating . "
+                + " BIND(xsd:string(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("false", "false", "false", "false", "true", "true"));
+    }
+
+    @Test
+    public void testCastStringFromBoolean2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"true\"^^xsd:boolean) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("true"));
+    }
+
+    @Test
+    public void testCastStringFromString1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:string_label ?rating . "
+                + " BIND(xsd:string(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("A", "B", "C", "1", "2", "3"));
+    }
+
+    @Test
+    public void testCastStringFromString2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"2.0654\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("2.0654"));
+    }
+
+    @Test
+    public void testCastStringFromString3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"abc\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("abc"));
+    }
+
+    @Test
+    public void testCastStringFromIRI() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"http://www.w3.org/2001/XMLSchema#string\") AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("http://www.w3.org/2001/XMLSchema#string"));
+    }
+
+    @Test
+    public void testCastStringFromLiteral() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"abc\"^^rdfs:literal) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("abc"));
+    }
+
+    @Ignore("H2 limitations in possible datetime pattern casts and datetime pattern checks")
+    @Test
+    public void testCastDateFromDateTime1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:datetime_label ?rating . "
+                + " BIND(xsd:date(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-10", "1998-12-10", "1997-12-13"));
+    }
+
+
+    @Test
+    public void testCastDateFromDateTime2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:date(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(query, ImmutableList.of("1999-12-14"));
+    }
+
+    @Test
+    public void testCastDateFromDate1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:date_label ?rating . "
+                + " BIND(xsd:date(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-10", "1998-12-10", "1997-12-13"));
+    }
+
+    @Test
+    public void testCastDateFromDate2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:date(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-14"));
+    }
+
+
+    @Test
+    public void testCastDateFromString1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:datestring_label ?rating . "
+                + " BIND(xsd:date(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-10", "1998-12-10", "1997-12-13"));
+    }
+
+
+    @Test
+    public void testCastDateFromString2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:date(\"1999-12-14\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-14"));
+    }
+
+    @Test
+    public void testCastDateFromString3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:date(\"199912-14\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDateFromInteger() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:date(\"19991214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDateFromDouble() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:date(\"19991214.12\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+
+    @Ignore("Handling of timezones varies based on local system")
+    @Test
+    public void testCastDateTimeFromDateTime1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:datetime_label ?rating . "
+                + " BIND(xsd:dateTime(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-10T09:00:00.000+01:00", "1998-12-10T09:15:00.000+01:00",
+                "1997-12-13T11:00:06.000+01:00"));
+    }
+
+
+    @Test
+    public void testCastDateTimeFromDateTime2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-14T09:30:00"));
+    }
+
+
+    @Test
+    public void testCastDateTimeFromDate1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:date_label ?rating . "
+                + " BIND(xsd:dateTime(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-10 00:00:00", "1998-12-10 00:00:00",
+                "1997-12-13 00:00:00"));
+    }
+
+
+    @Test
+    public void testCastDateTimeFromDate2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-14 00:00:00"));
+    }
+
+    @Ignore("H2 limitations in possible datetime pattern casts and datetime pattern checks")
+    @Test
+    public void testCastDateTimeFromDate3() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"1999-12-14Z\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-14T00:00:00+00:00"));
+    }
+
+    @Ignore("H2 limitations in possible datetime pattern casts and datetime pattern checks")
+    @Test
+    public void testCastDateTimeFromDate4() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"1999-12-14+01:00\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-14T00:00:00+01:00"));
+    }
+
+
+    @Ignore("H2 limitations in possible datetime pattern casts and datetime pattern checks")
+    @Test
+    public void testCastDateTimeFromString1() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:datetimestring_label ?rating . "
+                + " BIND(xsd:dateTime(?rating) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-10 11:00:00+03", "1998-12-10 11:15:00+03",
+                "1997-12-13 11:00:06"));
+    }
+
+
+    @Test
+    public void testCastDateTimeFromString2() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"1999-12-14T09:30:00\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1999-12-14 09:30:00"));
+    }
+
+    @Test
+    public void testCastDateTimeFromInteger() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"19991214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Test
+    public void testCastDateTimeFromDouble() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"19991214.12\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of());
+    }
+
+    @Ignore
+    @Test
+    public void testDatatypeCast() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x a ex:Individual . "
+                + " ?x ex:string_label ?v . "
+                + " FILTER(DATATYPE(xsd:integer(?v)) = xsd:integer )\n"
+                + "}";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("1", "2", "3"));
+    }
+
+    @Test
+    public void testCoalesceCast() {
+
+        String queryBind = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX ex: <http://example.org/>\n"
+                + "SELECT ?x (AVG(IF(ISNUMERIC(?string_rating), ?string_rating, COALESCE(xsd:integer(?string_rating), 0))) AS ?v) WHERE {\n"
+                + " ?x ex:string_label ?string_rating . "
+                + "}\n"
+                + "GROUP BY ?x";
+
+        runQueryAndCompare(queryBind, ImmutableList.of("0.0000000000", "0.0000000000", "0.0000000000", "1.0000000000",
+                "2.0000000000", "3.0000000000"));
+    }
+}

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/CastPrimitiveDatatypesTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/CastPrimitiveDatatypesTest.java
@@ -1698,7 +1698,6 @@ public class CastPrimitiveDatatypesTest extends AbstractRDF4JTest {
         runQueryAndCompare(queryBind, ImmutableList.of());
     }
 
-    @Ignore
     @Test
     public void testDatatypeCast() {
 

--- a/binding/rdf4j/src/test/resources/cast/cast-schema.sql
+++ b/binding/rdf4j/src/test/resources/cast/cast-schema.sql
@@ -1,0 +1,52 @@
+CREATE TABLE ratings (
+                         ID serial PRIMARY KEY,
+                         rating_string VARCHAR (1) NOT NULL );
+INSERT INTO ratings (id, rating_string) VALUES (1, 'A'), (2, 'B'), (3, 'C'), (4, 1), (5, 2), (6, 3);
+
+CREATE TABLE ratings_float (
+                               ID serial PRIMARY KEY,
+                               rating_float FLOAT NOT NULL );
+
+INSERT INTO ratings_float (ID, rating_float) VALUES (1, 0.1), (2, 0.2), (3, 0.3), (4, 0.04), (5, 5.05), (6, 6.66);
+
+CREATE TABLE ratings_double (
+                                ID serial PRIMARY KEY,
+                                rating_double DOUBLE PRECISION NOT NULL );
+INSERT INTO ratings_double (ID, rating_double) VALUES (1, 0.1), (2, 0.2), (3, 0.3), (4, 0.04), (5, 5.05), (6, 6.66);
+
+CREATE TABLE ratings_decimal (
+                                 ID serial PRIMARY KEY,
+                                 rating_decimal DOUBLE PRECISION NOT NULL );
+INSERT INTO ratings_decimal (ID, rating_decimal) VALUES (1, 0.1), (2, 0.2), (3, 0.3), (4, 0.04), (5, 5.05), (6, 6.66);
+
+CREATE TABLE ratings_integer (
+                                 ID serial PRIMARY KEY,
+                                 rating_integer BIGINT NOT NULL );
+INSERT INTO ratings_integer (ID, rating_integer) VALUES (1, 0), (2, 0), (3, 0), (4, 0), (5, 5), (6, 7);
+
+CREATE TABLE ratings_boolean (
+                                 ID serial PRIMARY KEY,
+                                 rating_boolean BOOLEAN NOT NULL );
+INSERT INTO ratings_boolean (ID, rating_boolean) VALUES (1, FALSE), (2, FALSE), (3, FALSE), (4, FALSE), (5, TRUE), (6, TRUE);
+
+CREATE TABLE dates (
+                       ID serial PRIMARY KEY,
+                       finaldate DATE NOT NULL );
+INSERT INTO dates (ID, finaldate) VALUES (1, '1999-12-10'), (2, '1998-12-10'), (3, '1997-12-13');
+
+CREATE TABLE dates_string (
+                              ID serial PRIMARY KEY,
+                              finaldate VARCHAR (10) NOT NULL );
+INSERT INTO dates_string (ID, finaldate) VALUES (1, '1999-12-10'), (2, '1998-12-10'), (3, '1997-12-13'), (4, 1), (5, 2), (6, 3);
+
+CREATE TABLE datetimes (
+                           ID serial PRIMARY KEY,
+                           finaldatetime TIMESTAMP NOT NULL );
+INSERT INTO datetimes (ID, finaldatetime) VALUES (1, '1999-12-10 11:00:00+03'), (2, '1998-12-10 11:15:00+03'),
+                                                 (3, '1997-12-13 11:00:06');
+
+CREATE TABLE datetimes_string (
+                                  ID serial PRIMARY KEY,
+                                  finaldatetime VARCHAR (25) NOT NULL );
+INSERT INTO datetimes_string (ID, finaldatetime) VALUES (1, '1999-12-10 11:00:00+03'), (2, '1998-12-10 11:15:00+03'),
+                                                        (3, '1997-12-13 11:00:06'), (4, 1), (5, 2), (6, 3);

--- a/binding/rdf4j/src/test/resources/cast/cast.obda
+++ b/binding/rdf4j/src/test/resources/cast/cast.obda
@@ -1,0 +1,48 @@
+[PrefixDeclaration]
+ex: http://example.org/
+rdfs: http://www.w3.org/2000/01/rdf-schema#
+rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+
+[MappingDeclaration] @collection [[
+
+mappingId   ratings
+target      ex:{id} a ex:Individual ; ex:string_label {rating_string} .
+source      SELECT id, rating_string FROM ratings
+
+mappingId   ratings_float
+target      ex:{id} a ex:Individual ; ex:float_label {rating_float} .
+source      SELECT id, rating_float FROM ratings_float
+
+mappingId   ratings_double
+target      ex:{id} a ex:Individual ; ex:double_label {rating_double} .
+source      SELECT id, rating_double FROM ratings_double
+
+mappingId   ratings_decimal
+target      ex:{id} a ex:Individual ; ex:decimal_label {rating_decimal} .
+source      SELECT id, rating_decimal FROM ratings_decimal
+
+mappingId   ratings_integer
+target      ex:{id} a ex:Individual ; ex:integer_label {rating_integer} .
+source      SELECT id, rating_integer FROM ratings_integer
+
+mappingId   ratings_boolean
+target      ex:{id} a ex:Individual ; ex:boolean_label {rating_boolean} .
+source      SELECT id, rating_boolean FROM ratings_boolean
+
+mappingId   ratings_date
+target      ex:{id} a ex:Individual ; ex:date_label {finaldate} .
+source      SELECT id, finaldate FROM dates
+
+mappingId   ratings_datetime
+target      ex:{id} a ex:Individual ; ex:datetime_label {finaldatetime} .
+source      SELECT id, finaldatetime FROM datetimes
+
+mappingId   ratings_date_string
+target      ex:{id} a ex:Individual ; ex:datestring_label {finaldate} .
+source      SELECT id, finaldate FROM dates_string
+
+mappingId   ratings_datetime_string
+target      ex:{id} a ex:Individual ; ex:datetimestring_label {finaldatetime} .
+source      SELECT id, finaldatetime FROM datetimes_string
+
+]]

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/DBFunctionSymbolFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/DBFunctionSymbolFactory.java
@@ -370,4 +370,22 @@ public interface DBFunctionSymbolFactory {
 
     IRISafenessDeclarationFunctionSymbol getIRISafenessDeclaration();
 
+    // RDF XSD Cast
+
+    DBFunctionSymbol checkAndConvertBoolean();
+    DBFunctionSymbol checkAndConvertBooleanFromString();
+    DBFunctionSymbol checkAndConvertDouble();
+    DBFunctionSymbol checkAndConvertFloat();
+    DBFunctionSymbol checkAndConvertFloatFromBoolean();
+    DBFunctionSymbol checkAndConvertFloatFromDouble();
+    DBFunctionSymbol checkAndConvertFloatFromNonFPNumeric();
+    DBFunctionSymbol checkAndConvertDecimal();
+    DBFunctionSymbol checkAndConvertDecimalFromBoolean();
+    DBFunctionSymbol checkAndConvertInteger();
+    DBFunctionSymbol checkAndConvertIntegerFromBoolean();
+    DBFunctionSymbol checkAndConvertStringFromDecimal();
+    DBFunctionSymbol checkAndConvertDateTimeFromDate();
+    DBFunctionSymbol checkAndConvertDateTimeFromString();
+    DBFunctionSymbol checkAndConvertDateFromDatetime();
+    DBFunctionSymbol checkAndConvertDateFromString();
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractDBFunctionSymbolFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractDBFunctionSymbolFactory.java
@@ -131,6 +131,23 @@ public abstract class AbstractDBFunctionSymbolFactory implements DBFunctionSymbo
     private final Map<DBTermType, DBBooleanFunctionSymbol> jsonIsNumberMap;
     private final Map<DBTermType, DBBooleanFunctionSymbol> isArrayMap;
 
+    private DBFunctionSymbol checkAndConvertBooleanFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertBooleanFromStringFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertDoubleFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertFloatFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertFloatFromBooleanFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertFloatFromDoubleFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertFloatFromNonFPNumericFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertDecimalFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertDecimalFromBooleanFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertIntegerFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertIntegerFromBooleanFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertStringFromDecimalFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertDateTimeFromDateFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertDateTimeFromStringFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertDateFromDateTimeFunctionSymbol;
+    private DBFunctionSymbol checkAndConvertDateFromStringFunctionSymbol;
+
     /**
      *  For conversion function symbols that are SIMPLE CASTs from an undetermined type (no normalization)
      */
@@ -258,6 +275,9 @@ public abstract class AbstractDBFunctionSymbolFactory implements DBFunctionSymbo
     private final DBTermType dbBooleanType;
     private final DBTermType dbIntegerType;
     private final DBTermType dbDecimalType;
+    private final DBTermType dbDoubleType;
+    private final DBTermType dbDateTimestampType;
+    private final DBTermType dbDateType;
 
     /**
      * Name (in the DB dialect), arity -> not predefined untyped DBFunctionSymbol
@@ -301,6 +321,9 @@ public abstract class AbstractDBFunctionSymbolFactory implements DBFunctionSymbo
         this.dbBooleanType = dbTypeFactory.getDBBooleanType();
         this.dbIntegerType = dbTypeFactory.getDBLargeIntegerType();
         this.dbDecimalType = dbTypeFactory.getDBDecimalType();
+        this.dbDoubleType = dbTypeFactory.getDBDoubleType();
+        this.dbDateTimestampType = dbTypeFactory.getDBDateTimestampType();
+        this.dbDateType = dbTypeFactory.getDBDateType();
 
         // NB: in terms of design, we prefer avoiding using tables as they are not thread-safe
         this.binaryMathTable = HashBasedTable.create();
@@ -422,6 +445,23 @@ public abstract class AbstractDBFunctionSymbolFactory implements DBFunctionSymbo
         rowNumberFct = createDBRowNumber();
         rowNumberWithOrderByFct = createDBRowNumberWithOrderBy();
         iriSafenessDeclarationFunctionSymbol = new IRISafenessDeclarationFunctionSymbolImpl(rootDBType);
+
+        checkAndConvertDateFromDateTimeFunctionSymbol = createCheckAndConvertDateFromDateTimeFunctionSymbol();
+        checkAndConvertDateFromStringFunctionSymbol = createCheckAndConvertDateFromStringFunctionSymbol();
+        checkAndConvertBooleanFunctionSymbol = createCheckAndConvertBooleanFunctionSymbol();
+        checkAndConvertBooleanFromStringFunctionSymbol = createCheckAndConvertBooleanFromStringFunctionSymbol();
+        checkAndConvertIntegerFunctionSymbol = createCheckAndConvertIntegerFunctionSymbol();
+        checkAndConvertIntegerFromBooleanFunctionSymbol = createCheckAndConvertIntegerFromBooleanFunctionSymbol();
+        checkAndConvertDecimalFunctionSymbol = createCheckAndConvertDecimalFunctionSymbol();
+        checkAndConvertDecimalFromBooleanFunctionSymbol = createCheckAndConvertDecimalFromBooleanFunctionSymbol();
+        checkAndConvertDoubleFunctionSymbol = createCheckAndConvertDoubleFunctionSymbol();
+        checkAndConvertFloatFunctionSymbol = createCheckAndConvertFloatFunctionSymbol();
+        checkAndConvertFloatFromBooleanFunctionSymbol = createCheckAndConvertFloatFromBooleanFunctionSymbol();
+        checkAndConvertFloatFromDoubleFunctionSymbol = createCheckAndConvertFloatFromDoubleFunctionSymbol();
+        checkAndConvertFloatFromNonFPNumericFunctionSymbol = createCheckAndConvertFloatFromNonFPNumericFunctionSymbol();
+        checkAndConvertStringFromDecimalFunctionSymbol = createCheckAndConvertStringFromDecimalFunctionSymbol();
+        checkAndConvertDateTimeFromDateFunctionSymbol = createCheckAndConvertDateTimeFromDateFunctionSymbol();
+        checkAndConvertDateTimeFromStringFunctionSymbol = createCheckAndConvertDateTimeFromStringFunctionSymbol();
     }
 
     protected ImmutableMap<DBTermType, DBTypeConversionFunctionSymbol> createNormalizationMap() {
@@ -1112,6 +1152,54 @@ public abstract class AbstractDBFunctionSymbolFactory implements DBFunctionSymbo
         return iriSafenessDeclarationFunctionSymbol;
     }
 
+    @Override
+    public DBFunctionSymbol checkAndConvertBoolean() { return checkAndConvertBooleanFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertBooleanFromString() { return checkAndConvertBooleanFromStringFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertDouble() { return checkAndConvertDoubleFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertFloat() { return checkAndConvertFloatFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertFloatFromBoolean() { return checkAndConvertFloatFromBooleanFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertFloatFromDouble() { return checkAndConvertFloatFromDoubleFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertFloatFromNonFPNumeric() { return checkAndConvertFloatFromNonFPNumericFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertDecimal() { return checkAndConvertDecimalFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertDecimalFromBoolean() { return checkAndConvertDecimalFromBooleanFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertInteger() { return checkAndConvertIntegerFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertIntegerFromBoolean() { return checkAndConvertIntegerFromBooleanFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertStringFromDecimal() { return checkAndConvertStringFromDecimalFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertDateTimeFromDate() { return checkAndConvertDateTimeFromDateFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertDateTimeFromString() { return checkAndConvertDateTimeFromStringFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertDateFromDatetime() { return checkAndConvertDateFromDateTimeFunctionSymbol; }
+
+    @Override
+    public DBFunctionSymbol checkAndConvertDateFromString() { return checkAndConvertDateFromStringFunctionSymbol; }
+
     protected abstract DBFunctionSymbol createDBCount(boolean isUnary, boolean isDistinct);
     protected abstract DBFunctionSymbol createDBSum(DBTermType termType, boolean isDistinct);
     protected abstract DBFunctionSymbol createDBAvg(DBTermType termType, boolean isDistinct);
@@ -1253,7 +1341,7 @@ public abstract class AbstractDBFunctionSymbolFactory implements DBFunctionSymbo
     }
 
     protected DBFunctionSymbol createDayFromDatetimeFunctionSymbol() {
-        return new UnaryDBFunctionSymbolWithSerializerImpl("DB_DAY_FROM_DATE", rootDBType, dbIntegerType, false,
+        return new UnaryDBFunctionSymbolWithSerializerImpl("DB_DAY_FROM_DATETIME", rootDBType, dbIntegerType, false,
                 this::serializeDayFromDatetime);
     }
 
@@ -1562,6 +1650,155 @@ public abstract class AbstractDBFunctionSymbolFactory implements DBFunctionSymbo
 
     protected DBBooleanFunctionSymbol createJsonIsScalar(DBTermType dbType) {
         throw new UnsupportedOperationException("Unsupported JSON-like datatype: " + dbType.getName());
+    }
+
+    /**
+     * SPARQL XSD cast functions
+     */
+    protected abstract String serializeCheckAndConvertBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                              Function<ImmutableTerm, String> termConverter,
+                                                              TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertBooleanFromString(ImmutableList<? extends ImmutableTerm> terms,
+                                                                        Function<ImmutableTerm, String> termConverter,
+                                                                        TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
+                                                             Function<ImmutableTerm, String> termConverter,
+                                                             TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertFloat(ImmutableList<? extends ImmutableTerm> terms,
+                                                            Function<ImmutableTerm, String> termConverter,
+                                                            TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertFloatFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                                       Function<ImmutableTerm, String> termConverter,
+                                                                       TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertFloatFromDouble(ImmutableList<? extends ImmutableTerm> terms,
+                                                                      Function<ImmutableTerm, String> termConverter,
+                                                                      TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertFloatFromNonFPNumeric(ImmutableList<? extends ImmutableTerm> terms,
+                                                                            Function<ImmutableTerm, String> termConverter,
+                                                                            TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
+                                                              Function<ImmutableTerm, String> termConverter,
+                                                              TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertDecimalFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                                         Function<ImmutableTerm, String> termConverter,
+                                                                         TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertInteger(ImmutableList<? extends ImmutableTerm> terms,
+                                                              Function<ImmutableTerm, String> termConverter,
+                                                              TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertIntegerFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                                         Function<ImmutableTerm, String> termConverter,
+                                                                         TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertStringFromDecimal(ImmutableList<? extends ImmutableTerm> terms,
+                                                                        Function<ImmutableTerm, String> termConverter,
+                                                                        TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertDateTimeFromDate(ImmutableList<? extends ImmutableTerm> terms,
+                                                                       Function<ImmutableTerm, String> termConverter,
+                                                                       TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertDateTimeFromString(ImmutableList<? extends ImmutableTerm> terms,
+                                                                         Function<ImmutableTerm, String> termConverter,
+                                                                         TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertDateFromDateTime(ImmutableList<? extends ImmutableTerm> terms,
+                                                                       Function<ImmutableTerm, String> termConverter,
+                                                                       TermFactory termFactory);
+
+    protected abstract String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
+                                                                     Function<ImmutableTerm, String> termConverter,
+                                                                     TermFactory termFactory);
+
+    protected DBFunctionSymbol createCheckAndConvertBooleanFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_BOOLEAN", rootDBType, dbBooleanType, false,
+                this::serializeCheckAndConvertBoolean);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertBooleanFromStringFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_BOOLEAN_FROM_STRING", dbStringType, dbBooleanType, false,
+                this::serializeCheckAndConvertBooleanFromString);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertDoubleFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_DOUBLE", rootDBType, dbDoubleType, false,
+                this::serializeCheckAndConvertDouble);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertFloatFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_FLOAT", rootDBType, dbDoubleType, false,
+                this::serializeCheckAndConvertFloat);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertFloatFromBooleanFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_FLOAT_FROM_BOOLEAN", dbBooleanType, dbDoubleType, false,
+                this::serializeCheckAndConvertFloatFromBoolean);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertFloatFromDoubleFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_FLOAT_FROM_DOUBLE", dbDoubleType, dbDoubleType, false,
+                this::serializeCheckAndConvertFloatFromDouble);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertFloatFromNonFPNumericFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_FLOAT_FROM_NONFPNUMERIC", rootDBType, dbDoubleType, false,
+                this::serializeCheckAndConvertFloatFromNonFPNumeric);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertDecimalFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_DECIMAL", rootDBType, dbDecimalType, false,
+                this::serializeCheckAndConvertDecimal);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertDecimalFromBooleanFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_DECIMAL_FROM_BOOLEAN", dbBooleanType, dbDecimalType, false,
+                this::serializeCheckAndConvertDecimalFromBoolean);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertIntegerFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_INTEGER", rootDBType, dbIntegerType, false,
+                this::serializeCheckAndConvertInteger);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertIntegerFromBooleanFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_INTEGER_FROM_BOOLEAN", dbBooleanType, dbIntegerType, false,
+                this::serializeCheckAndConvertIntegerFromBoolean);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertStringFromDecimalFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_STRING_FROM_DECIMAL", dbDecimalType, dbStringType, false,
+                this::serializeCheckAndConvertStringFromDecimal);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertDateTimeFromDateFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_DATETIME_FROM_DATE", dbDateType,
+                dbDateTimestampType, false,
+                this::serializeCheckAndConvertDateTimeFromDate);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertDateTimeFromStringFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_CHECK_AND_CONVERT_DATETIME_FROM_STRING", dbStringType,
+                dbDateTimestampType, false,
+                this::serializeCheckAndConvertDateTimeFromString);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertDateFromDateTimeFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_DATE_FROM_DATETIME", dbDateTimestampType, dbDateType, false,
+                this::serializeCheckAndConvertDateFromDateTime);
+    }
+
+    protected DBFunctionSymbol createCheckAndConvertDateFromStringFunctionSymbol() {
+        return new UnaryCastDBFunctionSymbolWithSerializerImpl("DB_DATE_FROM_STRING", dbStringType, dbDateType, false,
+                this::serializeCheckAndConvertDateFromString);
     }
 
     /**

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MockupDBFunctionSymbolFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MockupDBFunctionSymbolFactory.java
@@ -812,4 +812,100 @@ public class MockupDBFunctionSymbolFactory extends AbstractDBFunctionSymbolFacto
         throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
     }
 
+    @Override
+    protected String serializeCheckAndConvertBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertBooleanFromString(ImmutableList<? extends ImmutableTerm> terms,
+                                                               Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
+                                                    Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloat(ImmutableList<? extends ImmutableTerm> terms,
+                                                   Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloatFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                              Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloatFromNonFPNumeric(ImmutableList<? extends ImmutableTerm> terms,
+                                                                   Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloatFromDouble(ImmutableList<? extends ImmutableTerm> terms,
+                                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDecimalFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                                Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertInteger(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertIntegerFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                                Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertStringFromDecimal(ImmutableList<? extends ImmutableTerm> terms,
+                                                               Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDateTimeFromDate(ImmutableList<? extends ImmutableTerm> terms,
+                                                              Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDateTimeFromString(ImmutableList<? extends ImmutableTerm> terms,
+                                                                Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDateFromDateTime(ImmutableList<? extends ImmutableTerm> terms,
+                                                              Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
+                                                            Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        throw new UnsupportedOperationException("Operation not supported by the MockupDBFunctionSymbolFactory");
+    }
+
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/UnaryCastDBFunctionSymbolWithSerializerImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/UnaryCastDBFunctionSymbolWithSerializerImpl.java
@@ -1,0 +1,21 @@
+package it.unibz.inf.ontop.model.term.functionsymbol.db.impl;
+
+import it.unibz.inf.ontop.model.term.functionsymbol.db.DBFunctionSymbolSerializer;
+import it.unibz.inf.ontop.model.type.DBTermType;
+
+/**
+ * DBFunctionSymbol for XSD Cast Functions. May return NULL without NULL arguments.
+ */
+public class UnaryCastDBFunctionSymbolWithSerializerImpl extends UnaryDBFunctionSymbolWithSerializerImpl {
+
+    protected UnaryCastDBFunctionSymbolWithSerializerImpl(String name, DBTermType inputDBType, DBTermType targetType,
+                                                          boolean isAlwaysInjective,
+                                                          DBFunctionSymbolSerializer serializer) {
+        super(name, inputDBType, targetType, isAlwaysInjective, serializer);
+    }
+
+    @Override
+    protected boolean mayReturnNullWithoutNullArguments() {
+        return true;
+    }
+}

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/RDFDatatypeStringFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/RDFDatatypeStringFunctionSymbolImpl.java
@@ -61,6 +61,11 @@ public class RDFDatatypeStringFunctionSymbolImpl extends FunctionSymbolImpl {
     }
 
     @Override
+    protected boolean enableIfElseNullLifting() {
+        return true;
+    }
+
+    @Override
     public boolean canBePostProcessed(ImmutableList<? extends ImmutableTerm> arguments) {
         return true;
     }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/SPARQLCastFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/SPARQLCastFunctionSymbolImpl.java
@@ -1,0 +1,170 @@
+package it.unibz.inf.ontop.model.term.functionsymbol.impl;
+
+import com.google.common.collect.ImmutableList;
+import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.model.term.*;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.DBFunctionSymbol;
+import it.unibz.inf.ontop.model.type.*;
+import org.apache.commons.rdf.api.IRI;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+import static it.unibz.inf.ontop.model.type.DBTermType.Category.*;
+
+public class SPARQLCastFunctionSymbolImpl extends ReduciblePositiveAritySPARQLFunctionSymbolImpl {
+
+    private final RDFTermType targetType;
+    private final DBTypeFactory dbTypeFactory;
+    private final Pattern numericPattern = Pattern.compile("-?\\d+(\\.\\d+)?");
+    private final ImmutableList<String> booleanPattern = ImmutableList.of("true", "false", "t", "f", "1", "0");
+
+    private final Function<DBTermType, Optional<DBFunctionSymbol>> dbFunctionSymbolFct;
+
+
+    public SPARQLCastFunctionSymbolImpl(String functionSymbolName, IRI iriFunctionName, RDFDatatype targetDataType,
+                                        TypeFactory typeFactory,
+                                        Function<DBTermType, Optional<DBFunctionSymbol>> dbFunctionSymbolFct) {
+        super(functionSymbolName, iriFunctionName, ImmutableList.of(typeFactory.getAbstractRDFTermType()));
+        this.targetType = targetDataType;
+        this.dbTypeFactory = typeFactory.getDBTypeFactory();
+        this.dbFunctionSymbolFct = dbFunctionSymbolFct;
+    }
+
+    @Override
+    protected ImmutableTerm computeLexicalTerm(ImmutableList<ImmutableTerm> subLexicalTerms,
+                                               ImmutableList<ImmutableTerm> typeTerms, TermFactory termFactory, ImmutableTerm returnedTypeTerm) {
+
+        DBTermType targetTypeClosestDBType = targetType.getClosestDBType(dbTypeFactory);
+
+
+        // CASE 1: Input is typed
+        if ((typeTerms.size()>0) && (typeTerms.get(0) instanceof RDFTermTypeConstant)) {
+            RDFTermTypeConstant inputRDFType = (RDFTermTypeConstant) typeTerms.get(0);
+
+            // If no cast necessary, return term
+            if (inputRDFType.equals(returnedTypeTerm)) {
+                return subLexicalTerms.get(0);
+            }
+
+            // If constant is not consistent with expected output type, return NULL
+            if (!(checkTermConversionConsistency(inputRDFType.getRDFTermType(), termFactory,
+                    targetTypeClosestDBType, subLexicalTerms.get(0)))) {
+                return termFactory.getNullConstant();
+            }
+
+            DBTermType inputDBType = inputRDFType.getRDFTermType().getClosestDBType(dbTypeFactory);
+            return dbFunctionSymbolFct.apply(inputDBType).isPresent()
+                    ? termFactory.getImmutableFunctionalTerm(dbFunctionSymbolFct.apply(inputDBType).get(), subLexicalTerms.get(0))
+                    : termFactory.getNullConstant();
+        } else {
+            // CASE 2: Input is not typed, literal
+            return termFactory.getDBCastFunctionalTerm(targetTypeClosestDBType, subLexicalTerms.get(0));
+        }
+    }
+
+    @Override
+    protected ImmutableTerm computeTypeTerm(ImmutableList<? extends ImmutableTerm> subLexicalTerms,
+                                            ImmutableList<ImmutableTerm> typeTerms, TermFactory termFactory,
+                                            VariableNullability variableNullability) {
+        return termFactory.getRDFTermTypeConstant(targetType);
+    }
+
+    @Override
+    public boolean isAlwaysInjectiveInTheAbsenceOfNonInjectiveFunctionalTerms() {
+        return false;
+    }
+
+    @Override
+    public Optional<TermTypeInference> inferType(ImmutableList<? extends ImmutableTerm> terms) {
+        return Optional.of(TermTypeInference.declareTermType(targetType));
+    }
+
+    @Override
+    public boolean canBePostProcessed(ImmutableList<? extends ImmutableTerm> arguments) {
+        return false;
+    }
+
+    //TODO: Ideally this logic should pushed in the lower-level function symbols, that operates over DB terms.
+    // This would maximize the chances for this logic to be used, because we may not have yet constants when reducing to
+    // the SPARQL function into DB functions.
+    /**
+     * Checks for datatype compatibility, otherwise returns NULL
+     * CASE 1: Conversion between datatypes not permitted e.g. integer to datetime
+     * CASE 2: Conversion of particular values not permitted e.g. string "123a" to integer
+     */
+    protected boolean checkTermConversionConsistency(RDFTermType rdfTermType, TermFactory termFactory,
+                                                     DBTermType targetType2, ImmutableTerm term) {
+
+        DBTermType.Category inputType = rdfTermType.getClosestDBType(termFactory.getTypeFactory().getDBTypeFactory())
+                .getCategory();
+
+        if (targetType2.getNaturalRDFDatatype().isPresent()) {
+            switch (targetType2.getCategory()) {
+                case DATE:
+                    // Case 1: If concrete numeric, no conversion
+                    if (rdfTermType instanceof ConcreteNumericRDFDatatype)
+                        return false;
+                    if (inputType.equals(STRING) && (term instanceof DBConstant)) {
+                        try {
+                            LocalDate.parse(((DBConstant) term).getValue());
+                            return true;
+                        } catch (DateTimeParseException e) {
+                            return false;
+                        }
+                    }
+                    break;
+                case DATETIME:
+                    if (rdfTermType instanceof ConcreteNumericRDFDatatype)
+                        return false;
+                    if (inputType.equals(STRING) && (term instanceof DBConstant)) {
+                        try {
+                            // Drop Z from datetime format
+                            String targetDate = ((DBConstant) term).getValue().replace("Z", "");
+                            if (targetDate.chars().filter(ch -> ch == ':').count() == 3) {
+                                // Drop timezone; check only if valid datetime
+                                LocalDateTime.parse(targetDate.substring(0, targetDate.length()-6));
+                                // Check if valid timezone
+                                // Imperfect solution since some timezone combinations might not exist in the real world
+                                return (ImmutableList.of("00", "30", "45").contains(targetDate.substring(targetDate.length() - 2)))
+                                        && (ImmutableList.of("-", "+").contains(String.valueOf(targetDate.charAt(targetDate.length() - 6))))
+                                        && (Integer.parseInt(targetDate.substring(targetDate.length() - 5, targetDate.length() - 3)) < 15);
+                            } else {
+                                // Check if valid datetime
+                                LocalDateTime.parse(targetDate);
+                                return true;
+                            }
+
+                        } catch (DateTimeParseException e) {
+                            return false;
+                        }
+                    }
+                    break;
+                case FLOAT_DOUBLE:
+                case DECIMAL:
+                case INTEGER:
+                    if (inputType.equals(DATE) || inputType.equals(DATETIME))
+                        return false;
+                    if (inputType.equals(STRING) && (term instanceof DBConstant)) {
+                        if (term.isNull()) { return false; }
+                        return numericPattern.matcher(((DBConstant) term).getValue()).matches();
+                    }
+                    break;
+                case BOOLEAN:
+                    if (inputType.equals(DATE) || inputType.equals(DATETIME))
+                        return false;
+                    if (inputType.equals(STRING) && (term instanceof DBConstant)) {
+                        if (term.isNull()) { return false; }
+                        return booleanPattern.contains(((DBConstant) term).getValue());
+                    }
+                    break;
+            }
+        }
+        return true;
+    }
+
+}

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/SPARQLCastFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/SPARQLCastFunctionSymbolImpl.java
@@ -62,8 +62,9 @@ public class SPARQLCastFunctionSymbolImpl extends ReduciblePositiveAritySPARQLFu
                     ? termFactory.getImmutableFunctionalTerm(dbFunctionSymbolFct.apply(inputDBType).get(), subLexicalTerms.get(0))
                     : termFactory.getNullConstant();
         } else {
-            // CASE 2: Input is not typed, literal
-            return termFactory.getDBCastFunctionalTerm(targetTypeClosestDBType, subLexicalTerms.get(0));
+            // CASE 2: Input is not typed or variable, use STRING as default
+            return termFactory.getImmutableFunctionalTerm(
+                    dbFunctionSymbolFct.apply(dbTypeFactory.getDBStringType()).get(), subLexicalTerms.get(0));
         }
     }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/type/TypeFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/type/TypeFactory.java
@@ -65,6 +65,8 @@ public interface TypeFactory {
 		return getDatatype(XSD.DATETIME);
 	}
 
+	default RDFDatatype getXsdDate() { return getDatatype(XSD.DATE); }
+
 	default RDFDatatype getXsdDatetimeStampDatatype() {
 		return getDatatype(XSD.DATETIMESTAMP);
 	}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractSQLDBFunctionSymbolFactory.java
@@ -112,8 +112,13 @@ public abstract class AbstractSQLDBFunctionSymbolFactory extends AbstractDBFunct
     private DBIsNullOrNotFunctionSymbol isNotNull;
     // Created in init()
     private DBIsTrueFunctionSymbol isTrue;
-    protected final String numericPattern = "'^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?$'";
-    protected final String numericNonFPPattern = "'^[-+]?[0-9]*\\.?[0-9]*$'";
+    // XSD cast patterns
+    protected static final String numericPattern = "'^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?$'";
+    protected static final String numericNonFPPattern = "'^[-+]?[0-9]*\\.?[0-9]*$'";
+    protected static final String datePattern1 = "'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$'";
+    protected static final String datePattern2 = "'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$'";
+    protected static final String datePattern3 = "'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$'";
+    protected static final String datePattern4 = "'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$'";
 
     protected AbstractSQLDBFunctionSymbolFactory(ImmutableTable<String, Integer, DBFunctionSymbol> regularFunctionTable,
                                                  TypeFactory typeFactory) {
@@ -1398,10 +1403,6 @@ public abstract class AbstractSQLDBFunctionSymbolFactory extends AbstractDBFunct
     @Override
     protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
                                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String datePattern1 = "'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$'";
-        String datePattern2 = "'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$'";
-        String datePattern3 = "'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$'";
-        String datePattern4 = "'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$'";
         String term = termConverter.apply(terms.get(0));
         return String.format("CASE WHEN (%1$s !~ " + datePattern1 + " AND " +
                         "%1$s !~ " + datePattern2 +" AND " +

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractSQLDBFunctionSymbolFactory.java
@@ -1241,4 +1241,174 @@ public abstract class AbstractSQLDBFunctionSymbolFactory extends AbstractDBFunct
                 conditionString);
     }
 
+    /**
+     * CAST functions
+     */
+    // https://www.w3.org/TR/xpath-functions/#casting-boolean
+    @Override
+    protected String serializeCheckAndConvertBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("(CASE WHEN CAST(%1$s AS DECIMAL) = 0 THEN 'false' " +
+                        "WHEN %1$s = '' THEN 'false' " +
+                        "WHEN %1$s = 'NaN' THEN 'false' " +
+                        "ELSE 'true' " +
+                        "END)",
+                term);
+    }
+
+    // https://www.w3.org/TR/xmlschema-2/#boolean
+    @Override
+    protected String serializeCheckAndConvertBooleanFromString(ImmutableList<? extends ImmutableTerm> terms,
+                                                               Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN %1$s='1' THEN 'true' " +
+                        "WHEN UPPER(%1$s) LIKE 'TRUE' THEN 'true' " +
+                        "WHEN %1$s='0' THEN 'false' " +
+                        "WHEN UPPER(%1$s) LIKE 'FALSE' THEN 'false' " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
+                                                    Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String doublePattern1 = "\'^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$\'";
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN %1$s !~ " + doublePattern1 +
+                        " THEN NULL ELSE CAST(%1$s AS DOUBLE) END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloat(ImmutableList<? extends ImmutableTerm> terms,
+                                                   Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String floatPattern1 = "\'^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$\'";
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN %1$s !~ " + floatPattern1 + " THEN NULL " +
+                        "WHEN (CAST(%1$s AS FLOAT) NOT BETWEEN -3.40E38 AND -1.18E-38 AND " +
+                        "CAST(%1$s AS FLOAT) NOT BETWEEN 1.18E-38 AND 3.40E38 AND CAST(%1$s AS FLOAT) != 0) THEN NULL " +
+                        "ELSE CAST(%1$s AS FLOAT) END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloatFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                              Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN UPPER(%1$s) LIKE 'TRUE' THEN 1.0E0 " +
+                        "WHEN UPPER(%1$s) LIKE 'FALSE' THEN 0.0E0 " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloatFromNonFPNumeric(ImmutableList<? extends ImmutableTerm> terms,
+                                                                   Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN (CAST(%1$s AS FLOAT) NOT BETWEEN -3.40E38 AND -1.18E-38 AND " +
+                        "CAST(%1$s AS FLOAT) NOT BETWEEN 1.18E-38 AND 3.40E38 AND CAST(%1$s AS FLOAT) != 0) THEN NULL " +
+                        "ELSE CAST(%1$s AS FLOAT) END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloatFromDouble(ImmutableList<? extends ImmutableTerm> terms,
+                                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return termConverter.apply(
+                termFactory.getDBCastFunctionalTerm(dbDoubleType, terms.get(0)));
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String decimalPattern1 = "\'^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?$\'";
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN %1$s !~ " + decimalPattern1 + " THEN NULL " +
+                        "ELSE CAST(%1$s AS DECIMAL) END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDecimalFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                                Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN %1$s='1' THEN 1.0 " +
+                        "WHEN UPPER(%1$s) LIKE 'TRUE' THEN 1.0 " +
+                        "WHEN %1$s='0' THEN 0.0 " +
+                        "WHEN UPPER(%1$s) LIKE 'FALSE' THEN 0.0 " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertInteger(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return termConverter.apply(
+                termFactory.getDBCastFunctionalTerm(dbIntegerType, terms.get(0)));
+    }
+
+    @Override
+    protected String serializeCheckAndConvertIntegerFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                                Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN %1$s='1' THEN 1 " +
+                        "WHEN %1$s THEN 1 " +
+                        "WHEN %1$s='0' THEN 0 " +
+                        "WHEN NOT %1$s THEN 0 " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    // Per the standard, if only trailing 0-s and number can be represented as integer, drop them
+    // https://www.w3.org/TR/xpath-functions/#casting-to-string
+    @Override
+    protected String serializeCheckAndConvertStringFromDecimal(ImmutableList<? extends ImmutableTerm> terms,
+                                                               Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("(CASE WHEN MOD(%1$s,1) = 0 THEN CAST((%1$s) AS INTEGER) " +
+                        "ELSE %1$s " +
+                        "END)",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDateTimeFromDate(ImmutableList<? extends ImmutableTerm> terms,
+                                                              Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return termConverter.apply(
+                termFactory.getDBCastFunctionalTerm(dbTypeFactory.getDBDateTimestampType(), terms.get(0)));
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDateTimeFromString(ImmutableList<? extends ImmutableTerm> terms,
+                                                                Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return serializeCheckAndConvertDateTimeFromDate(terms, termConverter, termFactory);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDateFromDateTime(ImmutableList<? extends ImmutableTerm> terms,
+                                                              Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return termConverter.apply(
+                termFactory.getDBCastFunctionalTerm(dbTypeFactory.getDBDateType(), terms.get(0)));
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
+                                                            Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String datePattern1 = "\'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$\'";
+        String datePattern2 = "\'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$\'";
+        String datePattern3 = "\'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$\'";
+        String datePattern4 = "\'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$\'";
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN (%1$s !~ " + datePattern1 + " AND " +
+                        "%1$s !~ " + datePattern2 +" AND " +
+                        "%1$s !~ " + datePattern3 +" AND " +
+                        "%1$s !~ " + datePattern4 +" ) " +
+                        " THEN NULL ELSE CAST(%1$s AS DATE) END",
+                term);
+    }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractSQLDBFunctionSymbolFactory.java
@@ -1243,7 +1243,7 @@ public abstract class AbstractSQLDBFunctionSymbolFactory extends AbstractDBFunct
     }
 
     /**
-     * CAST functions
+     * XSD CAST functions
      */
     // https://www.w3.org/TR/xpath-functions/#casting-boolean
     @Override
@@ -1397,10 +1397,10 @@ public abstract class AbstractSQLDBFunctionSymbolFactory extends AbstractDBFunct
     @Override
     protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
                                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String datePattern1 = "\'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$\'";
-        String datePattern2 = "\'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$\'";
-        String datePattern3 = "\'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$\'";
-        String datePattern4 = "\'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$\'";
+        String datePattern1 = "'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$'";
+        String datePattern2 = "'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$'";
+        String datePattern3 = "'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$'";
+        String datePattern4 = "'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$'";
         String term = termConverter.apply(terms.get(0));
         return String.format("CASE WHEN (%1$s !~ " + datePattern1 + " AND " +
                         "%1$s !~ " + datePattern2 +" AND " +

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractSQLDBFunctionSymbolFactory.java
@@ -112,6 +112,7 @@ public abstract class AbstractSQLDBFunctionSymbolFactory extends AbstractDBFunct
     private DBIsNullOrNotFunctionSymbol isNotNull;
     // Created in init()
     private DBIsTrueFunctionSymbol isTrue;
+    protected final String numericPattern = "'^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?$'";
 
     protected AbstractSQLDBFunctionSymbolFactory(ImmutableTable<String, Integer, DBFunctionSymbol> regularFunctionTable,
                                                  TypeFactory typeFactory) {
@@ -1274,9 +1275,8 @@ public abstract class AbstractSQLDBFunctionSymbolFactory extends AbstractDBFunct
     @Override
     protected String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String doublePattern1 = "\'^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$\'";
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN %1$s !~ " + doublePattern1 +
+        return String.format("CASE WHEN %1$s !~ " + numericPattern +
                         " THEN NULL ELSE CAST(%1$s AS DOUBLE) END",
                 term);
     }
@@ -1284,9 +1284,8 @@ public abstract class AbstractSQLDBFunctionSymbolFactory extends AbstractDBFunct
     @Override
     protected String serializeCheckAndConvertFloat(ImmutableList<? extends ImmutableTerm> terms,
                                                    Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String floatPattern1 = "\'^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$\'";
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN %1$s !~ " + floatPattern1 + " THEN NULL " +
+        return String.format("CASE WHEN %1$s !~ " + numericPattern + " THEN NULL " +
                         "WHEN (CAST(%1$s AS FLOAT) NOT BETWEEN -3.40E38 AND -1.18E-38 AND " +
                         "CAST(%1$s AS FLOAT) NOT BETWEEN 1.18E-38 AND 3.40E38 AND CAST(%1$s AS FLOAT) != 0) THEN NULL " +
                         "ELSE CAST(%1$s AS FLOAT) END",
@@ -1324,9 +1323,8 @@ public abstract class AbstractSQLDBFunctionSymbolFactory extends AbstractDBFunct
     @Override
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String decimalPattern1 = "\'^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?$\'";
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN %1$s !~ " + decimalPattern1 + " THEN NULL " +
+        return String.format("CASE WHEN %1$s !~ " + numericPattern + " THEN NULL " +
                         "ELSE CAST(%1$s AS DECIMAL) END",
                 term);
     }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractSQLDBFunctionSymbolFactory.java
@@ -113,6 +113,7 @@ public abstract class AbstractSQLDBFunctionSymbolFactory extends AbstractDBFunct
     // Created in init()
     private DBIsTrueFunctionSymbol isTrue;
     protected final String numericPattern = "'^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?$'";
+    protected final String numericNonFPPattern = "'^[-+]?[0-9]*\\.?[0-9]*$'";
 
     protected AbstractSQLDBFunctionSymbolFactory(ImmutableTable<String, Integer, DBFunctionSymbol> regularFunctionTable,
                                                  TypeFactory typeFactory) {
@@ -1324,7 +1325,7 @@ public abstract class AbstractSQLDBFunctionSymbolFactory extends AbstractDBFunct
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN %1$s !~ " + numericPattern + " THEN NULL " +
+        return String.format("CASE WHEN %1$s !~ " + numericNonFPPattern + " THEN NULL " +
                         "ELSE CAST(%1$s AS DECIMAL) END",
                 term);
     }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DenodoDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DenodoDBFunctionSymbolFactory.java
@@ -339,7 +339,7 @@ public class DenodoDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN %1$s REGEXP_ILIKE " + numericPattern + " THEN " +
+        return String.format("CASE WHEN %1$s REGEXP_ILIKE " + numericNonFPPattern + " THEN " +
                         "CAST(%1$s AS DECIMAL) " +
                         "ELSE NULL " +
                         "END",

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DenodoDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DenodoDBFunctionSymbolFactory.java
@@ -360,10 +360,6 @@ public class DenodoDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
     @Override
     protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
                                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String datePattern1 = "'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$'";
-        String datePattern2 = "'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$'";
-        String datePattern3 = "'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$'";
-        String datePattern4 = "'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$'";
         String term = termConverter.apply(terms.get(0));
         return String.format("CASE WHEN (NOT %1$s REGEXP_ILIKE " + datePattern1 + " AND " +
                         "NOT %1$s REGEXP_ILIKE " + datePattern2 +" AND " +

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DremioDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DremioDBFunctionSymbolFactory.java
@@ -200,7 +200,7 @@ public class DremioDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN REGEXP_LIKE(%1$s, " + numericPattern + ") THEN " +
+        return String.format("CASE WHEN REGEXP_LIKE(%1$s, " + numericNonFPPattern + ") THEN " +
                         "CAST(%1$s AS DECIMAL(60,30)) " +
                         "ELSE NULL " +
                         "END",

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DremioDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DremioDBFunctionSymbolFactory.java
@@ -172,4 +172,62 @@ public class DremioDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         throw new UnsupportedOperationException(NOT_YET_SUPPORTED_MSG);
     }
+
+    /**
+     * XSD CAST functions
+     */
+    @Override
+    protected String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
+                                                    Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN NOT REGEXP_LIKE(%1$s, " + numericPattern + ")" +
+                        " THEN NULL ELSE CAST(%1$s AS DOUBLE) END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloat(ImmutableList<? extends ImmutableTerm> terms,
+                                                   Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN NOT REGEXP_LIKE(%1$s, " + numericPattern + ") THEN NULL " +
+                        "WHEN (CAST(%1$s AS FLOAT) NOT BETWEEN -3.40E38 AND -1.18E-38 AND " +
+                        "CAST(%1$s AS FLOAT) NOT BETWEEN 1.18E-38 AND 3.40E38 AND CAST(%1$s AS FLOAT) != 0) THEN NULL " +
+                        "ELSE CAST(%1$s AS FLOAT) END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN REGEXP_LIKE(%1$s, " + numericPattern + ") THEN " +
+                        "CAST(%1$s AS DECIMAL(60,30)) " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertInteger(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN REGEXP_LIKE(%1$s, "+ numericPattern +") THEN " +
+                        "CAST(FLOOR(ABS(CAST(%1$s AS DECIMAL(30,15)))) * SIGN(CAST(%1$s AS DECIMAL)) AS INTEGER) " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertIntegerFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                                Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN %1$s='1' THEN 1 " +
+                        "WHEN UPPER(%1$s) LIKE 'TRUE' THEN 1 " +
+                        "WHEN %1$s='0' THEN 0 " +
+                        "WHEN UPPER(%1$s) LIKE 'FALSE' THEN 0 " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DuckDBDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DuckDBDBFunctionSymbolFactory.java
@@ -283,7 +283,7 @@ public class DuckDBDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN REGEXP_MATCHES(%1$s, " + numericPattern + ") THEN " +
+        return String.format("CASE WHEN REGEXP_MATCHES(%1$s, " + numericNonFPPattern + ") THEN " +
                         "CAST(%1$s AS " + DEFAULT_DECIMAL_STR + ") " +
                         "ELSE NULL " +
                         "END",

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DuckDBDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DuckDBDBFunctionSymbolFactory.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
 
 import static it.unibz.inf.ontop.model.type.impl.SnowflakeDBTypeFactory.TIMESTAMP_LOCAL_TZ_STR;
 import static it.unibz.inf.ontop.model.type.impl.SnowflakeDBTypeFactory.TIMESTAMP_NO_TZ_STR;
+import static it.unibz.inf.ontop.model.type.impl.DuckDBDBTypeFactory.DEFAULT_DECIMAL_STR;
 
 public class DuckDBDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFactory {
 
@@ -264,4 +265,28 @@ public class DuckDBDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
                 ));
     }
 
+    /**
+     * XSD CAST functions
+     */
+    @Override
+    protected String serializeCheckAndConvertInteger(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN REGEXP_MATCHES(%1$s, "+ numericPattern +") THEN " +
+                        "CAST(FLOOR(ABS(CAST(%1$s AS " + DEFAULT_DECIMAL_STR + "))) * SIGN(CAST(%1$s AS DECIMAL)) AS INTEGER) " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN REGEXP_MATCHES(%1$s, " + numericPattern + ") THEN " +
+                        "CAST(%1$s AS " + DEFAULT_DECIMAL_STR + ") " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/H2SQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/H2SQLDBFunctionSymbolFactory.java
@@ -321,16 +321,14 @@ public class H2SQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     @Override
     protected String serializeCheckAndConvertDateFromDateTime(ImmutableList<? extends ImmutableTerm> terms,
                                                               Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        //return String.format("CAST(PARSEDATETIME(formatdatetime(timestamp %s, 'yyyy-MM-dd hh:mm:ss'), 'yyyy-MM-dd') AS DATE)", termConverter.apply(terms.get(0)));
         return String.format("CAST(TIMESTAMP %s AS DATE)", termConverter.apply(terms.get(0)));
     }
 
     @Override
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String decimalPattern1 = "\'^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?$\'";
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN %1$s !~ " + decimalPattern1 + " THEN NULL " +
+        return String.format("CASE WHEN %1$s !~ " + numericPattern + " THEN NULL " +
                         "ELSE CAST(%1$s AS "+ DEFAULT_DECIMAL_STR +") END",
                 term);
     }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/H2SQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/H2SQLDBFunctionSymbolFactory.java
@@ -282,7 +282,7 @@ public class H2SQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     }
 
     /**
-     * CAST functions
+     * XSD CAST functions
      */
     // H2 cannot detect NaN. A different error will be thrown by H2 and the boolean cast will fail.
     @Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/H2SQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/H2SQLDBFunctionSymbolFactory.java
@@ -328,7 +328,7 @@ public class H2SQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN %1$s !~ " + numericPattern + " THEN NULL " +
+        return String.format("CASE WHEN %1$s !~ " + numericNonFPPattern + " THEN NULL " +
                         "ELSE CAST(%1$s AS "+ DEFAULT_DECIMAL_STR +") END",
                 term);
     }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
@@ -363,11 +363,11 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
                 databaseInfoSupplier.getDatabaseVersion()
                         .map(s -> Integer.parseInt(s.substring(0, s.indexOf("."))))
                         .filter(s -> s > 7 ).isPresent()) {
-            return String.format("CASE WHEN %1$s NOT REGEXP " + numericPattern +
+            return String.format("CASE WHEN %1$s NOT REGEXP " + numericNonFPPattern +
                             " THEN NULL ELSE CAST(%1$s AS DECIMAL(60,30)) END",
                     term);
         } else {
-            return String.format("CASE WHEN %1$s NOT REGEXP BINARY " + numericPattern +
+            return String.format("CASE WHEN %1$s NOT REGEXP BINARY " + numericNonFPPattern +
                             " THEN NULL ELSE CAST(%1$s AS DECIMAL(60,30)) END",
                     term);
         }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
@@ -313,17 +313,16 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     @Override
     protected String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String doublePattern1 = "\'^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$\'";
         String term = termConverter.apply(terms.get(0));
         if (databaseInfoSupplier.getDatabaseVersion().isPresent() &&
                 databaseInfoSupplier.getDatabaseVersion()
                         .map(s -> Integer.parseInt(s.substring(0, s.indexOf("."))))
                         .filter(s -> s > 7 ).isPresent()) {
-            return String.format("CASE WHEN %1$s NOT REGEXP" + doublePattern1 +
+            return String.format("CASE WHEN %1$s NOT REGEXP" + numericPattern +
                             " THEN NULL ELSE %1$s + 0.0 END",
                     term); }
         else {
-            return String.format("CASE WHEN %1$s NOT REGEXP BINARY" + doublePattern1 +
+            return String.format("CASE WHEN %1$s NOT REGEXP BINARY" + numericPattern +
                             " THEN NULL ELSE %1$s + 0.0 END",
                     term); }
     }
@@ -331,17 +330,16 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     @Override
     protected String serializeCheckAndConvertFloat(ImmutableList<? extends ImmutableTerm> terms,
                                                    Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String floatPattern1 = "\'^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$\'";
         String term = termConverter.apply(terms.get(0));
         if (databaseInfoSupplier.getDatabaseVersion().isPresent() &&
                 databaseInfoSupplier.getDatabaseVersion()
                         .map(s -> Integer.parseInt(s.substring(0, s.indexOf("."))))
                         .filter(s -> s > 7 ).isPresent()) {
-            return String.format("CASE WHEN %1$s NOT REGEXP " + floatPattern1 +
+            return String.format("CASE WHEN %1$s NOT REGEXP " + numericPattern +
                             " THEN NULL ELSE %1$s + 0.0 END",
                     term);
         } else {
-            return String.format("CASE WHEN %1$s NOT REGEXP BINARY " + floatPattern1 +
+            return String.format("CASE WHEN %1$s NOT REGEXP BINARY " + numericPattern +
                             " THEN NULL ELSE %1$s + 0.0 END",
                     term);
         }
@@ -360,17 +358,16 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     @Override
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String decimalPattern1 = "\'^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$\'";
         String term = termConverter.apply(terms.get(0));
         if (databaseInfoSupplier.getDatabaseVersion().isPresent() &&
                 databaseInfoSupplier.getDatabaseVersion()
                         .map(s -> Integer.parseInt(s.substring(0, s.indexOf("."))))
                         .filter(s -> s > 7 ).isPresent()) {
-            return String.format("CASE WHEN %1$s NOT REGEXP " + decimalPattern1 +
+            return String.format("CASE WHEN %1$s NOT REGEXP " + numericPattern +
                             " THEN NULL ELSE CAST(%1$s AS DECIMAL(60,30)) END",
                     term);
         } else {
-            return String.format("CASE WHEN %1$s NOT REGEXP BINARY " + decimalPattern1 +
+            return String.format("CASE WHEN %1$s NOT REGEXP BINARY " + numericPattern +
                             " THEN NULL ELSE CAST(%1$s AS DECIMAL(60,30)) END",
                     term);
         }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
@@ -307,17 +307,22 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     }
 
     /**
-     * CAST functions
+     * XSD CAST functions
      */
+
+    // Cast and regex differ in MySQL version 8 and above vs. previous versions
+    private boolean isMySQLVersion8OrAbove() {
+        return databaseInfoSupplier.getDatabaseVersion().isPresent() &&
+                databaseInfoSupplier.getDatabaseVersion()
+                        .map(s -> Integer.parseInt(s.substring(0, s.indexOf("."))))
+                        .filter(s -> s > 7 ).isPresent();
+    }
 
     @Override
     protected String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        if (databaseInfoSupplier.getDatabaseVersion().isPresent() &&
-                databaseInfoSupplier.getDatabaseVersion()
-                        .map(s -> Integer.parseInt(s.substring(0, s.indexOf("."))))
-                        .filter(s -> s > 7 ).isPresent()) {
+        if (isMySQLVersion8OrAbove()) {
             return String.format("CASE WHEN %1$s NOT REGEXP" + numericPattern +
                             " THEN NULL ELSE %1$s + 0.0 END",
                     term); }
@@ -331,10 +336,7 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     protected String serializeCheckAndConvertFloat(ImmutableList<? extends ImmutableTerm> terms,
                                                    Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        if (databaseInfoSupplier.getDatabaseVersion().isPresent() &&
-                databaseInfoSupplier.getDatabaseVersion()
-                        .map(s -> Integer.parseInt(s.substring(0, s.indexOf("."))))
-                        .filter(s -> s > 7 ).isPresent()) {
+        if (isMySQLVersion8OrAbove()) {
             return String.format("CASE WHEN %1$s NOT REGEXP " + numericPattern +
                             " THEN NULL ELSE %1$s + 0.0 END",
                     term);
@@ -359,10 +361,7 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        if (databaseInfoSupplier.getDatabaseVersion().isPresent() &&
-                databaseInfoSupplier.getDatabaseVersion()
-                        .map(s -> Integer.parseInt(s.substring(0, s.indexOf("."))))
-                        .filter(s -> s > 7 ).isPresent()) {
+        if (isMySQLVersion8OrAbove()) {
             return String.format("CASE WHEN %1$s NOT REGEXP " + numericNonFPPattern +
                             " THEN NULL ELSE CAST(%1$s AS DECIMAL(60,30)) END",
                     term);
@@ -378,10 +377,7 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     protected String serializeCheckAndConvertInteger(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        if (databaseInfoSupplier.getDatabaseVersion().isPresent() &&
-                databaseInfoSupplier.getDatabaseVersion()
-                        .map(s -> Integer.parseInt(s.substring(0, s.indexOf("."))))
-                        .filter(s -> s > 7 ).isPresent()) {
+        if (isMySQLVersion8OrAbove()) {
             return String.format("IF(%1$s REGEXP '[^0-9]+$', NULL , " +
                             "FLOOR(ABS(CAST(%1$s AS DECIMAL(60,30))))  * SIGN(CAST(%1$s AS DECIMAL(60,30)))) ",
                     term);
@@ -437,15 +433,8 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     @Override
     protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
                                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String datePattern1 = "'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$'";
-        String datePattern2 = "'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$'";
-        String datePattern3 = "'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$'";
-        String datePattern4 = "'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$'";
         String term = termConverter.apply(terms.get(0));
-        if (databaseInfoSupplier.getDatabaseVersion().isPresent() &&
-                databaseInfoSupplier.getDatabaseVersion()
-                        .map(s -> Integer.parseInt(s.substring(0, s.indexOf("."))))
-                        .filter(s -> s > 7 ).isPresent()) {
+        if (isMySQLVersion8OrAbove()) {
             return String.format("CASE WHEN (%1$s NOT REGEXP " + datePattern1 + " AND " +
                             "%1$s NOT REGEXP " + datePattern2 +" AND " +
                             "%1$s NOT REGEXP " + datePattern3 +" AND " +

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
@@ -437,10 +437,10 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     @Override
     protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
                                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String datePattern1 = "\'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$\'";
-        String datePattern2 = "\'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$\'";
-        String datePattern3 = "\'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$\'";
-        String datePattern4 = "\'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$\'";
+        String datePattern1 = "'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$'";
+        String datePattern2 = "'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$'";
+        String datePattern3 = "'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$'";
+        String datePattern4 = "'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$'";
         String term = termConverter.apply(terms.get(0));
         if (databaseInfoSupplier.getDatabaseVersion().isPresent() &&
                 databaseInfoSupplier.getDatabaseVersion()

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/OracleDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/OracleDBFunctionSymbolFactory.java
@@ -485,9 +485,8 @@ public class OracleDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
     @Override
     protected String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String doublePattern1 = "\'^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$\'";
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN NOT REGEXP_LIKE(%1$s, " + doublePattern1 + ")" +
+        return String.format("CASE WHEN NOT REGEXP_LIKE(%1$s, " + numericPattern + ")" +
                         " THEN NULL ELSE CAST(%1$s AS DOUBLE PRECISION) END",
                 term);
     }
@@ -495,9 +494,8 @@ public class OracleDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
     @Override
     protected String serializeCheckAndConvertFloat(ImmutableList<? extends ImmutableTerm> terms,
                                                    Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String floatPattern1 = "\'^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$\'";
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN NOT REGEXP_LIKE(%1$s, " + floatPattern1 + ") THEN NULL " +
+        return String.format("CASE WHEN NOT REGEXP_LIKE(%1$s, " + numericPattern + ") THEN NULL " +
                         "WHEN (CAST(%1$s AS FLOAT) NOT BETWEEN -3.40E38 AND -1.18E-38 AND " +
                         "CAST(%1$s AS FLOAT) NOT BETWEEN 1.18E-38 AND 3.40E38 AND CAST(%1$s AS FLOAT) != 0) THEN NULL " +
                         "ELSE CAST(%1$s AS FLOAT) END",

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/OracleDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/OracleDBFunctionSymbolFactory.java
@@ -506,7 +506,7 @@ public class OracleDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN REGEXP_LIKE(%1$s, " + numericPattern + ") THEN " +
+        return String.format("CASE WHEN REGEXP_LIKE(%1$s, " + numericNonFPPattern + ") THEN " +
                         "CAST(%1$s AS NUMBER) " +
                         "ELSE NULL " +
                         "END",

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/OracleDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/OracleDBFunctionSymbolFactory.java
@@ -456,7 +456,7 @@ public class OracleDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
     }
 
     /**
-     * CAST functions
+     * XSD CAST functions
      */
     @Override
     protected String serializeCheckAndConvertBoolean(ImmutableList<? extends ImmutableTerm> terms,
@@ -506,7 +506,7 @@ public class OracleDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN REGEXP_LIKE(%1$s, '^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$') THEN " +
+        return String.format("CASE WHEN REGEXP_LIKE(%1$s, " + numericPattern + ") THEN " +
                         "CAST(%1$s AS NUMBER) " +
                         "ELSE NULL " +
                         "END",
@@ -517,7 +517,7 @@ public class OracleDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
     protected String serializeCheckAndConvertInteger(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN REGEXP_LIKE(%1$s, '^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$') THEN " +
+        return String.format("CASE WHEN REGEXP_LIKE(%1$s, "+ numericPattern +") THEN " +
                         "CAST(FLOOR(ABS(CAST(%1$s AS DECIMAL(30,15)))) * SIGN(CAST(%1$s AS DECIMAL)) AS INTEGER) " +
                         "ELSE NULL " +
                         "END",

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/PostgreSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/PostgreSQLDBFunctionSymbolFactory.java
@@ -591,10 +591,10 @@ public class PostgreSQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymb
     @Override
     protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
                                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String datePattern1 = "\'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$\'";
-        String datePattern2 = "\'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$\'";
-        String datePattern3 = "\'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$\'";
-        String datePattern4 = "\'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$\'";
+        String datePattern1 = "'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$'";
+        String datePattern2 = "'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$'";
+        String datePattern3 = "'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$'";
+        String datePattern4 = "'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$'";
         String term = termConverter.apply(terms.get(0));
         return String.format("CASE WHEN (%1$s !~ " + datePattern1 + " AND " +
                         "%1$s !~ " + datePattern2 +" AND " +

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/PostgreSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/PostgreSQLDBFunctionSymbolFactory.java
@@ -534,9 +534,8 @@ public class PostgreSQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymb
     @Override
     protected String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String doublePattern1 = "\'^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$\'";
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN %1$s !~ " + doublePattern1 +
+        return String.format("CASE WHEN %1$s !~ " + numericPattern +
                         " THEN NULL ELSE CAST(%1$s AS DOUBLE PRECISION) END",
                 term);
     }
@@ -544,9 +543,8 @@ public class PostgreSQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymb
     @Override
     protected String serializeCheckAndConvertFloat(ImmutableList<? extends ImmutableTerm> terms,
                                                    Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String floatPattern1 = "\'^-?([0-9]+[.]?[0-9]*|[.][0-9]+)$\'";
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN %1$s !~ " + floatPattern1 + " THEN NULL " +
+        return String.format("CASE WHEN %1$s !~ " + numericPattern + " THEN NULL " +
                         "WHEN (CAST(%1$s AS FLOAT) NOT BETWEEN -3.40E38 AND -1.18E-38 AND " +
                         "CAST(%1$s AS FLOAT) NOT BETWEEN 1.18E-38 AND 3.40E38 AND CAST(%1$s AS FLOAT) != 0) THEN NULL " +
                         "ELSE CAST(%1$s AS FLOAT) END",

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/PostgreSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/PostgreSQLDBFunctionSymbolFactory.java
@@ -591,10 +591,6 @@ public class PostgreSQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymb
     @Override
     protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
                                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String datePattern1 = "'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$'";
-        String datePattern2 = "'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$'";
-        String datePattern3 = "'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$'";
-        String datePattern4 = "'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$'";
         String term = termConverter.apply(terms.get(0));
         return String.format("CASE WHEN (%1$s !~ " + datePattern1 + " AND " +
                         "%1$s !~ " + datePattern2 +" AND " +

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/PrestoDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/PrestoDBFunctionSymbolFactory.java
@@ -1,20 +1,9 @@
 package it.unibz.inf.ontop.model.term.functionsymbol.db.impl;
 
-import com.google.common.collect.*;
 import com.google.inject.Inject;
-import it.unibz.inf.ontop.model.term.ImmutableTerm;
-import it.unibz.inf.ontop.model.term.TermFactory;
-import it.unibz.inf.ontop.model.term.functionsymbol.db.DBConcatFunctionSymbol;
 import it.unibz.inf.ontop.model.term.functionsymbol.db.DBFunctionSymbol;
-import it.unibz.inf.ontop.model.term.functionsymbol.db.DBTypeConversionFunctionSymbol;
 import it.unibz.inf.ontop.model.type.DBTermType;
-import it.unibz.inf.ontop.model.type.DBTypeFactory;
 import it.unibz.inf.ontop.model.type.TypeFactory;
-
-import java.util.function.Function;
-
-import static it.unibz.inf.ontop.model.type.impl.SnowflakeDBTypeFactory.TIMESTAMP_LOCAL_TZ_STR;
-import static it.unibz.inf.ontop.model.type.impl.SnowflakeDBTypeFactory.TIMESTAMP_NO_TZ_STR;
 
 public class PrestoDBFunctionSymbolFactory extends TrinoDBFunctionSymbolFactory {
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SQLServerDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SQLServerDBFunctionSymbolFactory.java
@@ -477,7 +477,7 @@ public class SQLServerDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbo
     }
 
     /**
-     * CAST functions
+     * XSD CAST functions
      */
     // NOTE: Not possible to specify NaN or 0/0
     @Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SnowflakeDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SnowflakeDBFunctionSymbolFactory.java
@@ -8,7 +8,6 @@ import it.unibz.inf.ontop.model.term.functionsymbol.db.*;
 import it.unibz.inf.ontop.model.type.DBTermType;
 import it.unibz.inf.ontop.model.type.DBTypeFactory;
 import it.unibz.inf.ontop.model.type.TypeFactory;
-import it.unibz.inf.ontop.model.type.impl.SQLServerDBTypeFactory;
 
 import java.util.function.Function;
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SnowflakeDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SnowflakeDBFunctionSymbolFactory.java
@@ -8,6 +8,7 @@ import it.unibz.inf.ontop.model.term.functionsymbol.db.*;
 import it.unibz.inf.ontop.model.type.DBTermType;
 import it.unibz.inf.ontop.model.type.DBTypeFactory;
 import it.unibz.inf.ontop.model.type.TypeFactory;
+import it.unibz.inf.ontop.model.type.impl.SQLServerDBTypeFactory;
 
 import java.util.function.Function;
 
@@ -152,5 +153,136 @@ public class SnowflakeDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbo
     @Override
     protected DBFunctionSymbol createEncodeURLorIRI(boolean preserveInternationalChars) {
         return new MySQLEncodeURLorIRIFunctionSymbolImpl(dbStringType, preserveInternationalChars);
+    }
+
+    /**
+     * XSD CAST functions
+     */
+    // NOTE: Not possible to specify NaN or 0/0
+    @Override
+    protected String serializeCheckAndConvertBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return String.format("(CASE WHEN %s IS NULL THEN NULL " +
+                        "WHEN CAST(%s AS " + NUMBER_38_10_STR + ") = 0 THEN '0' " +
+                        "WHEN %s = '' THEN '0' " +
+                        "ELSE '1' " +
+                        "END)",
+                termConverter.apply(terms.get(0)),
+                termConverter.apply(terms.get(0)),
+                termConverter.apply(terms.get(0)));
+    }
+
+    @Override
+    protected String serializeCheckAndConvertBooleanFromString(ImmutableList<? extends ImmutableTerm> terms,
+                                                               Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return String.format("CASE WHEN %s='1' THEN 1 " +
+                        "WHEN UPPER(%s) LIKE 'TRUE' THEN 1 " +
+                        "WHEN %s='0' THEN 0 " +
+                        "WHEN UPPER(%s) LIKE 'FALSE' THEN 0 " +
+                        "ELSE NULL " +
+                        "END",
+                termConverter.apply(terms.get(0)),
+                termConverter.apply(terms.get(0)),
+                termConverter.apply(terms.get(0)),
+                termConverter.apply(terms.get(0)));
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
+                                                    Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return String.format("TRY_CAST(%s AS DOUBLE PRECISION)", termConverter.apply(terms.get(0)));
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloat(ImmutableList<? extends ImmutableTerm> terms,
+                                                   Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return String.format("TRY_CAST(%s AS FLOAT)", termConverter.apply(terms.get(0)));
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloatFromNonFPNumeric(ImmutableList<? extends ImmutableTerm> terms,
+                                                                   Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return serializeCheckAndConvertFloat(terms, termConverter, termFactory);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return String.format("TRY_CAST(%s AS " + NUMBER_38_10_STR + ")", termConverter.apply(terms.get(0)));
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloatFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                              Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN %1$s='1' THEN 1.0 " +
+                        "WHEN UPPER(%1$s) LIKE 'TRUE' THEN 1.0 " +
+                        "WHEN %1$s='0' THEN 0.0 " +
+                        "WHEN UPPER(%1$s) LIKE 'FALSE' THEN 0.0 " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDecimalFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                                Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN %1$s='1' THEN 1.0 " +
+                        "WHEN UPPER(%1$s) LIKE 'TRUE' THEN 1.0 " +
+                        "WHEN %1$s='0' THEN 0.0 " +
+                        "WHEN UPPER(%1$s) LIKE 'FALSE' THEN 0.0 " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertInteger(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CAST(FLOOR(ABS(TRY_CAST(%1$s AS " + NUMBER_38_10_STR + "))) * SIGN(TRY_CAST(%1$s AS DECIMAL)) AS INTEGER)",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertIntegerFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                                Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN %1$s='1' THEN 1 " +
+                        "WHEN UPPER(%1$s) LIKE 'TRUE' THEN 1 " +
+                        "WHEN %1$s='0' THEN 0 " +
+                        "WHEN UPPER(%1$s) LIKE 'FALSE' THEN 0 " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertStringFromDecimal(ImmutableList<? extends ImmutableTerm> terms,
+                                                               Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("(CASE WHEN %1$s %% 1 = 0 THEN FLOOR(ABS(%1$s)) * SIGN(TRY_CAST (%1$s AS DECIMAL)) " +
+                        "ELSE %1$s " +
+                        "END)",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDateTimeFromDate(ImmutableList<? extends ImmutableTerm> terms,
+                                                              Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return String.format("TRY_CAST(%s AS DATETIME)", termConverter.apply(terms.get(0)));
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDateFromDateTime(ImmutableList<? extends ImmutableTerm> terms,
+                                                              Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return String.format("TRY_CAST(%s AS DATE)", termConverter.apply(terms.get(0)));
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
+                                                            Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        return this.serializeCheckAndConvertDateFromDateTime(terms, termConverter, termFactory);
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SparkSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SparkSQLDBFunctionSymbolFactory.java
@@ -267,10 +267,6 @@ public class SparkSQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
     @Override
     protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
                                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String datePattern1 = "'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$'";
-        String datePattern2 = "'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$'";
-        String datePattern3 = "'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$'";
-        String datePattern4 = "'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$'";
         String term = termConverter.apply(terms.get(0));
         return String.format("CASE WHEN (%1$s NOT RLIKE " + datePattern1 + " AND " +
                         "%1$s NOT RLIKE " + datePattern2 +" AND " +

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SparkSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SparkSQLDBFunctionSymbolFactory.java
@@ -243,7 +243,7 @@ public class SparkSQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN %1$s NOT RLIKE " + numericPattern + " THEN NULL " +
+        return String.format("CASE WHEN %1$s NOT RLIKE " + numericNonFPPattern + " THEN NULL " +
                         "ELSE CAST(%1$s AS "+ DECIMAL_38_10_STR +") END",
                 term);
     }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/TrinoDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/TrinoDBFunctionSymbolFactory.java
@@ -302,10 +302,6 @@ public class TrinoDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     @Override
     protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
                                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
-        String datePattern1 = "'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$'";
-        String datePattern2 = "'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$'";
-        String datePattern3 = "'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$'";
-        String datePattern4 = "'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$'";
         String term = termConverter.apply(terms.get(0));
         return String.format("CASE WHEN (REGEXP_LIKE(%1$s, " + datePattern1 + ") AND " +
                         "REGEXP_LIKE(%1$s, " + datePattern2 +") AND " +

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/TrinoDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/TrinoDBFunctionSymbolFactory.java
@@ -257,7 +257,7 @@ public class TrinoDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN REGEXP_LIKE(%1$s, " + numericPattern + ") THEN " +
+        return String.format("CASE WHEN REGEXP_LIKE(%1$s, " + numericNonFPPattern + ") THEN " +
                         "CAST(%1$s AS " + DEFAULT_DECIMAL_STR + ") " +
                         "ELSE NULL " +
                         "END",

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/TrinoDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/TrinoDBFunctionSymbolFactory.java
@@ -7,16 +7,11 @@ import it.unibz.inf.ontop.model.term.TermFactory;
 import it.unibz.inf.ontop.model.term.functionsymbol.db.*;
 import it.unibz.inf.ontop.model.type.DBTermType;
 import it.unibz.inf.ontop.model.type.DBTypeFactory;
-import it.unibz.inf.ontop.model.type.RDFDatatype;
 import it.unibz.inf.ontop.model.type.TypeFactory;
 
-import java.util.UUID;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
-import static it.unibz.inf.ontop.model.term.functionsymbol.db.impl.MySQLDBFunctionSymbolFactory.UUID_STR;
-import static it.unibz.inf.ontop.model.type.impl.DefaultSQLDBTypeFactory.*;
-import static it.unibz.inf.ontop.model.type.impl.PostgreSQLDBTypeFactory.*;
+import static it.unibz.inf.ontop.model.type.impl.TrinoDBTypeFactory.DEFAULT_DECIMAL_STR;
 import static it.unibz.inf.ontop.model.type.impl.SnowflakeDBTypeFactory.TIMESTAMP_LOCAL_TZ_STR;
 import static it.unibz.inf.ontop.model.type.impl.SnowflakeDBTypeFactory.TIMESTAMP_NO_TZ_STR;
 
@@ -225,4 +220,98 @@ public class TrinoDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
         return dbRight;
     }
 
+    /**
+     * XSD CAST functions
+     */
+    @Override
+    protected String serializeCheckAndConvertFloatFromNonFPNumeric(ImmutableList<? extends ImmutableTerm> terms,
+                                                                   Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN (CAST(%1$s AS REAL) NOT BETWEEN -3.40E38 AND -1.18E-38 AND " +
+                        "CAST(%1$s AS REAL) NOT BETWEEN 1.18E-38 AND 3.40E38 AND CAST(%1$s AS REAL) != 0) THEN NULL " +
+                        "ELSE CAST(%1$s AS REAL) END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
+                                                    Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN NOT REGEXP_LIKE(%1$s, " + numericPattern + ")" +
+                        " THEN NULL ELSE CAST(%1$s AS DOUBLE) END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertFloat(ImmutableList<? extends ImmutableTerm> terms,
+                                                   Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN NOT REGEXP_LIKE(%1$s, " + numericPattern + ") THEN NULL " +
+                        "WHEN (CAST(%1$s AS REAL) NOT BETWEEN -3.40E38 AND -1.18E-38 AND " +
+                        "CAST(%1$s AS REAL) NOT BETWEEN 1.18E-38 AND 3.40E38 AND CAST(%1$s AS REAL) != 0) THEN NULL " +
+                        "ELSE CAST(%1$s AS REAL) END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN REGEXP_LIKE(%1$s, " + numericPattern + ") THEN " +
+                        "CAST(%1$s AS " + DEFAULT_DECIMAL_STR + ") " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertInteger(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN REGEXP_LIKE(%1$s, "+ numericPattern +") THEN " +
+                        "CAST(FLOOR(ABS(CAST(%1$s AS " + DEFAULT_DECIMAL_STR + "))) * SIGN(CAST(%1$s AS DECIMAL)) AS INTEGER) " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertIntegerFromBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                                Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN %1$s='1' THEN 1 " +
+                        "WHEN UPPER(%1$s) LIKE 'TRUE' THEN 1 " +
+                        "WHEN %1$s='0' THEN 0 " +
+                        "WHEN UPPER(%1$s) LIKE 'FALSE' THEN 0 " +
+                        "ELSE NULL " +
+                        "END",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertBoolean(ImmutableList<? extends ImmutableTerm> terms,
+                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String term = termConverter.apply(terms.get(0));
+        return String.format("(CASE WHEN CAST(%1$s AS " + DEFAULT_DECIMAL_STR + ") = 0 THEN 'false' " +
+                        "WHEN %1$s = '' THEN 'false' " +
+                        "ELSE 'true' " +
+                        "END)",
+                term);
+    }
+
+    @Override
+    protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
+                                                            Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        String datePattern1 = "'^[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}$'";
+        String datePattern2 = "'^[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}$'";
+        String datePattern3 = "'^[0-9]{1,2}-[0-9]{1,2}-[0-9]{4}$'";
+        String datePattern4 = "'^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$'";
+        String term = termConverter.apply(terms.get(0));
+        return String.format("CASE WHEN (REGEXP_LIKE(%1$s, " + datePattern1 + ") AND " +
+                        "REGEXP_LIKE(%1$s, " + datePattern2 +") AND " +
+                        "REGEXP_LIKE(%1$s, " + datePattern3 +") AND " +
+                        "REGEXP_LIKE(%1$s, " + datePattern4 +") ) " +
+                        " THEN NULL ELSE CAST(%1$s AS DATE) END",
+                term);
+    }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/DefaultSQLDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/DefaultSQLDBTypeFactory.java
@@ -146,7 +146,7 @@ public class DefaultSQLDBTypeFactory implements SQLDBTypeFactory {
                     new NumberDBTermType(DOUBLE_STR, rootTermType.getAncestry(), xsdDouble, FLOAT_DOUBLE),
                     new NumberDBTermType(DOUBLE_PREC_STR, rootTermType.getAncestry(), xsdDouble, FLOAT_DOUBLE),
                     new BooleanDBTermType(BOOLEAN_STR, rootTermType.getAncestry(), xsdBoolean),
-                    new NonStringNonNumberNonBooleanNonDatetimeDBTermType(DATE_STR, rootAncestry, typeFactory.getDatatype(XSD.DATE)),
+                    new DateDBTermType(DATE_STR, rootAncestry, typeFactory.getDatatype(XSD.DATE)),
                     new NonStringNonNumberNonBooleanNonDatetimeDBTermType(TIME_STR, rootTermType.getAncestry(), typeFactory.getDatatype(XSD.TIME)),
                     new DatetimeDBTermType(TIMESTAMP_STR, rootTermType.getAncestry(), typeFactory.getXsdDatetimeDatatype())
                 )

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/DuckDBDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/DuckDBDBTypeFactory.java
@@ -28,7 +28,7 @@ public class DuckDBDBTypeFactory extends DefaultSQLDBTypeFactory {
     public static final String JSON_STR = "JSON";
     public static final String BYTEA_STR = "BYTEA";
 
-    private static final String DEFAULT_DECIMAL_STR = "DECIMAL(38, 18)";
+    public static final String DEFAULT_DECIMAL_STR = "DECIMAL(38, 18)";
 
 
     protected DuckDBDBTypeFactory(Map<String, DBTermType> typeMap, ImmutableMap<DefaultTypeCode, String> defaultTypeCodeMap) {

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/H2SQLDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/H2SQLDBTypeFactory.java
@@ -14,7 +14,7 @@ import static it.unibz.inf.ontop.model.type.DBTermType.Category.DECIMAL;
 public class H2SQLDBTypeFactory extends DefaultSQLDBTypeFactory {
 
     protected static final String GEOMETRY_STR = "GEOMETRY";
-    private static final String DEFAULT_DECIMAL_STR = "DECIMAL(20, 6)";
+    public static final String DEFAULT_DECIMAL_STR = "DECIMAL(20, 6)";
     private final DatabaseInfoSupplier databaseInfoSupplier;
 
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/SQLServerDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/SQLServerDBTypeFactory.java
@@ -20,7 +20,7 @@ public class SQLServerDBTypeFactory extends DefaultSQLDBTypeFactory {
     public static final String DATETIME2_STR = "DATETIME2";
     public static final String DATETIMEOFFSET_STR = "DATETIMEOFFSET";
     public static final String UNIQUEIDENTIFIER_STR = "UNIQUEIDENTIFIER";
-    private static final String DEFAULT_DECIMAL_STR = "DECIMAL(38, 19)";
+    public static final String DEFAULT_DECIMAL_STR = "DECIMAL(38, 19)";
 
 
     @AssistedInject

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/SparkSQLDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/SparkSQLDBTypeFactory.java
@@ -22,7 +22,7 @@ public class SparkSQLDBTypeFactory extends DefaultSQLDBTypeFactory {
     protected static final String SHORT_STR = "SHORT";
     protected static final String LONG_STR = "LONG";
     protected static final String STRING_STR = "STRING";
-    private static final String DECIMAL_38_10_STR = "DECIMAL(38, 10)";
+    public static final String DECIMAL_38_10_STR = "DECIMAL(38, 10)";
 
     @AssistedInject
     protected SparkSQLDBTypeFactory(@Assisted TermType rootTermType, @Assisted TypeFactory typeFactory) {

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/TrinoDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/TrinoDBTypeFactory.java
@@ -26,7 +26,7 @@ public class TrinoDBTypeFactory extends DefaultSQLDBTypeFactory {
 
     protected static final String GEOMETRY_STR = "GEOMETRY";
 
-    private static final String DEFAULT_DECIMAL_STR = "DECIMAL(38, 18)";
+    public static final String DEFAULT_DECIMAL_STR = "DECIMAL(38, 18)";
 
 
     protected TrinoDBTypeFactory(Map<String, DBTermType> typeMap, ImmutableMap<DefaultTypeCode, String> defaultTypeCodeMap) {

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/AbstractCastFunctionsTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/AbstractCastFunctionsTest.java
@@ -1,0 +1,1108 @@
+package it.unibz.inf.ontop.docker.lightweight;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableMultiset;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractCastFunctionsTest extends AbstractDockerRDF4JTest {
+
+    protected static final String OBDA_FILE = "/books/books.obda";
+    protected static final String OWL_FILE = "/books/books.owl";
+
+    @Test
+    public void testCastFloatFromFloat() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"2.0654\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"2.0654\"^^xsd:float"));
+    }
+
+    @Test
+    public void testCastFloatFromDouble() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"0\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastFloatFromDoubleExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastFloatFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"0.0\"^^xsd:float");
+    }
+
+    @Test
+    public void testCastFloatFromDecimal1() {
+
+        String query = "PREFIX  ns:  <http://example.org/ns#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  ?x ns:discount ?discount .\n"
+                + "   BIND (xsd:float(?discount) AS ?v)\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastFloatFromDecimal1ExpectedValues());
+    }
+
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.20\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.20\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Test
+    public void testCastFloatFromDecimal2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"0.0\"^^xsd:decimal) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastFloatFromDecimal2ExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastFloatFromDecimal2ExpectedValues() {
+        return ImmutableSet.of("\"0.0\"^^xsd:float");
+    }
+
+    @Test
+    public void testCastFloatFromInteger() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"91214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastFloatFromIntegerExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastFloatFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"91214.0\"^^xsd:float");
+    }
+
+    @Test
+    public void testCastFloatFromDateTime() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastFloatFromDate() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastFloatFromBoolean() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"true\"^^xsd:boolean) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastFloatFromBooleanExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastFloatFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1.0\"^^xsd:float");
+    }
+
+    @Test
+    public void testCastFloatFromString1() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x dc:title ?title . "
+                + " BIND(xsd:float(?title) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastFloatFromString2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"2.0654\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"2.0654\"^^xsd:float"));
+    }
+
+    @Test
+    public void testCastFloatFromString3() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"2\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastFloatFromString3ExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastFloatFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2.0\"^^xsd:float");
+    }
+
+    @Test
+    public void testCastFloatFromString4() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:float(\"abc\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastDoubleFromFloat() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"2.6\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"2.6\"^^xsd:double"));
+    }
+
+    @Test
+    public void testCastDoubleFromDouble() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"0.0\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"0.0\"^^xsd:double"));
+    }
+
+    @Test
+    public void testCastDoubleFromDecimal() {
+
+        String query = "PREFIX  ns:  <http://example.org/ns#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  ?x ns:discount ?discount .\n"
+                + "   BIND (xsd:double(?discount) AS ?v)\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDoubleFromDecimalExpectedValues());
+    }
+
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.20\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.20\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Test
+    public void testCastDoubleFromInteger() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"91214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDoubleFromIntegerExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDoubleFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"91214.0\"^^xsd:double");
+    }
+
+    @Test
+    public void testCastDoubleFromDateTime() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastDoubleFromDate() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastDoubleFromBoolean() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"true\"^^xsd:boolean) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDoubleFromBooleanExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDoubleFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1.0\"^^xsd:double");
+    }
+
+    @Test
+    public void testCastDoubleFromString1() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"2.0654\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"2.0654\"^^xsd:double"));
+    }
+
+    @Test
+    public void testCastDoubleFromString2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"2\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDoubleFromString2ExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDoubleFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2.0\"^^xsd:double");
+    }
+
+    @Test
+    public void testCastDoubleFromString3() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:double(\"abc\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastDecimalFromFloat() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"2.6\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDecimalFromFloatExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDecimalFromFloatExpectedValues() {
+        return ImmutableSet.of("\"2.6\"^^xsd:decimal");
+    }
+
+    @Test
+    public void testCastDecimalFromDouble() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"2.0654\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDecimalFromDoubleExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDecimalFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"2.0654\"^^xsd:decimal");
+    }
+
+    @Test
+    public void testCastDecimalFromDecimal1() {
+
+        String query = "PREFIX  ns:  <http://example.org/ns#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  ?x ns:discount ?discount .\n"
+                + "   BIND (xsd:decimal(?discount) AS ?v)\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDecimalFromDecimal1ExpectedValues());
+    }
+
+    protected ImmutableMultiset<String> getCastDecimalFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.20\"^^xsd:decimal", "\"0.25\"^^xsd:decimal", "\"0.20\"^^xsd:decimal",
+                "\"0.15\"^^xsd:decimal");
+    }
+
+    @Test
+    public void testCastDecimalFromDecimal2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"0.0\"^^xsd:decimal) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"0.0\"^^xsd:decimal"));
+    }
+
+    @Test
+    public void testCastDecimalFromInteger() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"19991214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDecimalFromIntegerExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDecimalFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"19991214\"^^xsd:decimal");
+    }
+
+    @Test
+    public void testCastDecimalFromDateTime() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastDecimalFromDate() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastDecimalFromBoolean() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"true\"^^xsd:boolean) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDecimalFromBooleanExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDecimalFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1.0\"^^xsd:decimal");
+    }
+
+    @Test
+    public void testCastDecimalFromString1() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x dc:title ?title . "
+                + " BIND(xsd:decimal(?title) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastDecimalFromString2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"2.0654\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDecimalFromString2ExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDecimalFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2.0654\"^^xsd:decimal");
+    }
+
+    @Test
+    public void testCastDecimalFromString3() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"2\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDecimalFromString3ExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2.0\"^^xsd:decimal");
+    }
+
+    @Test
+    public void testCastDecimalFromString4() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:decimal(\"abc\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastIntegerFromFloat1() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"2.0654\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"2\"^^xsd:integer"));
+    }
+
+    @Test
+    public void testCastIntegerFromFloat2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"2.6\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"2\"^^xsd:integer"));
+    }
+
+    @Test
+    public void testCastIntegerFromFloat3() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"-2.6\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"-2\"^^xsd:integer"));
+    }
+
+    @Test
+    public void testCastIntegerFromDouble() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"0.0\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"0\"^^xsd:integer"));
+    }
+
+    @Test
+    public void testCastIntegerFromDecimal1() {
+
+        String query = "PREFIX  ns:  <http://example.org/ns#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  ?x ns:discount ?discount .\n"
+                + "   BIND (xsd:integer(?discount) AS ?v)\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableMultiset.of("\"0\"^^xsd:integer", "\"0\"^^xsd:integer",
+                "\"0\"^^xsd:integer", "\"0\"^^xsd:integer"));
+    }
+
+    @Test
+    public void testCastIntegerFromDecimal2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"0.0\"^^xsd:decimal) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"0\"^^xsd:integer"));
+    }
+
+
+    @Test
+    public void testCastIntegerFromInteger() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"19991214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"19991214\"^^xsd:integer"));
+    }
+
+    @Test
+    public void testCastIntegerFromDateTime() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastIntegerFromDate() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastIntegerFromBoolean() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"true\"^^xsd:boolean) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"1\"^^xsd:integer"));
+    }
+
+    @Test
+    public void testCastIntegerFromString1() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x dc:title ?title . "
+                + " BIND(xsd:integer(?title) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastIntegerFromString2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"2.0654\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"2\"^^xsd:integer"));
+    }
+
+    @Test
+    public void testCastIntegerFromString3() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"2.5\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"2\"^^xsd:integer"));
+    }
+
+    @Test
+    public void testCastIntegerFromString4() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:integer(\"abc\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastBooleanFromFloat() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"2.0654\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastBooleanFromFloatExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastBooleanFromFloatExpectedValues() {
+        return ImmutableSet.of("\"true\"^^xsd:boolean");
+    }
+
+    @Test
+    public void testCastBooleanFromDouble() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"0.0\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastBooleanFromDoubleExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastBooleanFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"false\"^^xsd:boolean");
+    }
+
+    @Test
+    public void testCastBooleanFromDecimal() {
+
+        String query = "PREFIX  ns:  <http://example.org/ns#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  ?x ns:discount ?discount .\n"
+                + "   BIND (xsd:boolean(?discount) AS ?v)\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastBooleanFromDecimalExpectedValues());
+    }
+
+    protected ImmutableMultiset<String> getCastBooleanFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"true\"^^xsd:boolean", "\"true\"^^xsd:boolean",
+                "\"true\"^^xsd:boolean", "\"true\"^^xsd:boolean");
+    }
+
+    @Test
+    public void testCastBooleanFromInteger() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"19991214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastBooleanFromIntegerExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastBooleanFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"true\"^^xsd:boolean");
+    }
+
+    @Test
+    public void testCastBooleanFromDateTime() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastBooleanFromDate() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastBooleanFromBoolean() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"true\"^^xsd:boolean) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"true\"^^xsd:boolean"));
+    }
+
+    @Test
+    public void testCastBooleanFromString1() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
+                + "SELECT ?v WHERE {\n"
+                + " ?x dc:title ?title . "
+                + " BIND(xsd:boolean(?title) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+
+    @Test
+    public void testCastBooleanFromString2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"2.0654\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastBooleanFromString3() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"1\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastBooleanFromString3ExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastBooleanFromString3ExpectedValues() {
+        return ImmutableSet.of("\"true\"^^xsd:boolean");
+    }
+
+    @Test
+    public void testCastBooleanFromString4() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:boolean(\"false\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastBooleanFromString4ExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastBooleanFromString4ExpectedValues() {
+        return ImmutableSet.of("\"false\"^^xsd:boolean");
+    }
+
+    @Test
+    public void testCastStringFromFloat() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"2.0654\"^^xsd:float) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"2.0654\"^^xsd:string"));
+    }
+
+    @Test
+    public void testCastStringFromDouble() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"0.0\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"0.0\"^^xsd:string"));
+    }
+
+    @Test
+    public void testCastStringFromDecimal1() {
+
+        String query = "PREFIX  ns:  <http://example.org/ns#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  ?x ns:discount ?discount .\n"
+                + "   BIND (xsd:string(?discount) AS ?v)\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastStringFromDecimal1ExpectedValues());
+    }
+
+    protected ImmutableMultiset<String> getCastStringFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.20\"^^xsd:string", "\"0.25\"^^xsd:string", "\"0.20\"^^xsd:string",
+                "\"0.15\"^^xsd:string");
+    }
+
+    @Test
+    public void testCastStringFromDecimal2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"2.0\"^^xsd:decimal) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"2.0\"^^xsd:string"));
+    }
+
+    @Test
+    public void testCastStringFromInteger() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"19991214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"19991214\"^^xsd:string"));
+    }
+
+    @Test
+    public void testCastStringFromDateTime() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"1999-12-14T09:30:00\"^^xsd:string"));
+    }
+
+    @Test
+    public void testCastStringFromDate() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"1999-12-14\"^^xsd:string"));
+    }
+
+    @Test
+    public void testCastStringFromBoolean() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"true\"^^xsd:boolean) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"true\"^^xsd:string"));
+    }
+
+    @Test
+    public void testCastStringFromString1() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"2.0654\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"2.0654\"^^xsd:string"));
+    }
+
+    @Test
+    public void testCastStringFromString2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"abc\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"abc\"^^xsd:string"));
+    }
+
+    @Test
+    public void testCastStringFromIRI() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"http://www.w3.org/2001/XMLSchema#string\") AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"http://www.w3.org/2001/XMLSchema#string\"^^xsd:string"));
+    }
+
+    @Test
+    public void testCastStringFromLiteral() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:string(\"abc\"^^rdfs:literal) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"abc\"^^xsd:string"));
+    }
+
+    @Test
+    public void testCastDateFromDateTime1() {
+
+        String query = "PREFIX  ns:  <http://example.org/ns#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  ?x ns:pubYear ?year .\n"
+                + "   BIND (xsd:date(?year) AS ?v)\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"2014-06-05\"^^xsd:date", "\"2011-12-08\"^^xsd:date",
+                "\"2015-09-21\"^^xsd:date", "\"1970-11-05\"^^xsd:date"));
+    }
+
+    @Test
+    public void testCastDateFromDateTime2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:date(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"1999-12-14\"^^xsd:date"));
+    }
+
+    @Test
+    public void testCastDateFromDate() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:date(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"1999-12-14\"^^xsd:date"));
+    }
+
+    @Test
+    public void testCastDateFromString1() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:date(\"1999-12-14\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"1999-12-14\"^^xsd:date"));
+    }
+
+    @Test
+    public void testCastDateFromString2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:date(\"199912-14\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastDateFromInteger() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:date(\"19991214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastDateFromDouble() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:date(\"19991214.12\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Disabled("Timezones are system specific")
+    @Test
+    public void testCastDateTimeFromDateTime1() {
+
+        String query = "PREFIX  ns:  <http://example.org/ns#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  ?x ns:pubYear ?year .\n"
+                + "   BIND (xsd:dateTime(?year) AS ?v)\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDateTimeFromDateTime1ExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDateTimeFromDateTime1ExpectedValues() {
+        return ImmutableSet.of("\"2014-06-05 16:47:52+02\"^^xsd:dateTime",
+                "\"2011-12-08 11:30:00+01\"^^xsd:dateTime",
+                "\"2015-09-21 09:23:06+02\"^^xsd:dateTime",
+                "\"1970-11-05 07:50:00+01\"^^xsd:dateTime");
+    }
+
+    @Test
+    public void testCastDateTimeFromDateTime2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"1999-12-14T09:30:00\"^^xsd:dateTime) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of("\"1999-12-14T09:30:00\"^^xsd:dateTime"));
+    }
+
+    @Test
+    public void testCastDateTimeFromDate1() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"1999-12-14\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDateTimeFromDate1ExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDateTimeFromDate1ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00\"^^xsd:dateTime");
+    }
+
+    @Test
+    public void testCastDateTimeFromDate2() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"1999-12-14Z\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDateTimeFromDate2ExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDateTimeFromDate2ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00\"^^xsd:dateTime");
+    }
+
+    @Test
+    public void testCastDateTimeFromDate3() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"1999-12-14+01:00\"^^xsd:date) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDateTimeFromDate3ExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDateTimeFromDate3ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 01:00:00\"^^xsd:dateTime");
+    }
+
+    @Test
+    public void testCastDateTimeFromString() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"1999-12-14T09:30:00\"^^xsd:string) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, getCastDateTimeFromStringExpectedValues());
+    }
+
+    protected ImmutableSet<String> getCastDateTimeFromStringExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 09:30:00\"^^xsd:dateTime");
+    }
+
+    @Test
+    public void testCastDateTimeFromInteger() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"19991214\"^^xsd:integer) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+
+    @Test
+    public void testCastDateTimeFromDouble() {
+
+        String query = "PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>\n"
+                + "SELECT ?v WHERE \n"
+                + "{  BIND(xsd:dateTime(\"19991214.12\"^^xsd:double) AS ?v )\n"
+                + "}";
+
+        executeAndCompareValues(query, ImmutableSet.of());
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/athena/CastAthenaTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/athena/CastAthenaTest.java
@@ -1,0 +1,105 @@
+package it.unibz.inf.ontop.docker.lightweight.athena;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.AthenaLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@AthenaLightweightTest
+public class CastAthenaTest extends AbstractCastFunctionsTest {
+    private static final String PROPERTIES_FILE = "/books/athena/books-athena.properties";
+    private static final String OBDA_FILE_ATHENA = "/books/athena/books-athena.obda";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE_ATHENA, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    //TODO: Trino timestamp denormalizer missing
+    @Override
+    @Test
+    @Disabled("Lack of Trino timestamp denormalizer")
+    public void testCastDateTimeFromString() {
+        super.testCastDateTimeFromString();
+    }
+
+    //TODO: Trino timestamp denormalizer missing
+    @Override
+    @Test
+    @Disabled("Lack of Trino timestamp denormalizer")
+    public void testCastDateFromDateTime1() {
+        super.testCastDateFromDateTime1();
+    }
+
+    //TODO: Trino timestamp denormalizer missing
+    @Override
+    @Test
+    @Disabled("Lack of Trino timestamp denormalizer")
+    public void testCastDateFromDateTime2() {
+        super.testCastDateFromDateTime2();
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"2.065400000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromFloatExpectedValues() {
+        return ImmutableSet.of("\"2.600000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"19991214.000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2.065400000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2.000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate1ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.000 UTC\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate2ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.000 UTC\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate3ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.000 +01:00\"^^xsd:dateTime");
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/db2/CastDB2Test.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/db2/CastDB2Test.java
@@ -1,0 +1,108 @@
+package it.unibz.inf.ontop.docker.lightweight.db2;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.DB2LightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@DB2LightweightTest
+public class CastDB2Test extends AbstractCastFunctionsTest {
+
+    private static final String PROPERTIES_FILE = "/books/db2/books-db2.properties";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDoubleFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromFloatExpectedValues() {
+        return ImmutableSet.of("\"2.600000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"2.065400\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"19991214.000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2.065400\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2.000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDateTime1ExpectedValues() {
+        return ImmutableSet.of("\"2014-06-05T16:47:52.000000\"^^xsd:dateTime",
+                "\"2011-12-08T11:30:00.000000\"^^xsd:dateTime",
+                "\"2015-09-21T09:23:06.000000\"^^xsd:dateTime",
+                "\"1970-11-05T07:50:00.000000\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate1ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.0\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromStringExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 09:30:00.0\"^^xsd:dateTime");
+    }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in DB2 renders date-datetime casts impossible")
+    public void testCastDateTimeFromDate2() {
+        super.testCastDateTimeFromDate2();
+    }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in DB2 renders date-datetime casts impossible")
+    public void testCastDateTimeFromDate3() {
+        super.testCastDateTimeFromDate3();
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/denodo/CastDenodoTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/denodo/CastDenodoTest.java
@@ -1,0 +1,65 @@
+package it.unibz.inf.ontop.docker.lightweight.denodo;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.DenodoLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@DenodoLightweightTest
+public class CastDenodoTest extends AbstractCastFunctionsTest {
+
+    private static final String PROPERTIES_FILE = "/books/denodo/books-denodo.properties";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in Denodo renders this specific date-datetime casts impossible")
+    public void testCastDateTimeFromDate2() {
+        super.testCastDateTimeFromDate2();
+    }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in Denodo renders this specific date-datetime casts impossible")
+    public void testCastDateTimeFromDate3() {
+        super.testCastDateTimeFromDate3();
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate1ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.0\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromStringExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 09:30:00.0\"^^xsd:dateTime");
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/dremio/CastDremioTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/dremio/CastDremioTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeAll;
 import java.io.IOException;
 import java.sql.SQLException;
 
-@DremioLightweightTest
+//@DremioLightweightTest
 public class CastDremioTest extends AbstractCastFunctionsTest {
     private static final String PROPERTIES_FILE = "/books/dremio/books-dremio.properties";
     private static final String OBDA_FILE = "/books/dremio/books-dremio.obda";

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/dremio/CastDremioTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/dremio/CastDremioTest.java
@@ -1,0 +1,25 @@
+package it.unibz.inf.ontop.docker.lightweight.dremio;
+
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.DremioLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@DremioLightweightTest
+public class CastDremioTest extends AbstractCastFunctionsTest {
+    private static final String PROPERTIES_FILE = "/books/dremio/books-dremio.properties";
+    private static final String OBDA_FILE = "/books/dremio/books-dremio.obda";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/duckdb/CastDuckDBTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/duckdb/CastDuckDBTest.java
@@ -1,0 +1,91 @@
+package it.unibz.inf.ontop.docker.lightweight.duckdb;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.DuckDBLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@DuckDBLightweightTest
+public class CastDuckDBTest extends AbstractCastFunctionsTest {
+
+    private static final String PROPERTIES_FILE = "/books/duckdb/books-duckdb.properties";
+    private static final String OBDA_FILE_DUCKDB = "/books/duckdb/books-duckdb.obda";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE_DUCKDB, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in DuckDB limits datetime cast due to patterns")
+    public void testCastDateTimeFromDate2() { super.testCastDateTimeFromDate2(); }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in DuckDB limits datetime cast due to patterns")
+    public void testCastDateTimeFromDate3() {
+        super.testCastDateTimeFromDate3();
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    //NOTE: Valid but not consistent with other DB denormalizations
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate1ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14T00:00Z\"^^xsd:dateTime");
+    }
+
+    //NOTE: Valid but not consistent with other DB denormalizations
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromStringExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14T09:30Z\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"2.065400000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromFloatExpectedValues() {
+        return ImmutableSet.of("\"2.600000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"19991214.000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2.065400000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2.000000000000000000\"^^xsd:decimal");
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mariadb/CastMariaDBTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mariadb/CastMariaDBTest.java
@@ -1,0 +1,91 @@
+package it.unibz.inf.ontop.docker.lightweight.mariadb;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.MariaDBLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+@MariaDBLightweightTest
+public class CastMariaDBTest extends AbstractCastFunctionsTest {
+
+    private static final String PROPERTIES_FILE = "/books/mariadb/books-mariadb.properties";
+
+    @BeforeAll
+    public static void before() {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() {
+        release();
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"19991214.000000000000000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2.065400000000000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2.000000000000000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDoubleFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromDecimal2ExpectedValues() {
+        return ImmutableSet.of("\"0\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"0\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDoubleFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"91214\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDoubleFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"91214\"^^xsd:double");
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mssql/CastSQLServerTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mssql/CastSQLServerTest.java
@@ -1,0 +1,118 @@
+package it.unibz.inf.ontop.docker.lightweight.mssql;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.MSSQLLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@MSSQLLightweightTest
+public class CastSQLServerTest extends AbstractCastFunctionsTest {
+    private static final String PROPERTIES_FILE = "/books/mssql/books-mssql.properties";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromFloatExpectedValues() {
+        return ImmutableSet.of("\"2.6000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"2.0654000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"19991214.0000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2.0654000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2.0000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromFloatExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"0\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastBooleanFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"1\"^^xsd:boolean", "\"1\"^^xsd:boolean",
+                "\"1\"^^xsd:boolean", "\"1\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromString3ExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromString4ExpectedValues() {
+        return ImmutableSet.of("\"0\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate1ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.0\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate2ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.0\"^^xsd:dateTime");
+    }
+
+    @Override
+    @Disabled("Unsupported cast format for SQL Server")
+    @Test
+    public void testCastDateTimeFromDate3() {
+        super.testCastDateTimeFromDate3();
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromStringExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 09:30:00.0\"^^xsd:dateTime");
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mysql/CastMySQLTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mysql/CastMySQLTest.java
@@ -1,0 +1,59 @@
+package it.unibz.inf.ontop.docker.lightweight.mysql;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.MySQLLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+@MySQLLightweightTest
+public class CastMySQLTest extends AbstractCastFunctionsTest {
+
+    private static final String PROPERTIES_FILE = "/books/mysql/books-mysql.properties";
+
+    @BeforeAll
+    public static void before() {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() {
+        release();
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"19991214.000000000000000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2.065400000000000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2.000000000000000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDateTime1ExpectedValues() {
+        return ImmutableSet.of("\"2014-06-05T16:47:52+00:00\"^^xsd:dateTime",
+                "\"2011-12-08T11:30:00+00:00\"^^xsd:dateTime",
+                "\"2015-09-21T09:23:06+00:00\"^^xsd:dateTime",
+                "\"1970-11-05T07:50:00+00:00\"^^xsd:dateTime");
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/oracle/CastOracleTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/oracle/CastOracleTest.java
@@ -26,11 +26,6 @@ public class CastOracleTest extends AbstractCastFunctionsTest {
     }
 
     @Override
-    protected ImmutableSet<String> getCastFloatFromDoubleExpectedValues() {
-        return ImmutableSet.of("\"0\"^^xsd:float");
-    }
-
-    @Override
     protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
         return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
                 "\"0.15\"^^xsd:float");

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/oracle/CastOracleTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/oracle/CastOracleTest.java
@@ -1,0 +1,188 @@
+package it.unibz.inf.ontop.docker.lightweight.oracle;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.OracleLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+@OracleLightweightTest
+public class CastOracleTest extends AbstractCastFunctionsTest {
+
+    private static final String PROPERTIES_FILE = "/books/oracle/books-oracle.properties";
+    private static final String OBDA_FILE = "/books/oracle/books-oracle.obda";
+
+    @BeforeAll
+    public static void before() {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() {
+        release();
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"0\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromDecimal2ExpectedValues() {
+        return ImmutableSet.of("\"0\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"91214\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDoubleFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"91214\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDoubleFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDoubleFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDecimalFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:decimal", "\"0.25\"^^xsd:decimal", "\"0.2\"^^xsd:decimal",
+                "\"0.15\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastStringFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:string", "\"0.25\"^^xsd:string", "\"0.2\"^^xsd:string",
+                "\"0.15\"^^xsd:string");
+    }
+
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromFloatExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"0\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastBooleanFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"1\"^^xsd:boolean", "\"1\"^^xsd:boolean",
+                "\"1\"^^xsd:boolean", "\"1\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromString3ExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromString4ExpectedValues() {
+        return ImmutableSet.of("\"0\"^^xsd:boolean");
+    }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in Oracle renders date-datetime casts impossible")
+    public void testCastDateFromDateTime1() {
+        super.testCastDateFromDateTime1();
+    }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in Oracle renders date-datetime casts impossible")
+    public void testCastDateFromDateTime2() {
+        super.testCastDateFromDateTime2();
+    }
+
+    @Override
+    @Test
+    @Disabled("TO_DATE in Oracle incorrectly adds hh:mm:ss")
+    public void testCastDateFromString1() {
+        super.testCastDateFromString1();
+    }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in Oracle renders date-datetime casts impossible")
+    public void testCastDateTimeFromDate1() {
+        super.testCastDateTimeFromDate1();
+    }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in Oracle renders date-datetime casts impossible")
+    public void testCastDateTimeFromDate2() {
+        super.testCastDateTimeFromDate2();
+    }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in Oracle renders date-datetime casts impossible")
+    public void testCastDateTimeFromDate3() {
+        super.testCastDateTimeFromDate3();
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDateTime1ExpectedValues() {
+        return ImmutableSet.of("\"2014-06-05T16:47:52.000000\"^^xsd:dateTime",
+                "\"2011-12-08T11:30:00.000000\"^^xsd:dateTime",
+                "\"2015-09-21T09:23:06.000000\"^^xsd:dateTime",
+                "\"1970-11-05T07:50:00.000000\"^^xsd:dateTime");
+    }
+
+    @Override
+    @Disabled("Oracle handling of TZ system dependent. Output is 1999-12-14 09:30:00.0 Europe/Rome\"^^xsd:dateTime")
+    @Test
+    public void testCastDateTimeFromString() {
+        super.testCastDateTimeFromString();
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/postgresql/CastPostgreSQLTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/postgresql/CastPostgreSQLTest.java
@@ -1,0 +1,86 @@
+package it.unibz.inf.ontop.docker.lightweight.postgresql;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableMultiset;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.PostgreSQLLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+@PostgreSQLLightweightTest
+public class CastPostgreSQLTest extends AbstractCastFunctionsTest {
+
+    private static final String PROPERTIES_FILE = "/books/postgresql/books-postgresql.properties";
+
+    @BeforeAll
+    public static void before() {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() {
+        release();
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"0\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromDecimal2ExpectedValues() {
+        return ImmutableSet.of("\"0\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"91214\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDoubleFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"91214\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDoubleFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDoubleFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate3ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00\"^^xsd:dateTime");
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/postgresql/CastPostgreSQLTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/postgresql/CastPostgreSQLTest.java
@@ -6,6 +6,8 @@ import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
 import it.unibz.inf.ontop.docker.lightweight.PostgreSQLLightweightTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 @PostgreSQLLightweightTest
 public class CastPostgreSQLTest extends AbstractCastFunctionsTest {
@@ -20,6 +22,30 @@ public class CastPostgreSQLTest extends AbstractCastFunctionsTest {
     @AfterAll
     public static void after() {
         release();
+    }
+
+    @Disabled("PostgresSQL adds different TZ to result depending on local time")
+    @Test
+    public void testCastDateTimeFromDate1() {
+        super.testCastDateTimeFromDate1();
+    }
+
+    @Disabled("PostgresSQL adds different TZ to result depending on local time")
+    @Test
+    public void testCastDateTimeFromDate2() {
+        super.testCastDateTimeFromDate2();
+    }
+
+    @Disabled("PostgresSQL adds different TZ to result depending on local time")
+    @Test
+    public void testCastDateTimeFromDate3() {
+        super.testCastDateTimeFromDate3();
+    }
+
+    @Disabled("PostgresSQL adds different TZ to result depending on local time")
+    @Test
+    public void testCastDateTimeFromString() {
+        super.testCastDateTimeFromString();
     }
 
     @Override

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/presto/CastPrestoTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/presto/CastPrestoTest.java
@@ -1,0 +1,105 @@
+package it.unibz.inf.ontop.docker.lightweight.presto;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.PrestoLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@PrestoLightweightTest
+public class CastPrestoTest extends AbstractCastFunctionsTest {
+
+    private static final String PROPERTIES_FILE = "/books/presto/books-presto.properties";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    //TODO: Trino timestamp denormalizer missing
+    @Override
+    @Test
+    @Disabled("Lack of Trino timestamp denormalizer")
+    public void testCastDateTimeFromString() {
+        super.testCastDateTimeFromString();
+    }
+
+    //TODO: Trino timestamp denormalizer missing
+    @Override
+    @Test
+    @Disabled("Lack of Trino timestamp denormalizer")
+    public void testCastDateFromDateTime1() {
+        super.testCastDateFromDateTime1();
+    }
+
+    //TODO: Trino timestamp denormalizer missing
+    @Override
+    @Test
+    @Disabled("Lack of Trino timestamp denormalizer")
+    public void testCastDateFromDateTime2() {
+        super.testCastDateFromDateTime2();
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"2.065400000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromFloatExpectedValues() {
+        return ImmutableSet.of("\"2.600000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"19991214.000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2.065400000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2.000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate1ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.000 UTC\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate2ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.000 UTC\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate3ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.000 +01:00\"^^xsd:dateTime");
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/snowflake/CastSnowflakeTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/snowflake/CastSnowflakeTest.java
@@ -1,0 +1,131 @@
+package it.unibz.inf.ontop.docker.lightweight.snowflake;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.SnowflakeLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+@SnowflakeLightweightTest
+public class CastSnowflakeTest extends AbstractCastFunctionsTest {
+
+    private static final String PROPERTIES_FILE = "/books/snowflake/books-snowflake.properties";
+
+    @BeforeAll
+    public static void before() {
+        initOBDA("/books/snowflake/books-snowflake.obda", OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() {
+        release();
+    }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in Snowflake limits datetime cast due to patterns")
+    public void testCastDateTimeFromDate2() { super.testCastDateTimeFromDate2(); }
+
+    @Override
+    @Test
+    @Disabled("Timestamp norm/denorm in Snowflake limits datetime cast due to patterns")
+    public void testCastDateTimeFromDate3() {
+        super.testCastDateTimeFromDate3();
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromFloatExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"0\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastBooleanFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"1\"^^xsd:boolean", "\"1\"^^xsd:boolean",
+                "\"1\"^^xsd:boolean", "\"1\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromString3ExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastBooleanFromString4ExpectedValues() {
+        return ImmutableSet.of("\"0\"^^xsd:boolean");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate1ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.000\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromStringExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.000\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDoubleFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastFloatFromBooleanExpectedValues() {
+        return ImmutableSet.of("\"1\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"2.0654000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromFloatExpectedValues() {
+        return ImmutableSet.of("\"2.6000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"19991214.0000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2.0654000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2.0000000000\"^^xsd:decimal");
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/snowflake/CastSnowflakeTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/snowflake/CastSnowflakeTest.java
@@ -86,7 +86,7 @@ public class CastSnowflakeTest extends AbstractCastFunctionsTest {
 
     @Override
     protected ImmutableSet<String> getCastDateTimeFromStringExpectedValues() {
-        return ImmutableSet.of("\"1999-12-14 00:00:00.000\"^^xsd:dateTime");
+        return ImmutableSet.of("\"1999-12-14 09:30:00.000\"^^xsd:dateTime");
     }
 
     @Override

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/spark/CastSparkSQLTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/spark/CastSparkSQLTest.java
@@ -1,0 +1,97 @@
+package it.unibz.inf.ontop.docker.lightweight.spark;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.SparkSQLLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@SparkSQLLightweightTest
+public class CastSparkSQLTest extends AbstractCastFunctionsTest {
+
+    private static final String PROPERTIES_FILE = "/books/spark/books-spark.properties";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate1ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.0\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate2ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.0\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromFloatExpectedValues() {
+        return ImmutableSet.of("\"2.6000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"19991214.0000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2.0654000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2.0000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"2.0654000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromStringExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 09:30:00.0\"^^xsd:dateTime");
+    }
+
+    //TODO: Add DateDenormFunctionSymbol for SparkSQL
+    @Disabled("DateDenormFunctionSymbol needed which removes 'Z' from patterns 1999-12-14Z")
+    @Override
+    @Test
+    public void testCastDateTimeFromDate2() {
+        super.testCastDateTimeFromDate2();
+    }
+
+    //TODO: Modify SparkSQLTimestampDenormFunctionSymbol for SparkSQL
+    @Disabled("SparkSQLTimestampDenormFunctionSymbol needs to add space before + sign in pattern 1999-12-14+01:00")
+    @Override
+    @Test
+    public void testCastDateTimeFromDate3() {
+        super.testCastDateTimeFromDate3();
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/trino/CastTrinoTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/trino/CastTrinoTest.java
@@ -1,0 +1,105 @@
+package it.unibz.inf.ontop.docker.lightweight.trino;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractCastFunctionsTest;
+import it.unibz.inf.ontop.docker.lightweight.TrinoLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@TrinoLightweightTest
+public class CastTrinoTest extends AbstractCastFunctionsTest {
+
+    private static final String PROPERTIES_FILE = "/books/trino/books-trino.properties";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    //TODO: Trino timestamp denormalizer missing
+    @Override
+    @Test
+    @Disabled("Lack of Trino timestamp denormalizer")
+    public void testCastDateTimeFromString() {
+        super.testCastDateTimeFromString();
+    }
+
+    //TODO: Trino timestamp denormalizer missing
+    @Override
+    @Test
+    @Disabled("Lack of Trino timestamp denormalizer")
+    public void testCastDateFromDateTime1() {
+        super.testCastDateFromDateTime1();
+    }
+
+    //TODO: Trino timestamp denormalizer missing
+    @Override
+    @Test
+    @Disabled("Lack of Trino timestamp denormalizer")
+    public void testCastDateFromDateTime2() {
+        super.testCastDateFromDateTime2();
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",
+                "\"0.15\"^^xsd:float");
+    }
+
+    @Override
+    protected ImmutableMultiset<String> getCastDoubleFromDecimalExpectedValues() {
+        return ImmutableMultiset.of("\"0.2\"^^xsd:double", "\"0.25\"^^xsd:double", "\"0.2\"^^xsd:double",
+                "\"0.15\"^^xsd:double");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromDoubleExpectedValues() {
+        return ImmutableSet.of("\"2.065400000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromFloatExpectedValues() {
+        return ImmutableSet.of("\"2.600000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromIntegerExpectedValues() {
+        return ImmutableSet.of("\"19991214.000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString2ExpectedValues() {
+        return ImmutableSet.of("\"2.065400000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDecimalFromString3ExpectedValues() {
+        return ImmutableSet.of("\"2.000000000000000000\"^^xsd:decimal");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate1ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.000 UTC\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate2ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.000 UTC\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableSet<String> getCastDateTimeFromDate3ExpectedValues() {
+        return ImmutableSet.of("\"1999-12-14 00:00:00.000 +01:00\"^^xsd:dateTime");
+    }
+}

--- a/test/sparql-compliance/src/test/java/it/unibz/inf/ontop/test/sparql/MemorySPARQLOntopQueryTest.java
+++ b/test/sparql-compliance/src/test/java/it/unibz/inf/ontop/test/sparql/MemorySPARQLOntopQueryTest.java
@@ -48,14 +48,8 @@ public class MemorySPARQLOntopQueryTest extends MemoryOntopTestCase {
 			basicManifest + "term-6",  // missing result
 			basicManifest + "term-7", // org.eclipse.rdf4j.query.MalformedQueryException: Encountered "."
 
-			// SPARQL cast with function call on the datatype is not supported, e.g., FILTER(datatype(xsd:double(?v)) = xsd:double)
-			castManifest + "cast-str",
-			castManifest + "cast-flt",
-			castManifest + "cast-dbl",
-			castManifest + "cast-dec",
-			castManifest + "cast-int",
-			castManifest + "cast-dT",
-			castManifest + "cast-bool",
+			castManifest + "cast-dec", // expected results seem to incorrectly miss one record
+			castManifest + "cast-dT", // cannot exhaustively check for all timestamp patterns
 
 			exprBuiltInManifest + "sameTerm-eq", // JdbcSQLException: Data conversion error converting "zzz"
 			exprBuiltInManifest + "sameTerm-not-eq", // JdbcSQLException: Data conversion error converting "1.0e0" (H2 issue: "1.0e0"^^xsd:#double in the data & result)

--- a/test/sparql-compliance/src/test/java/it/unibz/inf/ontop/test/sparql/MemorySPARQLOntopQueryTest.java
+++ b/test/sparql-compliance/src/test/java/it/unibz/inf/ontop/test/sparql/MemorySPARQLOntopQueryTest.java
@@ -48,7 +48,6 @@ public class MemorySPARQLOntopQueryTest extends MemoryOntopTestCase {
 			basicManifest + "term-6",  // missing result
 			basicManifest + "term-7", // org.eclipse.rdf4j.query.MalformedQueryException: Encountered "."
 
-			castManifest + "cast-dec", // expected results seem to incorrectly miss one record
 			castManifest + "cast-dT", // cannot exhaustively check for all timestamp patterns
 
 			exprBuiltInManifest + "sameTerm-eq", // JdbcSQLException: Data conversion error converting "zzz"

--- a/test/sparql-compliance/src/test/java/it/unibz/inf/ontop/test/sparql/MemorySPARQLOntopQueryTest.java
+++ b/test/sparql-compliance/src/test/java/it/unibz/inf/ontop/test/sparql/MemorySPARQLOntopQueryTest.java
@@ -70,9 +70,7 @@ public class MemorySPARQLOntopQueryTest extends MemoryOntopTestCase {
 			openWorldManifest +"open-eq-09", // JdbcSQLException: Data conversion error converting "xyz" ("xyz"^^xsd:integer in the data ONLY)
 			openWorldManifest +"open-eq-10", // JdbcSQLException: Data conversion error converting "xyz" ("xyz"^^xsd:integer in the data & result)
 			openWorldManifest +"open-eq-11", // JdbcSQLException: Data conversion error converting "xyz" ("xyz"^^xsd:integer in the data & result)
-			openWorldManifest +"open-eq-12", // JdbcSQLException: Data conversion error converting "xyz" ("xyz"^^xsd:integer in the data & result)
-
-			sortManifest + "dawg-sort-function" // SPARQL cast with function call on the datatype is not supported, e.g., ORDER BY xsd:integer(?o)
+			openWorldManifest +"open-eq-12" // JdbcSQLException: Data conversion error converting "xyz" ("xyz"^^xsd:integer in the data & result)
 	);
 
 	public MemorySPARQLOntopQueryTest(String testIRI, String name, String queryFileURL, String resultFileURL,

--- a/test/sparql-compliance/src/test/java/it/unibz/inf/ontop/test/sparql11/MemorySPARQL11QueryTest.java
+++ b/test/sparql-compliance/src/test/java/it/unibz/inf/ontop/test/sparql11/MemorySPARQL11QueryTest.java
@@ -35,9 +35,6 @@ public class MemorySPARQL11QueryTest extends MemoryOntopTestCase {
 
 	private static final ImmutableSet<String> IGNORE = ImmutableSet.of(
 
-			/* AGGREGATES */
-			aggregatesManifest + "agg-err-02", // SPARQL cast with function call on the datatype is not supported, e.g., COALESCE(xsd:double(?p),0)))
-
 			/* FUNCTIONS*/
 			functionsManifest + "hours", // TODO: incorrect answers when timezone is present (CAST ... AS TIMESTAMP)
 			functionsManifest + "day", // TODO: incorrect answers when timezone is present (CAST ... AS TIMESTAMP)

--- a/test/sparql-compliance/src/test/resources/logback-test.xml
+++ b/test/sparql-compliance/src/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
   </appender>
 
 
-  <root level="DEBUG">
+  <root level="error">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/test/sparql-compliance/src/test/resources/logback-test.xml
+++ b/test/sparql-compliance/src/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
   </appender>
 
 
-  <root level="error">
+  <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
This PR introduces support for cast functions from the [XPath Constructor Functions](https://www.w3.org/TR/sparql11-query/#FunctionMapping) section of the SPARQL 1.1 recommendation. 

Support is only extended for primitive types as per the matrix in the recommendation and date, resulting in the following new matrix (where always allowed (Y), never allowed (N) and dependent on the lexical value (M)):

![image](https://user-images.githubusercontent.com/73277915/228351550-88b06c15-e505-4c71-9011-ed1ed5b8d6f5.png)

The respective behavior of the functions strives to support the scenarios detailed in https://www.w3.org/TR/xpath-functions-31/#casting. However, due to the limitations of most SQL dialects, full compliance is not possible. Hence the following exceptions apply:
- `xsd:boolean`. Casting NaN to boolean should result in `"false"^^xsd:boolean`, however this check is not feasible for many DB dialects, hence there is mostly no special handling of these values with support limited to PostgreSQL, Oracle and Spark.
- `xsd:decimal`. Casting to DECIMAL results in values with scale 0 in several SQL dialects. As such the custom DECIMAL_STR with an arbitrary precision defined in the respective DBTypeFactory of a dialect is used for each cast.
- `xsd:dateTime`. The list of possible timestamp patterns is too large, and many dialects lack an effective way to check for these patterns without getting extremely verbose. Hence, it is not possible to often detect whether a value is a valid timestamp before the cast is performed. With the exception of SQL Server and Snowflake which have TRY_CAST functions, applying this function to other dialects comes with severe limitations.