### PR TITLE
Fixed an issue with dremio, where VALUES clauses with integer constants caused the query to fail

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DefaultSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DefaultSelectFromWhereSerializer.java
@@ -318,6 +318,10 @@ public class DefaultSelectFromWhereSerializer implements SelectFromWhereSerializ
             return new QuerySerializationImpl(sqlSubString, ImmutableMap.of());
         }
 
+        protected String serializeValuesEntry(Constant constant, ImmutableMap<Variable, QualifiedAttributeID> childColumnIDs) {
+            return sqlTermSerializer.serialize(constant, childColumnIDs);
+        }
+
         @Override
         public QuerySerialization visit(SQLValuesExpression sqlValuesExpression) {
             ImmutableList<Variable> orderedVariables = sqlValuesExpression.getOrderedVariables();
@@ -327,7 +331,7 @@ public class DefaultSelectFromWhereSerializer implements SelectFromWhereSerializ
 
             String tuplesSerialized = sqlValuesExpression.getValues().stream()
                     .map(tuple -> tuple.stream()
-                            .map(constant -> sqlTermSerializer.serialize(constant, childColumnIDs))
+                            .map(constant -> serializeValuesEntry(constant, childColumnIDs))
                             .collect(Collectors.joining(",", " (", ")")))
                     .collect(Collectors.joining(","));
             RelationID alias = generateFreshViewAlias();

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DremioSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DremioSelectFromWhereSerializer.java
@@ -45,37 +45,14 @@ public class DremioSelectFromWhereSerializer extends DefaultSelectFromWhereSeria
                         return String.format("LIMIT %d OFFSET %d", limit, offset);
                     }
 
-                    private String serializeValuesEntry(Constant constant, ImmutableMap<Variable, QualifiedAttributeID> childColumnIDs) {
+                    //Due to a limitation of dremio, we need to cast integer constants in VALUES terms to integers, as they would be types as int64 otherwise.
+                    @Override
+                    protected String serializeValuesEntry(Constant constant, ImmutableMap<Variable, QualifiedAttributeID> childColumnIDs) {
                         String serialization = sqlTermSerializer.serialize(constant, childColumnIDs);
                         if(constant instanceof DBConstant && ((DBConstant) constant).getType().getCategory() == DBTermType.Category.INTEGER) {
                             return String.format("CAST(%s as INTEGER)", serialization);
                         }
                         return serialization;
-                    }
-
-                    //Due to a limitation of dremio, we need to cast integer constants in VALUES terms to integers.
-                    @Override
-                    public QuerySerialization visit(SQLValuesExpression sqlValuesExpression) {
-                        ImmutableList<Variable> orderedVariables = sqlValuesExpression.getOrderedVariables();
-                        ImmutableMap<Variable, QuotedID> variableAliases = createVariableAliases(ImmutableSet.copyOf(orderedVariables));
-                        // Leaf node
-                        ImmutableMap<Variable, QualifiedAttributeID> childColumnIDs = ImmutableMap.of();
-
-                        String tuplesSerialized = sqlValuesExpression.getValues().stream()
-                                .map(tuple -> tuple.stream()
-                                        .map(constant -> serializeValuesEntry(constant, childColumnIDs))
-                                        .collect(Collectors.joining(",", " (", ")")))
-                                .collect(Collectors.joining(","));
-                        RelationID alias = generateFreshViewAlias();
-                        String internalColumnNames = orderedVariables.stream()
-                                .map(variableAliases::get)
-                                .map(QuotedID::toString)
-                                .collect(Collectors.joining(",", " (", ")"));
-                        String sql = "(VALUES " + tuplesSerialized + ") AS " + alias + internalColumnNames;
-
-                        ImmutableMap<Variable, QualifiedAttributeID> columnIDs = attachRelationAlias(alias, variableAliases);
-
-                        return new QuerySerializationImpl(sql, columnIDs);
                     }
 
                     //                    @Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DremioSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DremioSelectFromWhereSerializer.java
@@ -1,15 +1,22 @@
 package it.unibz.inf.ontop.generation.serializer.impl;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import it.unibz.inf.ontop.dbschema.DBParameters;
 import it.unibz.inf.ontop.dbschema.QualifiedAttributeID;
+import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.RelationID;
+import it.unibz.inf.ontop.generation.algebra.SQLValuesExpression;
 import it.unibz.inf.ontop.generation.algebra.SelectFromWhereWithModifiers;
 import it.unibz.inf.ontop.generation.serializer.SelectFromWhereSerializer;
 import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.model.term.functionsymbol.db.impl.NullIgnoringDBGroupConcatFunctionSymbol;
 import it.unibz.inf.ontop.model.type.DBTermType;
+
+import java.util.stream.Collectors;
 
 @Singleton
 public class DremioSelectFromWhereSerializer extends DefaultSelectFromWhereSerializer implements SelectFromWhereSerializer {
@@ -36,6 +43,39 @@ public class DremioSelectFromWhereSerializer extends DefaultSelectFromWhereSeria
                     @Override
                     protected String serializeLimitOffset(long limit, long offset, boolean noSortCondition) {
                         return String.format("LIMIT %d OFFSET %d", limit, offset);
+                    }
+
+                    private String serializeValuesEntry(Constant constant, ImmutableMap<Variable, QualifiedAttributeID> childColumnIDs) {
+                        String serialization = sqlTermSerializer.serialize(constant, childColumnIDs);
+                        if(constant instanceof DBConstant && ((DBConstant) constant).getType().getCategory() == DBTermType.Category.INTEGER) {
+                            return String.format("CAST(%s as INTEGER)", serialization);
+                        }
+                        return serialization;
+                    }
+
+                    //Due to a limitation of dremio, we need to cast integer constants in VALUES terms to integers.
+                    @Override
+                    public QuerySerialization visit(SQLValuesExpression sqlValuesExpression) {
+                        ImmutableList<Variable> orderedVariables = sqlValuesExpression.getOrderedVariables();
+                        ImmutableMap<Variable, QuotedID> variableAliases = createVariableAliases(ImmutableSet.copyOf(orderedVariables));
+                        // Leaf node
+                        ImmutableMap<Variable, QualifiedAttributeID> childColumnIDs = ImmutableMap.of();
+
+                        String tuplesSerialized = sqlValuesExpression.getValues().stream()
+                                .map(tuple -> tuple.stream()
+                                        .map(constant -> serializeValuesEntry(constant, childColumnIDs))
+                                        .collect(Collectors.joining(",", " (", ")")))
+                                .collect(Collectors.joining(","));
+                        RelationID alias = generateFreshViewAlias();
+                        String internalColumnNames = orderedVariables.stream()
+                                .map(variableAliases::get)
+                                .map(QuotedID::toString)
+                                .collect(Collectors.joining(",", " (", ")"));
+                        String sql = "(VALUES " + tuplesSerialized + ") AS " + alias + internalColumnNames;
+
+                        ImmutableMap<Variable, QualifiedAttributeID> columnIDs = attachRelationAlias(alias, variableAliases);
+
+                        return new QuerySerializationImpl(sql, columnIDs);
                     }
 
                     //                    @Override

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/dremio/other/UnionWithValuesDremioArrowFlightTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/dremio/other/UnionWithValuesDremioArrowFlightTest.java
@@ -1,0 +1,36 @@
+package it.unibz.inf.ontop.docker.lightweight.dremio.other;
+
+import it.unibz.inf.ontop.docker.lightweight.AbstractDockerRDF4JTest;
+import it.unibz.inf.ontop.docker.lightweight.DremioLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@DremioLightweightTest
+public class UnionWithValuesDremioArrowFlightTest extends AbstractDockerRDF4JTest {
+
+    private static final String PROPERTIES_FILE = "/books/dremio/books-dremio-arrowflight.properties";
+    private static final String OBDA_FILE = "/books/dremio/books-dremio.obda";
+    private static final String OWL_FILE = "/books/dremio/ontology-with-facts.ttl";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void test() {
+        String query = "SELECT * WHERE { ?s ?p ?o. }";
+        assertNotEquals(0, runQueryAndCount(query));
+    }
+}

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/dremio/other/UnionWithValuesDremioTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/dremio/other/UnionWithValuesDremioTest.java
@@ -1,0 +1,36 @@
+package it.unibz.inf.ontop.docker.lightweight.dremio.other;
+
+import it.unibz.inf.ontop.docker.lightweight.AbstractDockerRDF4JTest;
+import it.unibz.inf.ontop.docker.lightweight.DremioLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@DremioLightweightTest
+public class UnionWithValuesDremioTest extends AbstractDockerRDF4JTest {
+
+    private static final String PROPERTIES_FILE = "/books/dremio/books-dremio.properties";
+    private static final String OBDA_FILE = "/books/dremio/books-dremio.obda";
+    private static final String OWL_FILE = "/books/dremio/ontology-with-facts.ttl";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void test() {
+        String query = "SELECT * WHERE { ?s ?p ?o. }";
+        assertNotEquals(0, runQueryAndCount(query));
+    }
+}

--- a/test/lightweight-tests/src/test/resources/books/dremio/books-dremio-arrowflight.properties
+++ b/test/lightweight-tests/src/test/resources/books/dremio/books-dremio-arrowflight.properties
@@ -2,3 +2,5 @@ jdbc.url = jdbc:arrow-flight-sql://${docker.url}:32010/?useEncryption=false&sche
 jdbc.user = dremio
 jdbc.password = ${dremio.password}
 jdbc.driver = org.apache.arrow.driver.jdbc.ArrowFlightJdbcDriver
+ontop.enableFactExtractionWithTBox=true
+ontop.queryOntologyAnnotation = true

--- a/test/lightweight-tests/src/test/resources/books/dremio/books-dremio.properties
+++ b/test/lightweight-tests/src/test/resources/books/dremio/books-dremio.properties
@@ -2,3 +2,5 @@ jdbc.url = jdbc:dremio:direct=${docker.url}:31010;schema=books.public
 jdbc.user = dremio
 jdbc.password = ${dremio.password}
 jdbc.driver = com.dremio.jdbc.Driver
+ontop.enableFactExtractionWithTBox=true
+ontop.queryOntologyAnnotation = true

--- a/test/lightweight-tests/src/test/resources/books/dremio/ontology-with-facts.ttl
+++ b/test/lightweight-tests/src/test/resources/books/dremio/ontology-with-facts.ttl
@@ -1,0 +1,5 @@
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix test:   <http://test.example.org/> .
+
+test:someIndividual test:someValue "0"^^xsd:integer .
+test:someIndividual test:someValue "water" .


### PR DESCRIPTION
Achieved this, by changing the query serialization, so that integer constants in "Values" Nodes would be encased by CAST(<constant> AS INTEGER)