### PR TITLE
Implemented FlattenLens for Redshift

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/PostgresSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/PostgresSelectFromWhereSerializer.java
@@ -31,7 +31,7 @@ import static it.unibz.inf.ontop.model.type.impl.PostgreSQLDBTypeFactory.*;
 public class PostgresSelectFromWhereSerializer extends DefaultSelectFromWhereSerializer implements SelectFromWhereSerializer {
 
     @Inject
-    private PostgresSelectFromWhereSerializer(TermFactory termFactory) {
+    protected PostgresSelectFromWhereSerializer(TermFactory termFactory) {
         super(new DefaultSQLTermSerializer(termFactory) {
             @Override
             protected String castFloatingConstant(String value, DBTermType dbType) {

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/RedshiftSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/RedshiftSelectFromWhereSerializer.java
@@ -52,7 +52,7 @@ public class RedshiftSelectFromWhereSerializer extends PostgresSelectFromWhereSe
                                                                   Optional<Variable> indexVar, DBTermType flattenedType,
                                                                   ImmutableMap<Variable, QualifiedAttributeID> allColumnIDs,
                                                                   QuerySerialization subQuerySerialization) {
-                        //We now build the query string of the form SELECT <variables> FROM <subquery> JOIN LATERAL <flatten_function>(<flattenedVariable>) WITH ORDINALITY AS <name>
+                        //We build the query string of the form SELECT <outputVar> FROM <subquery>, <flattenedVar> AS <outputVar> [AT <indexVar>
                         StringBuilder builder = new StringBuilder();
 
                         builder.append(

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/RedshiftSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/RedshiftSelectFromWhereSerializer.java
@@ -1,0 +1,78 @@
+package it.unibz.inf.ontop.generation.serializer.impl;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import it.unibz.inf.ontop.dbschema.DBParameters;
+import it.unibz.inf.ontop.dbschema.QualifiedAttributeID;
+import it.unibz.inf.ontop.generation.algebra.SQLFlattenExpression;
+import it.unibz.inf.ontop.generation.algebra.SelectFromWhereWithModifiers;
+import it.unibz.inf.ontop.generation.serializer.SelectFromWhereSerializer;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.model.type.DBTermType;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+
+import java.util.Optional;
+
+public class RedshiftSelectFromWhereSerializer extends PostgresSelectFromWhereSerializer {
+
+    @Inject
+    protected RedshiftSelectFromWhereSerializer(TermFactory termFactory) {
+        super(termFactory);
+    }
+
+    @Override
+    public SelectFromWhereSerializer.QuerySerialization serialize(SelectFromWhereWithModifiers selectFromWhere, DBParameters dbParameters) {
+        return selectFromWhere.acceptVisitor(
+                new DefaultSelectFromWhereSerializer.DefaultRelationVisitingSerializer(dbParameters.getQuotedIDFactory()) {
+                    /**
+                     * https://www.postgresql.org/docs/8.1/queries-limit.html
+                     * <p>
+                     * [LIMIT { number | ALL }] [OFFSET number]
+                     * <p>
+                     * If a limit count is given, no more than that many rows will be returned
+                     * (but possibly less, if the query itself yields less rows).
+                     * LIMIT ALL is the same as omitting the LIMIT clause.
+                     * <p>
+                     * OFFSET says to skip that many rows before beginning to return rows.
+                     * OFFSET 0 is the same as omitting the OFFSET clause. If both OFFSET and LIMIT
+                     * appear, then OFFSET rows are skipped before starting to count the LIMIT rows
+                     * that are returned.
+                     */
+
+                    // serializeLimit and serializeOffset are standard
+                    @Override
+                    protected String serializeLimitOffset(long limit, long offset, boolean noSortCondition) {
+                        return String.format("LIMIT %d\nOFFSET %d", limit, offset);
+                    }
+
+                    @Override
+                    protected QuerySerialization serializeFlatten(SQLFlattenExpression sqlFlattenExpression,
+                                                                  Variable flattenedVar, Variable outputVar,
+                                                                  Optional<Variable> indexVar, DBTermType flattenedType,
+                                                                  ImmutableMap<Variable, QualifiedAttributeID> allColumnIDs,
+                                                                  QuerySerialization subQuerySerialization) {
+                        //We now build the query string of the form SELECT <variables> FROM <subquery> JOIN LATERAL <flatten_function>(<flattenedVariable>) WITH ORDINALITY AS <name>
+                        StringBuilder builder = new StringBuilder();
+
+                        builder.append(
+                                String.format(
+                                        "%s, %s AS %s %s",
+                                        subQuerySerialization.getString(),
+                                        allColumnIDs.get(flattenedVar).getSQLRendering(),
+                                        allColumnIDs.get(outputVar).getSQLRendering(),
+                                        indexVar.map(v -> String.format(" AT %s",
+                                                        allColumnIDs.get(v).getSQLRendering()))
+                                                .orElse("")
+                                ));
+
+                        return new QuerySerializationImpl(
+                                builder.toString(),
+                                allColumnIDs.entrySet().stream()
+                                        .filter(e -> e.getKey() != flattenedVar)
+                                        .collect(ImmutableCollectors.toMap())
+                        );
+                    }
+                });
+    }
+}

--- a/db/rdb/src/main/resources/it/unibz/inf/ontop/injection/sql-default.properties
+++ b/db/rdb/src/main/resources/it/unibz/inf/ontop/injection/sql-default.properties
@@ -167,7 +167,7 @@ com.simba.athena.jdbc.Driver-normalizer =  it.unibz.inf.ontop.generation.normali
 #Redshift
 com.amazon.redshift.jdbc42.Driver-symbolFactory = it.unibz.inf.ontop.model.term.functionsymbol.db.impl.RedshiftDBFunctionSymbolFactory
 com.amazon.redshift.jdbc42.Driver-typeFactory = it.unibz.inf.ontop.model.type.impl.RedshiftDBTypeFactory
-com.amazon.redshift.jdbc42.Driver-serializer = it.unibz.inf.ontop.generation.serializer.impl.PostgresSelectFromWhereSerializer
+com.amazon.redshift.jdbc42.Driver-serializer = it.unibz.inf.ontop.generation.serializer.impl.RedshiftSelectFromWhereSerializer
 com.amazon.redshift.jdbc42.Driver-metadataProvider = it.unibz.inf.ontop.dbschema.impl.PostgreSQLDBMetadataProvider
 com.amazon.redshift.jdbc42.Driver-normalizer =  it.unibz.inf.ontop.generation.normalization.impl.ConvertValuesToUnionNormalizer
 #DuckDB

--- a/test/lightweight-tests/lightweight-db-test-images/redshift/sql/nested.sql
+++ b/test/lightweight-tests/lightweight-db-test-images/redshift/sql/nested.sql
@@ -1,0 +1,14 @@
+CREATE TABLE company_data_arrays (
+    id integer NOT NULL PRIMARY KEY,
+    days super,
+    income super,
+    workers super,
+    managers super
+);
+
+INSERT INTO company_data_arrays VALUES (1,  ARRAY('2023-01-01 18:00:00', '2023-01-15 18:00:00', '2023-01-29 12:00:00'), ARRAY(10000, 18000, 13000), ARRAY(ARRAY('Sam', 'Cynthia'), ARRAY('Bob'), ARRAY('Jim')), ARRAY('{"firstName": "Mary", "lastName": "Jane", "age": 28}', '{"firstName": "Carlos", "lastName": "Carlson", "age": 45}', '{"firstName": "John", "lastName": "Moriarty", "age": 60}'));
+INSERT INTO company_data_arrays VALUES (2,  ARRAY('2023-02-12 18:00:00', '2023-02-26 18:00:00'), ARRAY(14000, 0), ARRAY(ARRAY('Jim', 'Cynthia'), ARRAY()), ARRAY('{"firstName": "Helena", "lastName": "of Troy"}', '{"firstName": "Robert", "lastName": "Smith", "age": 48}'));
+INSERT INTO company_data_arrays VALUES (3,  ARRAY('2023-03-12 18:00:00', '2023-03-26 18:00:00'), ARRAY(15000, 20000), ARRAY(ARRAY('Carl', 'Bob', 'Cynthia'), ARRAY('Jim', 'Bob')), ARRAY('{"firstName": "Joseph", "lastName": "Grey"}', '{"firstName": "Godfrey", "lastName": "Hamilton", "age": 59}'));
+INSERT INTO company_data_arrays VALUES (4,  ARRAY(), ARRAY(), NULL, ARRAY());
+
+GRANT SELECT ON company_data_arrays TO "IAM:ontop-athena";

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/redshift/NestedDataRedshiftTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/redshift/NestedDataRedshiftTest.java
@@ -1,0 +1,50 @@
+package it.unibz.inf.ontop.docker.lightweight.redshift;
+
+import com.google.common.collect.ImmutableMultiset;
+import it.unibz.inf.ontop.docker.lightweight.AbstractNestedDataTest;
+import it.unibz.inf.ontop.docker.lightweight.RedshiftLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@RedshiftLightweightTest
+public class NestedDataRedshiftTest extends AbstractNestedDataTest {
+
+    private static final String PROPERTIES_FILE = "/nested/redshift/nested-redshift.properties";
+    private static final String LENS_FILE = "/nested/redshift/nested-lenses-array.json";
+
+    private static final String OBDA_FILE= "/nested/nested.obda";
+
+    @BeforeAll
+    public static void before() throws IOException, SQLException {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE, LENS_FILE);
+    }
+
+    @AfterAll
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Override
+    protected ImmutableMultiset getFlattenTimestampExpectedValues() {
+        return ImmutableMultiset.of( "\"2023-01-01T18:00:00+00\"^^xsd:dateTime", "\"2023-01-15T18:00:00+00\"^^xsd:dateTime", "\"2023-01-29T12:00:00+00\"^^xsd:dateTime",
+                "\"2023-02-12T18:00:00+00\"^^xsd:dateTime", "\"2023-02-26T18:00:00+00\"^^xsd:dateTime",
+                "\"2023-03-12T18:00:00+00\"^^xsd:dateTime", "\"2023-03-26T18:00:00+00\"^^xsd:dateTime");
+    }
+
+    @Override
+    protected ImmutableMultiset getFlattenWithAggregateExpectedValues() {
+        return ImmutableMultiset.of("\"Carl: 15000.000000000000000000\"^^xsd:string", "\"Jim: 15666.666666666666666666\"^^xsd:string",
+                "\"Cynthia: 13000.000000000000000000\"^^xsd:string", "\"Sam: 10000.000000000000000000\"^^xsd:string",
+                "\"Bob: 17666.666666666666666666\"^^xsd:string");
+    }
+
+    //Redshift starts counting at 0 for the position argument.
+    @Override
+    protected ImmutableMultiset getFlattenWithPositionExpectedValues() {
+        return ImmutableMultiset.of( "\"1\"^^xsd:integer", "\"1\"^^xsd:integer", "\"1\"^^xsd:integer",
+                "\"0\"^^xsd:integer", "\"0\"^^xsd:integer", "\"0\"^^xsd:integer", "\"2\"^^xsd:integer");
+    }
+}

--- a/test/lightweight-tests/src/test/resources/nested/redshift/nested-lenses-array.json
+++ b/test/lightweight-tests/src/test/resources/nested/redshift/nested-lenses-array.json
@@ -1,0 +1,157 @@
+{
+  "relations": [
+    {
+      "name": ["lenses","flattened_dates_mid"],
+      "baseRelation": ["company_data_arrays"],
+      "flattenedColumn": {
+        "name": "days",
+        "datatype": "super"
+      },
+      "columns": {
+        "kept": [
+          "id"
+        ],
+        "new": "invoice_date",
+        "position": "index"
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["lenses","flattened_income_mid"],
+      "baseRelation": ["company_data_arrays"],
+      "flattenedColumn": {
+        "name": "income",
+        "datatype": "super"
+      },
+      "columns": {
+        "kept": [
+          "id"
+        ],
+        "new": "period_income",
+        "position": "index"
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["lenses","flattened_workers_mid"],
+      "baseRelation": ["company_data_arrays"],
+      "flattenedColumn": {
+        "name": "workers",
+        "datatype": "super"
+      },
+      "columns": {
+        "kept": [
+          "id"
+        ],
+        "new": "worker_list",
+        "position": "index"
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["lenses","flattened_workers_mid2"],
+      "baseRelation": ["lenses","flattened_workers_mid"],
+      "flattenedColumn": {
+        "name": "worker_list",
+        "datatype": "super"
+      },
+      "columns": {
+        "kept": [
+          "id",
+          "index"
+        ],
+        "new": "name"
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["lenses","flattened_managers"],
+      "baseRelation": ["company_data_arrays"],
+      "flattenedColumn": {
+        "name": "managers",
+        "datatype": "super"
+      },
+      "columns": {
+        "kept": [
+          "id"
+        ],
+        "new": "manager",
+        "position": "index"
+      },
+      "type": "FlattenLens"
+    },
+    {
+      "name": ["lenses","managers"],
+      "baseRelation": ["lenses","flattened_managers"],
+      "columns": {
+        "added": [
+          {
+            "name": "firstname",
+            "expression": "CAST(json_extract_path_text(CAST(manager as VARCHAR), 'firstName') AS VARCHAR)"
+          },
+          {
+            "name": "lastname",
+            "expression": "CAST(json_extract_path_text(CAST(manager as VARCHAR), 'lastName') AS VARCHAR)"
+          },
+          {
+            "name": "age",
+            "expression": "CAST(CASE WHEN json_extract_path_text(CAST(manager as VARCHAR), 'age') = '' THEN NULL ELSE json_extract_path_text(CAST(manager as VARCHAR), 'age') END AS integer)"
+          }
+        ],
+        "hidden": [
+          "manager"
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["lenses","flattened_dates"],
+      "baseRelation": ["lenses","flattened_dates_mid"],
+      "columns": {
+        "added": [
+          {
+            "name": "invoice_date",
+            "expression": "CAST(invoice_date AS TIMESTAMP)"
+          }
+        ],
+        "hidden": [
+          "invoice_date"
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["lenses","flattened_income"],
+      "baseRelation": ["lenses","flattened_income_mid"],
+      "columns": {
+        "added": [
+          {
+            "name": "period_income",
+            "expression": "CAST(period_income AS integer)"
+          }
+        ],
+        "hidden": [
+          "period_income"
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["lenses","flattened_workers"],
+      "baseRelation": ["lenses","flattened_workers_mid2"],
+      "columns": {
+        "added": [
+          {
+            "name": "name",
+            "expression": "CAST(name AS VARCHAR)"
+          }
+        ],
+        "hidden": [
+          "name"
+        ]
+      },
+      "type": "BasicLens"
+    }
+  ]
+}
+

--- a/test/lightweight-tests/src/test/resources/nested/redshift/nested-redshift.properties
+++ b/test/lightweight-tests/src/test/resources/nested/redshift/nested-redshift.properties
@@ -1,0 +1,4 @@
+jdbc.url = jdbc:redshift:iam://default.${redshift.account}.eu-central-1.redshift-serverless.amazonaws.com:5439/dev
+jdbc.property.AccessKeyID = ${redshift.user}
+jdbc.property.SecretAccessKey = ${redshift.password}
+jdbc.driver = com.amazon.redshift.jdbc42.Driver


### PR DESCRIPTION
Redshift uses the `SUPER` type for all nested data structures (arrays, maps, and structs). We cannot get more precise typing information, so we cannot infer the base type of an array (also, redshift arrays do not need to be all of the same type, so such a base type does not exist anyways).

Redshift supports the "ARRAY_FLATTEN" function, but this function flattens the array on all levels, so it is not compatible for our FlattenLens.

Instead, redshift also allows using array columns as `FROM` sources, so we perform the flatten operation as `SELECT <variables> FROM <subquery>, <array_column> AT <index_variable>`