### PR TITLE
Implemented FlattenLens for BigQuery

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/BigQuerySelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/BigQuerySelectFromWhereSerializer.java
@@ -1,13 +1,20 @@
 package it.unibz.inf.ontop.generation.serializer.impl;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import it.unibz.inf.ontop.dbschema.DBParameters;
+import it.unibz.inf.ontop.dbschema.QualifiedAttributeID;
 import it.unibz.inf.ontop.dbschema.RelationID;
+import it.unibz.inf.ontop.generation.algebra.SQLFlattenExpression;
 import it.unibz.inf.ontop.generation.algebra.SelectFromWhereWithModifiers;
 import it.unibz.inf.ontop.generation.serializer.SelectFromWhereSerializer;
 import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.term.Variable;
 import it.unibz.inf.ontop.model.type.DBTermType;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+
+import java.util.Optional;
 
 @Singleton
 public class BigQuerySelectFromWhereSerializer extends DefaultSelectFromWhereSerializer implements SelectFromWhereSerializer {
@@ -43,6 +50,28 @@ public class BigQuerySelectFromWhereSerializer extends DefaultSelectFromWhereSer
                     @Override
                     protected RelationID generateFreshViewAlias() {
                         return idFactory.createRelationID(VIEW_PREFIX + viewCounter.incrementAndGet());
+                    }
+
+                    @Override
+                    protected QuerySerialization serializeFlatten(SQLFlattenExpression sqlFlattenExpression, Variable flattenedVar, Variable outputVar, Optional<Variable> indexVar, DBTermType flattenedType, ImmutableMap<Variable, QualifiedAttributeID> allColumnIDs, QuerySerialization subQuerySerialization) {
+                        //We build the query string of the form SELECT <variables> FROM <subquery> CROSS JOIN UNNEST(<flattenedVariable>) WITH OFFSET <names>
+                        StringBuilder builder = new StringBuilder();
+
+                        builder.append(
+                                String.format(
+                                        "%s CROSS JOIN UNNEST(%s) %s ",
+                                        subQuerySerialization.getString(),
+                                        allColumnIDs.get(flattenedVar).getSQLRendering(),
+                                        allColumnIDs.get(outputVar).getSQLRendering()
+                                ));
+                        indexVar.ifPresent( v -> builder.append(String.format(" WITH OFFSET %s ", allColumnIDs.get(indexVar.get()).getSQLRendering())));
+
+                        return new QuerySerializationImpl(
+                                builder.toString(),
+                                allColumnIDs.entrySet().stream()
+                                        .filter(e -> e.getKey() != flattenedVar)
+                                        .collect(ImmutableCollectors.toMap())
+                        );
                     }
                 });
     }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/BigQueryDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/BigQueryDBTypeFactory.java
@@ -1,16 +1,18 @@
 package it.unibz.inf.ontop.model.type.impl;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import it.unibz.inf.ontop.model.type.*;
 import it.unibz.inf.ontop.model.vocabulary.XSD;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static it.unibz.inf.ontop.model.type.DBTermType.Category.*;
-import static it.unibz.inf.ontop.model.type.impl.NonStringNonNumberNonBooleanNonDatetimeDBTermType.StrictEqSupport.NOTHING;
-import static it.unibz.inf.ontop.model.type.impl.NonStringNonNumberNonBooleanNonDatetimeDBTermType.StrictEqSupport.SAME_TYPE_NO_CONSTANT;
 
 public class BigQueryDBTypeFactory extends DefaultSQLDBTypeFactory {
     private static final String INT64_STR = "INT64";
@@ -21,12 +23,45 @@ public class BigQueryDBTypeFactory extends DefaultSQLDBTypeFactory {
     protected static final String JSON_STR = "JSON";
     protected static final String BYTES_STR = "BYTES";
 
+    protected static final String ARRAY_STR = "ARRAY<T>";
+
     protected BigQueryDBTypeFactory(Map<String, DBTermType> typeMap, ImmutableMap<DefaultTypeCode, String> defaultTypeCodeMap) {
         super(typeMap, defaultTypeCodeMap);
     }
     @AssistedInject
     protected BigQueryDBTypeFactory(@Assisted TermType rootTermType, @Assisted TypeFactory typeFactory) {
-        super(createBigQueryTypeMap(rootTermType, typeFactory), createBigQueryCodeMap());
+        super(createBigQueryTypeMap(rootTermType, typeFactory), createBigQueryCodeMap(), createGenericAbstractTypeMap(rootTermType, typeFactory));
+    }
+
+    private static ImmutableList<GenericDBTermType> createGenericAbstractTypeMap(TermType rootTermType, TypeFactory typeFactory) {
+        TermTypeAncestry rootAncestry = rootTermType.getAncestry();
+
+        GenericDBTermType abstractArrayType = new ArrayDBTermType(ARRAY_STR, rootAncestry, s -> {
+            if(s.equals("ARRAY"))
+                return Optional.of(typeFactory.getDBTypeFactory().getDBStringType());
+            if(!s.startsWith("ARRAY<") || !s.endsWith(">")) {
+                return Optional.empty();
+            }
+            String contents = s.substring(6, s.length() - 1);
+
+            int depth = 0;
+            for(int i = 0; i < contents.length(); i++) {
+                if(contents.charAt(i) == '<')
+                    depth += 1;
+                else if(contents.charAt(i) == '>')
+                    depth -= 1;
+                else if(contents.charAt(i) == ',' && depth == 0)
+                    return Optional.empty();
+            }
+            if(depth != 0)
+                return Optional.empty();
+
+            return Optional.of(typeFactory.getDBTypeFactory().getDBTermType(contents));
+        });
+
+        List<GenericDBTermType> list = new ArrayList<>();
+        list.add(abstractArrayType);
+        return ImmutableList.copyOf(list);
     }
 
     protected static Map<String, DBTermType> createBigQueryTypeMap(TermType rootTermType, TypeFactory typeFactory) {

--- a/test/lightweight-tests/lightweight-db-test-images/bigquery/sql/nested.sql
+++ b/test/lightweight-tests/lightweight-db-test-images/bigquery/sql/nested.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS nested.company_data_arrays;
+CREATE TABLE nested.company_data_arrays (
+    id integer NOT NULL,
+    days array<timestamp>,
+    income array<integer>,
+    workers array<struct<names array<string>>>,
+    managers array<json>
+) as SELECT * from (
+  (SELECT 1 as id,  [TIMESTAMP '2023-01-01 18:00:00', TIMESTAMP '2023-01-15 18:00:00', TIMESTAMP '2023-01-29 12:00:00'] as days, [10000, 18000, 13000] as income, [STRUCT(['Sam', 'Cynthia']), STRUCT(['Bob']), STRUCT(['Jim'])] as workers, [JSON '{"firstName": "Mary", "lastName": "Jane", "age": 28}', JSON '{"firstName": "Carlos", "lastName": "Carlson", "age": 45}', JSON '{"firstName": "John", "lastName": "Moriarty", "age": 60}'] as managers)
+  UNION ALL (SELECT 2 as id,  [TIMESTAMP '2023-02-12 18:00:00', TIMESTAMP '2023-02-26 18:00:00'] as days, [14000, 0] as income, [STRUCT(['Jim', 'Cynthia']), STRUCT(NULL)] as workers, [JSON '{"firstName": "Helena", "lastName": "of Troy"}', JSON '{"firstName": "Robert", "lastName": "Smith", "age": 48}'] as managers)
+  UNION ALL (SELECT 3 as id,  [TIMESTAMP '2023-03-12 18:00:00', TIMESTAMP '2023-03-26 18:00:00'] as days, [15000, 20000] as income, [STRUCT(['Carl', 'Bob', 'Cynthia']), STRUCT(['Jim', 'Bob'])] as workers, [JSON '{"firstName": "Joseph", "lastName": "Grey"}', JSON '{"firstName": "Godfrey", "lastName": "Hamilton", "age": 59}'] as managers)
+  UNION ALL (SELECT 4 as id,  NULL as days, NULL as income, NULL as workers, NULL as managers)
+);

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/NestedDataBigQueryTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/NestedDataBigQueryTest.java
@@ -1,0 +1,49 @@
+package it.unibz.inf.ontop.docker.lightweight.bigquery;
+
+import com.google.common.collect.ImmutableMultiset;
+import it.unibz.inf.ontop.docker.lightweight.AbstractNestedDataTest;
+import it.unibz.inf.ontop.docker.lightweight.BigQueryLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@BigQueryLightweightTest
+public class NestedDataBigQueryTest extends AbstractNestedDataTest {
+
+    private static final String PROPERTIES_FILE = "/nested/bigquery/nested-bigquery.properties";
+    private static final String OBDA_FILE = "/nested/nested.obda";
+    private static final String LENS_FILE = "/nested/bigquery/nested-lenses-array.json";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE, LENS_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Override
+    protected ImmutableMultiset getFlattenTimestampExpectedValues() {
+        return ImmutableMultiset.of( "\"2023-01-01T18:00:00+00:00\"^^xsd:dateTime", "\"2023-01-15T18:00:00+00:00\"^^xsd:dateTime", "\"2023-01-29T12:00:00+00:00\"^^xsd:dateTime",
+                "\"2023-02-12T18:00:00+00:00\"^^xsd:dateTime", "\"2023-02-26T18:00:00+00:00\"^^xsd:dateTime",
+                "\"2023-03-12T18:00:00+00:00\"^^xsd:dateTime", "\"2023-03-26T18:00:00+00:00\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableMultiset getFlattenWithAggregateExpectedValues() {
+        return ImmutableMultiset.of("\"Carl: 15000.0\"^^xsd:string", "\"Jim: 15666.666666666666\"^^xsd:string",
+                "\"Cynthia: 13000.0\"^^xsd:string", "\"Sam: 10000.0\"^^xsd:string",
+                "\"Bob: 17666.666666666668\"^^xsd:string");
+    }
+
+    //BigQuery starts counting at 0
+    @Override
+    protected ImmutableMultiset getFlattenWithPositionExpectedValues() {
+        return ImmutableMultiset.of( "\"1\"^^xsd:integer", "\"1\"^^xsd:integer", "\"1\"^^xsd:integer",
+                "\"0\"^^xsd:integer", "\"0\"^^xsd:integer", "\"0\"^^xsd:integer", "\"2\"^^xsd:integer");
+    }
+}

--- a/test/lightweight-tests/src/test/resources/nested/bigquery/nested-bigquery.properties
+++ b/test/lightweight-tests/src/test/resources/nested/bigquery/nested-bigquery.properties
@@ -1,0 +1,4 @@
+jdbc.url = jdbc:bigquery://${bigquery.domain}:443;ProjectId=${bigquery.project};OAuthType=0
+jdbc.property.OAuthServiceAcctEmail = ${bigquery.user}
+jdbc.property.OAuthPvtKey = ${bigquery.password}
+jdbc.driver = com.simba.googlebigquery.jdbc.Driver

--- a/test/lightweight-tests/src/test/resources/nested/bigquery/nested-lenses-array.json
+++ b/test/lightweight-tests/src/test/resources/nested/bigquery/nested-lenses-array.json
@@ -1,0 +1,125 @@
+{
+  "relations": [
+    {
+      "name": ["lenses","flattened_dates"],
+      "baseRelation": ["nested","company_data_arrays"],
+      "flattenedColumn": {
+        "name": "days",
+        "datatype": "array<timestamp>"
+      },
+      "columns": {
+        "kept": [
+          "id"
+        ],
+        "new": "invoice_date",
+        "position": "index"
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["lenses","flattened_income"],
+      "baseRelation": ["nested", "company_data_arrays"],
+      "flattenedColumn": {
+        "name": "income",
+        "datatype": "array<integer>"
+      },
+      "columns": {
+        "kept": [
+          "id"
+        ],
+        "new": "period_income",
+        "position": "index"
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["lenses","flattened_workers_mid"],
+      "baseRelation": ["nested", "company_data_arrays"],
+      "flattenedColumn": {
+        "name": "workers",
+        "datatype": "array<array<string>>"
+      },
+      "columns": {
+        "kept": [
+          "id"
+        ],
+        "new": "worker_list",
+        "position": "index"
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["lenses","flattened_workers_mid2"],
+      "baseRelation": ["lenses","flattened_workers_mid"],
+      "columns": {
+        "added": [
+          {
+            "name": "worker_list",
+            "expression": "JSON_EXTRACT_STRING_ARRAY(TO_JSON(worker_list), '$.names')"
+          }
+        ],
+        "hidden": [
+          "worker_list"
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["lenses","flattened_workers"],
+      "baseRelation": ["lenses","flattened_workers_mid2"],
+      "flattenedColumn": {
+        "name": "worker_list",
+        "datatype": "array<string>"
+      },
+      "columns": {
+        "kept": [
+          "id",
+          "index"
+        ],
+        "new": "name"
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["lenses","flattened_managers"],
+      "baseRelation": ["nested", "company_data_arrays"],
+      "flattenedColumn": {
+        "name": "managers",
+        "datatype": "array<string>"
+      },
+      "columns": {
+        "kept": [
+          "id"
+        ],
+        "new": "manager",
+        "position": "index"
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["lenses","managers"],
+      "baseRelation": ["lenses","flattened_managers"],
+      "columns": {
+        "added": [
+          {
+            "name": "firstname",
+            "expression": "CAST(json_extract_scalar(manager, '$.firstName') AS string)"
+          },
+          {
+            "name": "lastname",
+            "expression": "CAST(json_extract_scalar(manager, '$.lastName') AS string)"
+          },
+          {
+            "name": "age",
+            "expression": "CAST(json_extract_scalar(manager, '$.age') AS integer)"
+          }
+        ],
+        "hidden": [
+          "manager"
+        ]
+      },
+      "type": "BasicLens"
+    }
+  ]
+}
+


### PR DESCRIPTION
BigQuery supports the ARRAY type with type signature ARRAY<T>
BigQuery also supports the JSON type.

BigQuery does not support multi-dimensional arrays of the type ARRAY<ARRAY<T>>. However, we can have nested arrays of the form ARRAY<STRUCT<ARRAY<T>>> (this is the recommended approach from the BigQuery documentation).
The test cases have been implemented with this in mind.

The Flatten operation can be performed as a CROSS JOIN with the table function UNNEST [WITH OFFSET]. The `ordinality` column generated this way starts at 0 (whereas most other dialects start at 1).

Automated Github CI tests do not work for BigQuery, but all test cases were run locally to ensure nothing was broken.