### PR TITLE
Ontop property to ignore invalid mapping entries

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/IgnoreInvalidMappingEntriesTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/IgnoreInvalidMappingEntriesTest.java
@@ -1,0 +1,58 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class IgnoreInvalidMappingEntriesTest extends AbstractRDF4JTest {
+    private static final String OBDA_FILE = "/ignore-invalid-mapping-entries/test.obda";
+    private static final String SQL_SCRIPT = "/ignore-invalid-mapping-entries/test.sql";
+    private static final String PROPERTY_FILE = "/ignore-invalid-mapping-entries/ignore-invalid.properties";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE, null, PROPERTY_FILE, null);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void testCorrectNumberOfIndividuals() {
+        String query = "PREFIX : <http://www.ontop-vkg.com/ignore-invalid-test#>\n" +
+                "SELECT  ?v \n" +
+                "WHERE {\n" +
+                " ?v a :Animal . \n" +
+                "}";
+        assertEquals(8, runQueryAndCount(query));
+    }
+
+    @Test
+    public void testCorrectNumberOfPartiallyIncorrectIndividuals() {
+        String query = "PREFIX : <http://www.ontop-vkg.com/ignore-invalid-test#>\n" +
+                "SELECT  ?v \n" +
+                "WHERE {\n" +
+                " ?v a :Rabbit . \n" +
+                "}";
+        assertEquals(2, runQueryAndCount(query));
+    }
+
+    @Test
+    public void testCorrectNumberOfFullyIncorrectIndividuals() {
+        String query = "PREFIX : <http://www.ontop-vkg.com/ignore-invalid-test#>\n" +
+                "SELECT  ?v \n" +
+                "WHERE {\n" +
+                " ?v a :Turtle . \n" +
+                "}";
+        assertEquals(0, runQueryAndCount(query));
+    }
+}

--- a/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/ignore-invalid.properties
+++ b/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/ignore-invalid.properties
@@ -1,0 +1,1 @@
+ontop.ignoreInvalidMappingEntries = true

--- a/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/test.obda
+++ b/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/test.obda
@@ -1,0 +1,32 @@
+[PrefixDeclaration]
+:		http://www.ontop-vkg.com/ignore-invalid-test#
+owl:		http://www.w3.org/2002/07/owl#
+rdf:		http://www.w3.org/1999/02/22-rdf-syntax-ns#
+xml:		http://www.w3.org/XML/1998/namespace
+xsd:		http://www.w3.org/2001/XMLSchema#
+obda:		https://w3id.org/obda/vocabulary#
+rdfs:		http://www.w3.org/2000/01/rdf-schema#
+quest:		http://obda.org/quest#
+
+[MappingDeclaration] @collection [[
+mappingId	MAPID-dogs
+target		:animals/{name} a :Animal; a :Dog; :name {name}; :age {age}; :breed {breed} .
+source		SELECT name, age, breed FROM dogs;
+
+mappingId	MAPID-cats
+target		:animals/{name} a :Animal; a :Cat; :name {name}; :age {age}; :breed {breed} .
+source		SELECT name, age, breed FROM cats;
+
+mappingId	MAPID-turtles
+target		:animals/{name} a :Animal; a :Turtle; :name {name}; :age {age}; :breed {breed} .
+source		SELECT name, age, breed FROM turtles;
+
+mappingId	MAPID-rabbits1
+target		:animals/{name} a :Animal; a :Rabbit; :name {name}; :age {age} .
+source		SELECT name, age FROM rabbits;
+
+mappingId	MAPID-rabbits2
+target		:animals/{name} a :Animal; a :Rabbit; :breed {breed} .
+source		SELECT name, breed FROM rabbits;
+]]
+

--- a/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/test.sql
+++ b/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/test.sql
@@ -1,0 +1,35 @@
+CREATE TABLE dogs(
+    name varchar,
+    age integer,
+    breed varchar
+);
+
+CREATE TABLE cats(
+    name varchar,
+    age integer,
+    breed varchar
+);
+
+CREATE TABLE turtles(
+    name varchar,
+    age integer
+);
+
+CREATE TABLE rabbits(
+    name varchar,
+    age integer
+);
+
+INSERT INTO dogs VALUES ('Layka', 3, 'Mongrel');
+INSERT INTO dogs VALUES ('Iggy', 5, 'Boston Terrier');
+INSERT INTO dogs VALUES ('Tessa', 2, 'Yorkshire Terrier');
+
+INSERT INTO cats VALUES ('Mittens', 10, 'Turkish Angora');
+INSERT INTO cats VALUES ('Shan', 4, 'Siamese');
+INSERT INTO cats VALUES ('Grumpy', 7, 'Mixed');
+
+INSERT INTO turtles VALUES ('Cassiopeia', 50);
+INSERT INTO turtles VALUES ('Lemmy K', 8);
+
+INSERT INTO rabbits VALUES ('Bugs', 14);
+INSERT INTO rabbits VALUES ('White Rabbit', 100);

--- a/core/model/src/main/resources/property_description.json
+++ b/core/model/src/main/resources/property_description.json
@@ -63,6 +63,10 @@
     "type": "Boolean",
     "description": "Since 4.2.0. Default value: `false`. If `true`, the column names of black-box views and their data types are retrieved by querying the database. If `false`, data types remain unknown and the extraction of column names is unsafe."
   },
+  "ontop.ignoreInvalidMappingEntries": {
+    "type": "Boolean",
+    "description": "Since 5.1.0. Default value: `false`. If `true`, mapping entries that result in an error will be ignored instead of failing the initialization procedure."
+  },
   "ontop.enableValuesNode": {
     "type": "Boolean",
     "description": "Since 4.2.0. Default value: `true`. If false Union Nodes are used instead of Values Nodes for facts."

--- a/core/obda/src/main/java/it/unibz/inf/ontop/injection/OntopOBDASettings.java
+++ b/core/obda/src/main/java/it/unibz/inf/ontop/injection/OntopOBDASettings.java
@@ -10,10 +10,17 @@ public interface OntopOBDASettings extends OntopModelSettings {
      */
     boolean allowRetrievingBlackBoxViewMetadataFromDB();
 
+    /**
+     * If true, the OBDA loading procedure will not fail if some of the provided mappings are invalid, they will be
+     * ignored instead.
+     */
+    boolean ignoreInvalidMappingEntries();
+
     //--------------------------
     // Keys
     //--------------------------
 
     String  SAME_AS = "ontop.sameAs";
     String ALLOW_RETRIEVING_BLACK_BOX_VIEW_METADATA_FROM_DB = "ontop.allowRetrievingBlackBoxViewMetadataFromDB";
+    String IGNORE_INVALID_MAPPING_ENTRIES = "ontop.ignoreInvalidMappingEntries";
 }

--- a/core/obda/src/main/java/it/unibz/inf/ontop/injection/impl/OntopOBDASettingsImpl.java
+++ b/core/obda/src/main/java/it/unibz/inf/ontop/injection/impl/OntopOBDASettingsImpl.java
@@ -34,4 +34,9 @@ public class OntopOBDASettingsImpl extends OntopModelSettingsImpl implements Ont
     public boolean allowRetrievingBlackBoxViewMetadataFromDB() {
         return getRequiredBoolean(ALLOW_RETRIEVING_BLACK_BOX_VIEW_METADATA_FROM_DB);
     }
+
+    @Override
+    public boolean ignoreInvalidMappingEntries() {
+        return getRequiredBoolean(IGNORE_INVALID_MAPPING_ENTRIES);
+    }
 }

--- a/core/obda/src/main/resources/it/unibz/inf/ontop/injection/obda-default.properties
+++ b/core/obda/src/main/resources/it/unibz/inf/ontop/injection/obda-default.properties
@@ -8,6 +8,7 @@
 ontop.sameAs=false
 
 ontop.allowRetrievingBlackBoxViewMetadataFromDB = false
+ontop.ignoreInvalidMappingEntries = false
 
 
 ##########################################

--- a/test/rdb2rdf-compliance/src/test/java/RDB2RDFTest.java
+++ b/test/rdb2rdf-compliance/src/test/java/RDB2RDFTest.java
@@ -248,6 +248,7 @@ public class RDB2RDFTest {
 		PROPERTIES.setProperty(OntopSQLCoreSettings.JDBC_DRIVER, JDBC_DRIVER);
 		PROPERTIES.setProperty(OntopMappingSettings.BASE_IRI, BASE_IRI);
 		PROPERTIES.setProperty(OntopOBDASettings.ALLOW_RETRIEVING_BLACK_BOX_VIEW_METADATA_FROM_DB, "true");
+		PROPERTIES.setProperty(OntopOBDASettings.IGNORE_INVALID_MAPPING_ENTRIES, "false");
 	}
 
 	@Before

--- a/test/rdb2rdf-compliance/src/test/java/RDB2RDFTest.java
+++ b/test/rdb2rdf-compliance/src/test/java/RDB2RDFTest.java
@@ -248,7 +248,6 @@ public class RDB2RDFTest {
 		PROPERTIES.setProperty(OntopSQLCoreSettings.JDBC_DRIVER, JDBC_DRIVER);
 		PROPERTIES.setProperty(OntopMappingSettings.BASE_IRI, BASE_IRI);
 		PROPERTIES.setProperty(OntopOBDASettings.ALLOW_RETRIEVING_BLACK_BOX_VIEW_METADATA_FROM_DB, "true");
-		PROPERTIES.setProperty(OntopOBDASettings.IGNORE_INVALID_MAPPING_ENTRIES, "false");
 	}
 
 	@Before


### PR DESCRIPTION
Individual mapping entries with errors in them can now be ignored by setting the property `ontop.ignoreInvalidMappingEntries`

Also added a test case for this feature.