### PR TITLE
Flatten Lens: Infer Unique and Foreign Key Constraints

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FlattenNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FlattenNodeImpl.java
@@ -193,7 +193,15 @@ public class FlattenNodeImpl extends CompositeQueryNodeImpl implements FlattenNo
      * Unique constraints are lost after flattening
      */
     public ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(IQTree child) {
-        return ImmutableSet.of();
+        //If there is no index variable, we cannot infer unique constraints.
+        if(indexVariable.isEmpty())
+            return ImmutableSet.of();
+
+        var childConstraints = child.inferUniqueConstraints();
+        return childConstraints.stream()
+                .map(constraint -> Stream.concat(constraint.stream(), Stream.of(indexVariable.get()))
+                            .collect(ImmutableCollectors.toSet()))
+                .collect(ImmutableCollectors.toSet());
     }
 
     /**

--- a/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/NestedViewsPersonTest.java
+++ b/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/NestedViewsPersonTest.java
@@ -28,7 +28,7 @@ public class NestedViewsPersonTest {
                 .map(v -> v.getID().getName())
                 .collect(ImmutableCollectors.toSet());
 
-        assertEquals(constraints, ImmutableSet.of());
+        assertEquals(constraints, ImmutableSet.of("id", "pos"));
     }
 
     @Test

--- a/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/NestedViewsPersonTest.java
+++ b/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/NestedViewsPersonTest.java
@@ -19,7 +19,7 @@ public class NestedViewsPersonTest {
     }
 
     @Test
-    public void testNoUC() {
+    public void testInferredUC() {
         ImmutableSet<String> constraints = viewDefinitions.stream()
                 .map(RelationDefinition::getUniqueConstraints)
                 .flatMap(Collection::stream)
@@ -51,5 +51,25 @@ public class NestedViewsPersonTest {
                 .collect(ImmutableCollectors.toSet());
 
         assertEquals(ImmutableSet.of("ssn", "fullName"), dependents);
+    }
+
+    @Test
+    public void testInferredFKs() {
+        ImmutableSet<ForeignKeyConstraint> fks = viewDefinitions.stream()
+                .map(RelationDefinition::getForeignKeys)
+                .flatMap(Collection::stream)
+                .collect(ImmutableCollectors.toSet());
+        assertEquals(2, fks.size());
+
+        ForeignKeyConstraint fk = fks.stream().findFirst().get();
+        String target = fk.getReferencedRelation().getID().getSQLRendering();
+        assertEquals("\"hr\".\"person-xt\"", target);
+
+        ImmutableSet<String> keys = fk.getComponents().stream()
+                .map(ForeignKeyConstraint.Component::getAttribute)
+                .map(a -> a.getID().getName())
+                .collect(ImmutableCollectors.toSet());
+
+        assertEquals(ImmutableSet.of("id"), keys);
     }
 }


### PR DESCRIPTION
Added functionality to infer integrity constraints for the Flatten Lens:
- UC: If a position argument `pos` is included in the Lens, and any of the base relation's UCs `c` is fully included, then `c` + `pos` is a unique constraint.
- FK: If any of the base relation's UCs is fully included, then we can use it as a foreign key to the base relation.