### PR TITLE
Implemented a common base structure for FlattenNode implementation

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DefaultSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DefaultSelectFromWhereSerializer.java
@@ -346,7 +346,85 @@ public class DefaultSelectFromWhereSerializer implements SelectFromWhereSerializ
 
         @Override
         public QuerySerialization visit(SQLFlattenExpression sqlFlattenExpression) {
+            QuerySerialization subQuerySerialization = getSQLSerializationForChild(sqlFlattenExpression.getSubExpression());
+            ImmutableMap<Variable, QualifiedAttributeID> allColumnIDs = buildFlattenColumIDMap(
+                    sqlFlattenExpression,
+                    subQuerySerialization
+            );
+
+            Variable flattenedVar = sqlFlattenExpression.getFlattenedVar();
+            Variable outputVar = sqlFlattenExpression.getOutputVar();
+            DBTermType flattenedType = sqlFlattenExpression.getFlattenedType();
+            Optional<Variable> indexVar = sqlFlattenExpression.getIndexVar();
+
+            return serializeFlatten(sqlFlattenExpression, flattenedVar, outputVar, indexVar, flattenedType, allColumnIDs, subQuerySerialization);
+        }
+
+        protected ImmutableMap<Variable, QualifiedAttributeID> buildFlattenColumIDMap(SQLFlattenExpression sqlFlattenExpression,
+                                                                                    QuerySerialization subQuerySerialization) {
+            ImmutableMap<Variable, QualifiedAttributeID> freshVariableAliases = createVariableAliases(getFreshVariables(sqlFlattenExpression)).entrySet().stream()
+                    .collect(ImmutableCollectors.toMap(
+                            Map.Entry::getKey,
+                            e -> new QualifiedAttributeID(null, e.getValue())
+                    ));
+            return ImmutableMap.<Variable, QualifiedAttributeID>builder()
+                    .putAll(freshVariableAliases)
+                    .putAll(subQuerySerialization.getColumnIDs())
+                    .build();
+        }
+
+        private ImmutableSet<Variable> getFreshVariables(SQLFlattenExpression sqlFlattenExpression) {
+            ImmutableSet.Builder<Variable> builder = ImmutableSet.builder();
+            builder.add(sqlFlattenExpression.getOutputVar());
+            sqlFlattenExpression.getIndexVar().ifPresent(builder::add);
+            return builder.build();
+        }
+
+        protected QuerySerialization serializeFlatten(SQLFlattenExpression sqlFlattenExpression, Variable flattenedVar,
+                                                      Variable outputVar, Optional<Variable> indexVar, DBTermType flattenedType,
+                                                      ImmutableMap<Variable, QualifiedAttributeID> allColumnIDs, QuerySerialization subQuerySerialization) {
             throw new UnsupportedOperationException("Nested data support unavailable for this DBMS");
+        }
+
+        protected QuerySerialization serializeFlattenAsFunction(Variable flattenedVar, ImmutableMap<Variable, QualifiedAttributeID> allColumnIDs,
+                                                                QuerySerialization subQuerySerialization, String flattenFunctionCallWithAlias) {
+            var alias = this.generateFreshViewAlias().getSQLRendering();
+            var variableAliases = allColumnIDs.entrySet().stream()
+                    .filter(e -> e.getKey() != flattenedVar)
+                    .collect(ImmutableCollectors.toMap(
+                            v -> v.getKey(),
+                            v -> new QualifiedAttributeID(idFactory.createRelationID(alias), v.getValue().getAttribute())
+                    ));
+            var subProjection = subQuerySerialization.getColumnIDs().keySet().stream()
+                    .filter(v -> variableAliases.containsKey(v))
+                    .map(
+                            v -> subQuerySerialization.getColumnIDs().get(v).getSQLRendering() + " AS " + idFactory.createAttributeID(v.getName()).getSQLRendering()
+                    )
+                    .collect(Collectors.joining(", "));
+            if(subProjection.length() > 0)
+                subProjection += ",";
+
+            StringBuilder builder = new StringBuilder();
+
+            builder.append(String.format(
+                    "(SELECT %s %s FROM %s) %s",
+                    subProjection,
+                    flattenFunctionCallWithAlias,
+                    subQuerySerialization.getString(),
+                    alias
+            ));
+
+            return new QuerySerializationImpl(
+                    builder.toString(),
+                    variableAliases
+            );
+        }
+
+        protected QuerySerialization serializeFlattenAsFunction(Variable flattenedVar, ImmutableMap<Variable, QualifiedAttributeID> allColumnIDs,
+                                                                QuerySerialization subQuerySerialization, String flattenFunctionCall, String aliasFormat) {
+            var flattenFunctionCallWithAlias = String.format("%s AS %s",
+                    flattenFunctionCall, aliasFormat);
+            return serializeFlattenAsFunction(flattenedVar, allColumnIDs, subQuerySerialization, flattenFunctionCallWithAlias);
         }
     }
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DremioSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DremioSelectFromWhereSerializer.java
@@ -95,84 +95,22 @@ public class DremioSelectFromWhereSerializer extends DefaultSelectFromWhereSeria
 //                    }
 
 
-                    //Taken from postgres implementation
-                    private ImmutableMap<Variable, QualifiedAttributeID> buildFlattenColumIDMap(SQLFlattenExpression sqlFlattenExpression,
-                                                                                                QuerySerialization subQuerySerialization) {
-                        ImmutableMap<Variable, QualifiedAttributeID> freshVariableAliases = createVariableAliases(getFreshVariables(sqlFlattenExpression)).entrySet().stream()
-                                .collect(ImmutableCollectors.toMap(
-                                        Map.Entry::getKey,
-                                        e -> new QualifiedAttributeID(null, e.getValue())
-                                ));
-                        return ImmutableMap.<Variable, QualifiedAttributeID>builder()
-                                .putAll(freshVariableAliases)
-                                .putAll(subQuerySerialization.getColumnIDs())
-                                .build();
-                    }
-
-                    //Taken from postgres implementation
-                    private ImmutableSet<Variable> getFreshVariables(SQLFlattenExpression sqlFlattenExpression) {
-                        ImmutableSet.Builder<Variable> builder = ImmutableSet.builder();
-                        builder.add(sqlFlattenExpression.getOutputVar());
-                        sqlFlattenExpression.getIndexVar().ifPresent(builder::add);
-                        return builder.build();
-                    }
-
-                    //Taken from spark implementation
                     @Override
-                    public QuerySerialization visit(SQLFlattenExpression sqlFlattenExpression) {
-                        QuerySerialization subQuerySerialization = getSQLSerializationForChild(sqlFlattenExpression.getSubExpression());
-                        ImmutableMap<Variable, QualifiedAttributeID> allColumnIDs = buildFlattenColumIDMap(
-                                sqlFlattenExpression,
-                                subQuerySerialization
-                        );
-
-                        Variable flattenedVar = sqlFlattenExpression.getFlattenedVar();
-                        Variable outputVar = sqlFlattenExpression.getOutputVar();
-                        DBTermType flattenedType = sqlFlattenExpression.getFlattenedType();
-                        Optional<Variable> indexVar = sqlFlattenExpression.getIndexVar();
-                        StringBuilder builder = new StringBuilder();
+                    protected QuerySerialization serializeFlatten(SQLFlattenExpression sqlFlattenExpression, Variable flattenedVar, Variable outputVar, Optional<Variable> indexVar, DBTermType flattenedType, ImmutableMap<Variable, QualifiedAttributeID> allColumnIDs, QuerySerialization subQuerySerialization) {
                         if(indexVar.isPresent()) {
                             throw new SQLSerializationException("Dremio does not support FLATTEN with position arguments.");
                         }
 
                         //We express the flatten call as a `SELECT *, FLATTEN({array}) FROM child.
 
-                        //EXPLODE only works on ARRAY<T> types, so we first transform the JSON-array into an ARRAY<STRING> if it is not already one
+                        //FLATTEN only works on ARRAY<T> types, so we first transform the JSON-array into an ARRAY<STRING> if it is not already one
                         var expression = flattenedType.getCategory() == DBTermType.Category.ARRAY
                                 ? allColumnIDs.get(flattenedVar).getSQLRendering()
                                 : String.format("CONVERT_FROM(%s, 'json')", allColumnIDs.get(flattenedVar).getSQLRendering());
 
-                        //We compute an alias for the sub-query, and new aliases for each projected variable.
-                        var alias = this.generateFreshViewAlias().getSQLRendering();
-                        var variableAliases = allColumnIDs.entrySet().stream()
-                                .filter(e -> e.getKey() != flattenedVar)
-                                .collect(ImmutableCollectors.toMap(
-                                        v -> v.getKey(),
-                                        v -> new QualifiedAttributeID(idFactory.createRelationID(alias), v.getValue().getAttribute())
-                                ));
-                        var subProjection = subQuerySerialization.getColumnIDs().keySet().stream()
-                                .filter(v -> variableAliases.containsKey(v))
-                                .map(
-                                        v -> subQuerySerialization.getColumnIDs().get(v).getSQLRendering() + " AS " + idFactory.createAttributeID(v.getName()).getSQLRendering()
-                                )
-                                .collect(Collectors.joining(", "));
-                        if(subProjection.length() > 0)
-                            subProjection += ",";
-
-
-                        builder.append(String.format(
-                                "(SELECT %s CASE WHEN RAND() > 1 THEN NULL ELSE FLATTEN(%s) END AS %s FROM %s) %s",
-                                subProjection,
-                                expression,
-                                allColumnIDs.get(outputVar).getSQLRendering(),
-                                subQuerySerialization.getString(),
-                                alias
-
-                        ));
-                        return new QuerySerializationImpl(
-                                builder.toString(),
-                                variableAliases
-                        );
+                        var flattenFunctionCall = String.format("CASE WHEN RAND() > 1 THEN NULL ELSE FLATTEN(%s) END", expression);
+                        var aliasFormat = allColumnIDs.get(outputVar).getSQLRendering();
+                        return serializeFlattenAsFunction(flattenedVar, allColumnIDs, subQuerySerialization, flattenFunctionCall, aliasFormat);
                     }
                 });
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DuckDBSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DuckDBSelectFromWhereSerializer.java
@@ -47,91 +47,26 @@ public class DuckDBSelectFromWhereSerializer extends DefaultSelectFromWhereSeria
                         return String.format("OFFSET %d", offset);
                     }
 
-                    //Taken from postgres implementation
-                    private ImmutableMap<Variable, QualifiedAttributeID> buildFlattenColumIDMap(SQLFlattenExpression sqlFlattenExpression,
-                                                                                                QuerySerialization subQuerySerialization) {
-                        ImmutableMap<Variable, QualifiedAttributeID> freshVariableAliases = createVariableAliases(getFreshVariables(sqlFlattenExpression)).entrySet().stream()
-                                .collect(ImmutableCollectors.toMap(
-                                        Map.Entry::getKey,
-                                        e -> new QualifiedAttributeID(null, e.getValue())
-                                ));
-                        return ImmutableMap.<Variable, QualifiedAttributeID>builder()
-                                .putAll(freshVariableAliases)
-                                .putAll(subQuerySerialization.getColumnIDs())
-                                .build();
-                    }
-
-                    //Taken from postgres implementation
-                    private ImmutableSet<Variable> getFreshVariables(SQLFlattenExpression sqlFlattenExpression) {
-                        ImmutableSet.Builder<Variable> builder = ImmutableSet.builder();
-                        builder.add(sqlFlattenExpression.getOutputVar());
-                        sqlFlattenExpression.getIndexVar().ifPresent(builder::add);
-                        return builder.build();
-                    }
-
                     @Override
-                    public QuerySerialization visit(SQLFlattenExpression sqlFlattenExpression) {
-                        QuerySerialization subQuerySerialization = getSQLSerializationForChild(sqlFlattenExpression.getSubExpression());
-                        ImmutableMap<Variable, QualifiedAttributeID> allColumnIDs = buildFlattenColumIDMap(
-                                sqlFlattenExpression,
-                                subQuerySerialization
-                        );
-
-                        Variable flattenedVar = sqlFlattenExpression.getFlattenedVar();
-                        Variable outputVar = sqlFlattenExpression.getOutputVar();
-                        Optional<Variable> indexVar = sqlFlattenExpression.getIndexVar();
-                        StringBuilder builder = new StringBuilder();
-
+                    protected QuerySerialization serializeFlatten(SQLFlattenExpression sqlFlattenExpression, Variable flattenedVar, Variable outputVar, Optional<Variable> indexVar, DBTermType flattenedType, ImmutableMap<Variable, QualifiedAttributeID> allColumnIDs, QuerySerialization subQuerySerialization) {
                         //We express the flatten call as a `SELECT *, UNNEST({array}) FROM child.
                         var expression = allColumnIDs.get(flattenedVar).getSQLRendering();
 
-                        //We compute an alias for the sub-query, and new aliases for each projected variable.
-                        var alias = this.generateFreshViewAlias().getSQLRendering();
-                        var variableAliases = allColumnIDs.entrySet().stream()
-                                .filter(e -> e.getKey() != flattenedVar)
-                                .collect(ImmutableCollectors.toMap(
-                                        v -> v.getKey(),
-                                        v -> new QualifiedAttributeID(idFactory.createRelationID(alias), v.getValue().getAttribute())
-                                ));
-                        var subProjection = subQuerySerialization.getColumnIDs().keySet().stream()
-                                .filter(v -> variableAliases.containsKey(v))
-                                .map(
-                                        v -> subQuerySerialization.getColumnIDs().get(v).getSQLRendering() + " AS " + idFactory.createAttributeID(v.getName()).getSQLRendering()
-                                )
-                                .collect(Collectors.joining(", "));
-                        if(subProjection.length() > 0)
-                            subProjection += ",";
-
                         //If an index is required, we use create a second list which is an integer range from 1 to len(list) and unnset it, too.
+                        String flattenCall;
                         if(indexVar.isPresent()) {
-                            builder.append(String.format(
-                                    "(SELECT %s UNNEST(%s) AS %s, UNNEST(RANGE(1, len(%s) + 1)) as %s FROM %s) %s",
-                                    subProjection,
+                            flattenCall = String.format("UNNEST(%s) AS %s, UNNEST(RANGE(1, len(%s) + 1)) as %s",
                                     expression,
                                     allColumnIDs.get(outputVar).getSQLRendering(),
                                     expression,
-                                    allColumnIDs.get(indexVar.get()).getSQLRendering(),
-                                    subQuerySerialization.getString(),
-                                    alias
-
-                            ));
+                                    allColumnIDs.get(indexVar.get()).getSQLRendering());
                         } else {
-                            builder.append(String.format(
-                                    "(SELECT %s (UNNEST(%s)) AS %s FROM %s) %s",
-                                    subProjection,
+                            flattenCall = String.format("(UNNEST(%s)) AS %s",
                                     expression,
-                                    allColumnIDs.get(outputVar).getSQLRendering(),
-                                    subQuerySerialization.getString(),
-                                    alias
-
-                            ));
+                                    allColumnIDs.get(outputVar).getSQLRendering());
                         }
-                        return new QuerySerializationImpl(
-                                builder.toString(),
-                                variableAliases
-                        );
+                        return serializeFlattenAsFunction(flattenedVar, allColumnIDs, subQuerySerialization, flattenCall);
                     }
-
                 });
     }
 }

--- a/test/lightweight-tests/src/test/resources/nested/duckdb/nested-lenses-array.json
+++ b/test/lightweight-tests/src/test/resources/nested/duckdb/nested-lenses-array.json
@@ -87,15 +87,15 @@
         "added": [
           {
             "name": "firstname",
-            "expression": "json_extract_string(manager, 'firstName')::varchar"
+            "expression": "CAST(json_extract_string(manager, 'firstName') AS varchar)"
           },
           {
             "name": "lastname",
-            "expression": "json_extract_string(manager, 'lastName')::varchar"
+            "expression": "CAST(json_extract_string(manager, 'lastName') AS varchar)"
           },
           {
             "name": "age",
-            "expression": "json_extract_string(manager, 'age')::integer"
+            "expression": "CAST(json_extract_string(manager, 'age') AS integer)"
           }
         ],
         "hidden": [

--- a/test/lightweight-tests/src/test/resources/nested/spark/nested-lenses-array.json
+++ b/test/lightweight-tests/src/test/resources/nested/spark/nested-lenses-array.json
@@ -87,15 +87,15 @@
         "added": [
           {
             "name": "firstname",
-            "expression": "GET_JSON_OBJECT(manager, '$.firstName')::string"
+            "expression": "CAST(GET_JSON_OBJECT(manager, '$.firstName') AS string)"
           },
           {
             "name": "lastname",
-            "expression": "GET_JSON_OBJECT(manager, '$.lastName')::string"
+            "expression": "CAST(GET_JSON_OBJECT(manager, '$.lastName') AS string)"
           },
           {
             "name": "age",
-            "expression": "GET_JSON_OBJECT(manager, '$.age')::integer"
+            "expression": "CAST(GET_JSON_OBJECT(manager, '$.age') AS integer)"
           }
         ],
         "hidden": [

--- a/test/lightweight-tests/src/test/resources/nested/spark/nested-lenses-json.json
+++ b/test/lightweight-tests/src/test/resources/nested/spark/nested-lenses-json.json
@@ -87,15 +87,15 @@
         "added": [
           {
             "name": "firstname",
-            "expression": "GET_JSON_OBJECT(manager, '$.firstName')::string"
+            "expression": "CAST(GET_JSON_OBJECT(manager, '$.firstName') AS string)"
           },
           {
             "name": "lastname",
-            "expression": "GET_JSON_OBJECT(manager, '$.lastName')::string"
+            "expression": "CAST(GET_JSON_OBJECT(manager, '$.lastName') AS string)"
           },
           {
             "name": "age",
-            "expression": "GET_JSON_OBJECT(manager, '$.age')::integer"
+            "expression": "CAST(GET_JSON_OBJECT(manager, '$.age') AS integer)"
           }
         ],
         "hidden": [
@@ -111,7 +111,7 @@
         "added": [
           {
             "name": "invoice_date",
-            "expression": "invoice_date::timestamp"
+            "expression": "CAST(invoice_date AS timestamp)"
           }
         ],
         "hidden": [
@@ -127,7 +127,7 @@
         "added": [
           {
             "name": "period_income",
-            "expression": "period_income::integer"
+            "expression": "CAST(period_income AS integer)"
           }
         ],
         "hidden": [
@@ -143,7 +143,7 @@
         "added": [
           {
             "name": "name",
-            "expression": "name::string"
+            "expression": "CAST(name AS string)"
           }
         ],
         "hidden": [


### PR DESCRIPTION
Many dialects use similar structures for the "flatten" procedure.
We can reduce duplicate code by implementing a common base structure for all dialects that use a flatten-like function in the SELECT parts of the query.