### PR TITLE
QuotedIDFactory refactoring introducing type annotation and lookup by type

### DIFF
--- a/core/model/pom.xml
+++ b/core/model/pom.xml
@@ -62,6 +62,10 @@
             <artifactId>guice-assistedinject</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.github.solf</groupId>
+            <artifactId>nullanno</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/core/model/src/main/java/it/unibz/inf/ontop/dbschema/QuotedIDFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/dbschema/QuotedIDFactory.java
@@ -9,9 +9,9 @@ package it.unibz.inf.ontop.dbschema;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,42 +20,153 @@ package it.unibz.inf.ontop.dbschema;
  * #L%
  */
 
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Factory for creating attribute and relation identifier from strings.
- * It defines the rules of transforming unquoted and quoted identifiers.
- * 
- * @author Roman Kontchakov
+ * <p>
+ * Instances of this class define the rules of transforming unquoted and quoted identifiers, and different
+ * {@code QuotedIDFactory} sub-classes can be defined to address different DBMS backends.
+ * </p><p>
+ * Each {@code QuotedIDFactory} implementation class should be associated to a <i>factory type identifier</i> obtainable
+ * via {@link #getIDFactoryType()} and generally deriving from a {@link IDFactoryType} class annotation. This identifier
+ * is a human-readable string that uniquely identifies the factory type (e.g., {@code POSTGRESQL}) in data written by
+ * Ontop (e.g., the DB metadata saved to file) so to allow reading back that data using the proper
+ * {@code QuotedIDFactory} implementation.
+ * <p></p>
+ * When implementing {@code QuotedIDFactory}, add a {@link IDFactoryType} annotation to specify the factory type
+ * identifier, and then add a binding for the implementation class in the {@code OntopAbstractModule} sub-class of the
+ * enclosing Ontop project (see the implementation of {@code OntopModelModule} for an example of how
+ * {@code SQLStandardQuotedIDFactory} is bound).
+ * </p>
  *
+ * @author Roman Kontchakov (original implementation)
  */
-
+@NonNullByDefault
 public interface QuotedIDFactory {
 
-	/**
-	 * Creates a new attribute ID from a string.
-	 * @param attributeId possibly quoted attribute ID (SQL rendering)
-	 * @return attribute ID
-	 */
-	QuotedID createAttributeID(@Nonnull String attributeId);
+    /**
+     * Creates a new attribute ID from a string.
+     *
+     * @param attributeId possibly quoted attribute ID (SQL rendering)
+     * @return attribute ID
+     */
+    QuotedID createAttributeID(String attributeId);
 
+    /**
+     * Creates a new relation ID from the supplied name.
+     *
+     * @param tableId the name
+     * @return relation ID
+     */
+    RelationID createRelationID(String tableId);
 
-	RelationID createRelationID(@Nonnull String tableId);
+    /**
+     * Creates a new relation ID from the component strings.
+     *
+     * @param components list of the possibly quoted components of relation ID,
+     *                   from the catalog to the table name
+     * @return relation ID
+     */
+    RelationID createRelationID(String... components);
 
-	/**
-	 * Creates a new relation ID from the component strings.
-	 * @param components list of the possibly quoted components of relation ID,
-	 *                      from the catalog to the table name
-	 * @return relation ID
-	 */
-	RelationID createRelationID(String... components);
+    /**
+     * Returns the quotation string used in the SQL rendering.
+     *
+     * @return the quotation string
+     */
+    String getIDQuotationString();
 
+    /**
+     * Returns whether notation {@code [identifier]} for schema/table/attribute identifiers is supported.
+     *
+     * @return true if square bracked notation is supported
+     */
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    boolean supportsSquareBracketQuotation();
 
-	/**
-	 * @return quotation string used in the SQL rendering
-	 */
-	String getIDQuotationString();
+    /**
+     * Returns an identifier (such as "POSTGRESQL") useful to denote the type of factory when writing/reading database
+     * metadata. The default implementation retrieves the identifier from a {@link IDFactoryType} annotation placed on
+     * the java class this object is instance of. Consider adding a {@code IDFactoryType} in derived classes or, for
+     * wrappers, overriding and delegating this method to the wrapped {@code QuotedIDFactory}.
+     *
+     * @return a string identifier of this factory type, not null
+     * @throws UnsupportedOperationException if a factory type ID is not available
+     */
+    default String getIDFactoryType() {
+        return getIDFactoryType(getClass());
+    }
 
-	boolean supportsSquareBracketQuotation();
+    static String getIDFactoryType(Class<? extends QuotedIDFactory> factoryClass) {
+        //noinspection ConstantConditions
+        return Stream.<Class<?>>iterate(factoryClass, Objects::nonNull, Class::getSuperclass)
+                .flatMap(c -> Stream.ofNullable(c.getAnnotation(IDFactoryType.class)).map(IDFactoryType::value))
+                .findFirst()
+                .orElseThrow(() -> new UnsupportedOperationException("No @IDFactoryType annotation found"));
+    }
+
+    /**
+     * Supplies a human-readable string identifier of a {@link QuotedIDFactory} implementation class.
+     * <p>
+     * This annotation is read by default by {@link QuotedIDFactory#getIDFactoryType()} and its value can be used to
+     * indicate the type of {@code QuotedIDFactory} in read/written data.
+     * </p>
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @interface IDFactoryType {
+
+        /**
+         * The string identifying the ID factory type (such as {@code POSTGRESQL}).
+         *
+         * @return a string identifier of the ID factory type
+         */
+        String value();
+
+    }
+
+    /**
+     * Supplier of {@link QuotedIDFactory} based on factory type identifier.
+     * <p>
+     * Instances of this interface can be used / injected wherever it is needed to obtain a {@code QuotedIDFactory}
+     * instance matching a factory type (e.g., {@code POSTGRESQL}) only known at runtime, e.g., because deserialized
+     * from read data. An instance of this interface covering all available {@code QuotedIDFactory} types in Ontop can
+     * be injected using Ontop configuration / injection mechanism.
+     * </p>
+     */
+    interface Supplier {
+
+        /**
+         * Returns a {@code QuotedIDFactory} with the ID factory type specified.
+         *
+         * @param idFactoryType factory type identifier
+         * @return a corresponding factory instance
+         */
+        Optional<QuotedIDFactory> get(String idFactoryType);
+
+        /**
+         * Utility method producing a {@code Supplier} whose {@code get()} method returns one of the specified
+         * {@code QuotedIDFactory}.
+         *
+         * @param factories the factories to return
+         * @return the created supplier
+         */
+        static Supplier wrap(QuotedIDFactory... factories) {
+            ImmutableMap<String, Optional<QuotedIDFactory>> map = Stream.of(factories)
+                    .collect(ImmutableMap.toImmutableMap(QuotedIDFactory::getIDFactoryType, Optional::of));
+            return idFactoryType -> map.getOrDefault(idFactoryType, Optional.empty());
+        }
+
+    }
+
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/QuotedIDImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/QuotedIDImpl.java
@@ -20,14 +20,10 @@ package it.unibz.inf.ontop.dbschema.impl;
  * #L%
  */
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import it.unibz.inf.ontop.dbschema.QuotedID;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -51,14 +47,11 @@ public class QuotedIDImpl implements QuotedID {
      * (used only in QuotedIDFactory implementations)
      *
      * @param id cannot be null
-     * @param quoteString cannot be null (the empty string stands for no quotation, as in getIdentifierQuoteString)
+     * @param quoteString the empty string stands for no quotation, as in getIdentifierQuoteString
+     * @param caseSensitive specifies whether the ID is case-sensitive
      */
-    QuotedIDImpl(String id, String quoteString) {
-        this(id, quoteString, true);
-    }
-
     QuotedIDImpl(String id, String quoteString, boolean caseSensitive) {
-        this.id = id;
+        this.id = Objects.requireNonNull(id);
         this.quoteString = Objects.requireNonNull(quoteString);
         this.caseSensitive = caseSensitive;
         // increases collisions but makes it possible to have case-insensitive ids (for MySQL)
@@ -117,13 +110,4 @@ public class QuotedIDImpl implements QuotedID {
     public int hashCode() {
         return hashCode;
     }
-
-    // TODO: This doesn't seem to be used in the project. Remove it?
-    public static class QuotedIDSerializer extends JsonSerializer<QuotedID> {
-        @Override
-        public void serialize(QuotedID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-            gen.writeString(value.getSQLRendering());
-        }
-    }
-
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/QuotedIDImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/QuotedIDImpl.java
@@ -1,6 +1,5 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
-
 /*
  * #%L
  * ontop-obdalib-core
@@ -25,10 +24,11 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import it.unibz.inf.ontop.dbschema.QuotedID;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
-
+import java.util.Objects;
 
 /**
  * Database identifier used for schema names, table names and aliases
@@ -39,8 +39,7 @@ import java.io.IOException;
  * @author Roman Kontchakov
  *
  */
-
-
+@NonNullByDefault
 public class QuotedIDImpl implements QuotedID {
 
     private final String id;
@@ -51,16 +50,16 @@ public class QuotedIDImpl implements QuotedID {
     /**
      * (used only in QuotedIDFactory implementations)
      *
-     * @param id can be null
+     * @param id cannot be null
      * @param quoteString cannot be null (the empty string stands for no quotation, as in getIdentifierQuoteString)
      */
-    QuotedIDImpl(@Nonnull String id, String quoteString) {
+    QuotedIDImpl(String id, String quoteString) {
         this(id, quoteString, true);
     }
 
-    QuotedIDImpl(@Nonnull String id, String quoteString, boolean caseSensitive) {
+    QuotedIDImpl(String id, String quoteString, boolean caseSensitive) {
         this.id = id;
-        this.quoteString = quoteString;
+        this.quoteString = Objects.requireNonNull(quoteString);
         this.caseSensitive = caseSensitive;
         // increases collisions but makes it possible to have case-insensitive ids (for MySQL)
         this.hashCode = id.toLowerCase().hashCode();
@@ -71,8 +70,6 @@ public class QuotedIDImpl implements QuotedID {
      *
      * @return identifier without quotation marks (for comparison etc.)
      */
-
-    @Nonnull
     @Override
     public String getName() {
         return id;
@@ -83,8 +80,6 @@ public class QuotedIDImpl implements QuotedID {
      *
      * @return identifier possibly in quotes
      */
-
-    @Nonnull
     @Override
     public String getSQLRendering() {
         return quoteString + id + quoteString;
@@ -98,9 +93,8 @@ public class QuotedIDImpl implements QuotedID {
     /**
      * compares two identifiers ignoring quotation
      */
-
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj)
             return true;
 
@@ -124,10 +118,12 @@ public class QuotedIDImpl implements QuotedID {
         return hashCode;
     }
 
+    // TODO: This doesn't seem to be used in the project. Remove it?
     public static class QuotedIDSerializer extends JsonSerializer<QuotedID> {
         @Override
         public void serialize(QuotedID value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
             gen.writeString(value.getSQLRendering());
         }
     }
+
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/RawQuotedIDFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/RawQuotedIDFactory.java
@@ -2,8 +2,8 @@ package it.unibz.inf.ontop.dbschema.impl;
 
 import it.unibz.inf.ontop.dbschema.QuotedID;
 import it.unibz.inf.ontop.dbschema.QuotedIDFactory;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 /**
@@ -12,22 +12,22 @@ import java.util.Objects;
  *
  * TO BE USED ONLY IN METADATA EXTRACTION
  */
-
+@NonNullByDefault
 public class RawQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
     private final QuotedIDFactory idFactory;
 
     public RawQuotedIDFactory(QuotedIDFactory idFactory) {
-        this.idFactory = idFactory;
+        this.idFactory = Objects.requireNonNull(idFactory);
     }
 
     /**
-     * creates an ID from the database record (as though it is a quoted name)
+     * Creates an ID from the database record (as though it is a quoted name).
      *
-     * @param s
-     * @return
+     * @param s the name
+     * @return quoted name
      */
-    protected QuotedID createFromString(@Nonnull String s) {
+    protected QuotedID createFromString(String s) {
         Objects.requireNonNull(s);
         return new QuotedIDImpl(s, idFactory.getIDQuotationString());
     }
@@ -36,4 +36,11 @@ public class RawQuotedIDFactory extends SQLStandardQuotedIDFactory {
     public String getIDQuotationString() {
         return idFactory.getIDQuotationString();
     }
+
+    @Override
+    public String getIDFactoryType() {
+        // For completeness. Apparently lookup by type ID is not relevant for this kind of factory
+        return "RAW-" + idFactory.getIDFactoryType();
+    }
+
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/RawQuotedIDFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/RawQuotedIDFactory.java
@@ -29,7 +29,7 @@ public class RawQuotedIDFactory extends SQLStandardQuotedIDFactory {
      */
     protected QuotedID createFromString(String s) {
         Objects.requireNonNull(s);
-        return new QuotedIDImpl(s, idFactory.getIDQuotationString());
+        return new QuotedIDImpl(s, idFactory.getIDQuotationString(), true);
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLStandardQuotedIDFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLStandardQuotedIDFactory.java
@@ -25,9 +25,10 @@ package it.unibz.inf.ontop.dbschema.impl;
 import com.google.common.collect.ImmutableList;
 import it.unibz.inf.ontop.dbschema.QuotedID;
 import it.unibz.inf.ontop.dbschema.QuotedIDFactory;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
 import it.unibz.inf.ontop.dbschema.RelationID;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 /**
@@ -60,25 +61,25 @@ import java.util.Objects;
  *
  *
  * @author Roman Kontchakov
- *
  */
-
+@IDFactoryType("STANDARD")
+@NonNullByDefault
 public class SQLStandardQuotedIDFactory implements QuotedIDFactory {
 
 	public static final String QUOTATION_STRING = "\"";
+
 	public static final String NO_QUOTATION = "";
 
 	@Override
-	public QuotedID createAttributeID(@Nonnull String s) {
+	public QuotedID createAttributeID(String s) {
 		Objects.requireNonNull(s);
 		return createFromString(s);
 	}
 
 	@Override
-	public RelationID createRelationID(@Nonnull String tableId) {
+	public RelationID createRelationID(String tableId) {
 		return new RelationIDImpl(ImmutableList.of(createFromString(tableId)));
 	}
-
 
 	@Override
 	public RelationID createRelationID(String... components) {
@@ -91,7 +92,7 @@ public class SQLStandardQuotedIDFactory implements QuotedIDFactory {
 		return new RelationIDImpl(builder.build());
 	}
 	
-	protected QuotedID createFromString(@Nonnull String s) {
+	protected QuotedID createFromString(String s) {
 		Objects.requireNonNull(s);
 
 		if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
@@ -109,4 +110,5 @@ public class SQLStandardQuotedIDFactory implements QuotedIDFactory {
 	public boolean supportsSquareBracketQuotation() {
 		return false;
 	}
+
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLStandardQuotedIDFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLStandardQuotedIDFactory.java
@@ -30,6 +30,7 @@ import it.unibz.inf.ontop.dbschema.RelationID;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 import java.util.Objects;
+import java.util.function.UnaryOperator;
 
 /**
  * Creates QuotedIdentifiers following the rules of SQL standard:<br>
@@ -72,7 +73,6 @@ public class SQLStandardQuotedIDFactory implements QuotedIDFactory {
 
 	@Override
 	public QuotedID createAttributeID(String s) {
-		Objects.requireNonNull(s);
 		return createFromString(s);
 	}
 
@@ -93,12 +93,16 @@ public class SQLStandardQuotedIDFactory implements QuotedIDFactory {
 	}
 	
 	protected QuotedID createFromString(String s) {
+		return createFromString(s, QUOTATION_STRING, String::toUpperCase, NO_QUOTATION, true);
+	}
+
+	protected final QuotedID createFromString(String s, String quotationString, UnaryOperator<String> fold, String defaultQuotationString, boolean caseSensitive) {
 		Objects.requireNonNull(s);
 
-		if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
-			return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING);
+		if (s.startsWith(quotationString) && s.endsWith(quotationString))
+			return new QuotedIDImpl(s.substring(1, s.length() - 1), quotationString, caseSensitive);
 
-		return new QuotedIDImpl(s.toUpperCase(), NO_QUOTATION);
+		return new QuotedIDImpl(fold.apply(s), defaultQuotationString, caseSensitive);
 	}
 	
 	@Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/injection/impl/OntopAbstractModule.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/injection/impl/OntopAbstractModule.java
@@ -1,13 +1,22 @@
 package it.unibz.inf.ontop.injection.impl;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.name.Named;
 import it.unibz.inf.ontop.injection.OntopModelSettings;
 
-import java.util.List;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class OntopAbstractModule extends AbstractModule {
 
     /**
@@ -26,51 +35,142 @@ public abstract class OntopAbstractModule extends AbstractModule {
         this.settings = settings;
     }
 
-    public Class<?> getImplementation(String interfaceClassName) throws UnknownClassException {
-        String implementationClassName = settings.getProperty(interfaceClassName)
-                .orElseThrow(() -> new UnknownClassException(String.format(
-                        "No entry for the interface %s in the settings.",
-                        interfaceClassName)));
-
-        try {
-            return Class.forName(implementationClassName);
-        } catch (ClassNotFoundException e) {
-            throw new UnknownClassException(e.getMessage());
-        }
+    protected final <T> Optional<Class<? extends T>> getImplementation(Key<T> qualifiedAbstractType) {
+        return settings.getProperty(getSettingsProperty(qualifiedAbstractType)).map(implementationClassName -> {
+            try {
+                @SuppressWarnings("unchecked")
+                Class<T> abstractClass = (Class<T>) qualifiedAbstractType.getTypeLiteral().getRawType();
+                return Class.forName(implementationClassName).asSubclass(abstractClass);
+            } catch (ClassNotFoundException e) {
+                throw new UnknownClassException(e.getMessage());
+            }
+        });
     }
 
-    public Class getImplementation(Class abstractInterface) throws UnknownClassException {
-        return getImplementation(abstractInterface.getCanonicalName());
+    /**
+     * Suggest replacing calls to this method with (more compact calls to {@link #buildFactory(Class, Class[])}
+     */
+    protected final Module buildFactory(Iterable<Class<?>> abstractTypes, Class<?> factoryInterface) {
+        return buildFactory(
+                Key.get(factoryInterface),
+                StreamSupport.stream(abstractTypes.spliterator(), false)
+                        .map(Key::get).<Key<?>>toArray(Key[]::new));
     }
 
-    protected Module buildFactory(List<Class> types,  Class factoryInterface) {
+    protected final Module buildFactory(Class<?> factoryInterface, Class<?>... abstractTypes) {
+        return buildFactory(Key.get(factoryInterface), Stream.of(abstractTypes).map(Key::get).<Key<?>>toArray(Key[]::new));
+    }
+
+    protected final Module buildFactory(Key<?> qualifiedFactoryInterface, Key<?>... qualifiedAbstractTypes) {
         FactoryModuleBuilder builder = new FactoryModuleBuilder();
 
-        /*
-         * Types to be implemented by the factory
-         */
-        for (Class type : types) {
-            builder = builder.implement(type, getImplementation(type.getCanonicalName()));
+        // Types to be implemented by the factory
+        for (Key<?> qualifiedAbstractType : qualifiedAbstractTypes) {
+            // getImplementation() is guaranteed to return a subtype (if binding defined in the settings)
+            Class<?> implementationClass = getImplementation((Key<?>) qualifiedAbstractType)
+                    .orElseThrow(() -> new UnknownClassException(String.format(
+                            "Cannot build factory %s: no property %s in the settings for abstract type %s.",
+                            qualifiedFactoryInterface.getTypeLiteral().toString(),
+                            getSettingsProperty(qualifiedAbstractType),
+                            qualifiedAbstractType.getTypeLiteral().toString())));
+            //noinspection unchecked,rawtypes
+            builder = builder.implement((Key) qualifiedAbstractType, implementationClass);
         }
-        return builder.build(factoryInterface);
+        return builder.build(qualifiedFactoryInterface);
     }
 
     /**
      * To be called by sub-classes, inside the {@link #configure()} method.
      */
-    protected void configureCoreConfiguration() {
+    protected final void configureCoreConfiguration() {
         bind(OntopModelSettings.class).toInstance(settings);
     }
 
-    protected OntopModelSettings getSettings() {
+    protected final OntopModelSettings getSettings() {
         return settings;
     }
 
     /**
-     * To bind classes with default constructors.
+     * Returns the settings property associated to the given Guice key, which can be employed by users to configure the
+     * implementation class to use for that key.
+     * <p>
+     * A Guice key is a {@code <type, qualifier>} pair, where the type is a class or a generic type and the qualifier
+     * is either missing, an annotation instance or an annotation type. The method handles all the possible cases
+     * producing a property name that is the concatenation of the <i>encoding of the type</i> and of the <i>encoding of
+     * the qualifier</i>, where:
+     * <ul>
+     * <li>the returned property name is the concatenation of <i>type encoding</i> and <i>qualifier encoding</i></li>
+     * <li>the <i>type encoding</i> has the form {@code my.package.Class.NestedClass<optional.generic.type.Name>}</li>
+     * <li>the <i>qualifier encoding</i> is {@code -name} in the typical case of a {@link Named}{@code ("name")}
+     * annotation, otherwise it is {@code @my.package.AnnotationClass.AnnotationNestedClass} possibly followed by
+     * {@code (value1,value2,...)} with the (toString) values of annotation attributes, lexicographically sorted</li>
+     * </ul>
+     * </p>
+     *
+     * @param qualifiedAbstractType the key to map to a settings property
+     * @return the settings property for the key
      */
-    protected void bindFromSettings(Class abstractClass) {
-        bind(abstractClass).to(getImplementation(abstractClass.getCanonicalName()));
+    protected final String getSettingsProperty(Key<?> qualifiedAbstractType) {
+
+        // The first part of the property is given by the key type, including generics information if present
+        Type type = qualifiedAbstractType.getTypeLiteral().getType();
+        String typeName = type instanceof Class<?>
+                ? ((Class<?>) type).getCanonicalName()
+                : type.toString().replace('$', '.'); // convert: pkg.Class$Nested -> pkg.Class.Nested
+
+        // The second part depends on the presence of an annotation/annotation type. Four possible exhaustive cases:
+        if (qualifiedAbstractType.getAnnotationType() == null) {
+            // (1) Key(type, null) -> return "typeName" (incl. generics info)
+            return typeName;
+
+        } else if (!qualifiedAbstractType.hasAttributes()) {
+            // (2) Key(type, annotationType) -> return "typeName@annotationTypeName"
+            return typeName + "@" + qualifiedAbstractType.getAnnotationType().getCanonicalName();
+
+        } else if (qualifiedAbstractType.getAnnotation() instanceof Named) {
+            // (3) Key(type, @Named(name)) -> return "typeName-name"
+            // note: need checking only @Named from Guice, as @Named from javax.inject is mapped to the former
+            return typeName + "-" + ((Named) qualifiedAbstractType.getAnnotation()).value();
+
+        } else {
+            // (4) Key(type, annotation) -> return "typeName@annotationTypeName(args)" (args guaranteed to be present)
+            var annotation = qualifiedAbstractType.getAnnotation();
+            var annotationType = qualifiedAbstractType.getAnnotationType();
+            String sortedCommaSeparatedArgs = Arrays.stream(annotationType.getDeclaredMethods())
+                    .sorted(Comparator.comparing(Method::getName))
+                    .map(m -> {
+                        try {
+                            return String.valueOf(m.invoke(annotation));
+                        } catch (Throwable ex) {
+                            throw new Error("Could not access annotation value", ex); // should not happen
+                        }
+                    })
+                    .collect(Collectors.joining(","));
+            return typeName + "@" + annotationType.getCanonicalName() + "(" + sortedCommaSeparatedArgs + ")";
+        }
+    }
+
+    /**
+     * Bind the default implementation mapped to property {@code abstractClass.getCanonicalName()} in the settings.
+     * Mainly used to bind classes with default constructors (although guice can deal with other constructors and forms
+     * of injection).
+     */
+    protected final <T> void bindFromSettings(Class<T> abstractType) {
+        bindFromSettings(Key.get(abstractType)); // delegate
+    }
+
+    protected final <T> void bindFromSettings(Key<T> qualifiedAbstractType) {
+        bind(qualifiedAbstractType).to(getImplementation(qualifiedAbstractType)
+                .orElseThrow(() -> new UnknownClassException(String.format(
+                        "No property %s in the settings for abstract type %s.",
+                        getSettingsProperty(qualifiedAbstractType),
+                        qualifiedAbstractType.getTypeLiteral().toString()))));
+    }
+
+    protected final <T> void bindFromSettings(Key<T> qualifiedAbstractType,
+                                              Class<? extends T> defaultImplementationClass) {
+        Objects.requireNonNull(defaultImplementationClass);
+        bind(qualifiedAbstractType).to(getImplementation(qualifiedAbstractType).orElse(defaultImplementationClass));
     }
 
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/injection/impl/OntopModelConfigurationImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/injection/impl/OntopModelConfigurationImpl.java
@@ -80,7 +80,6 @@ public class OntopModelConfigurationImpl implements OntopModelConfiguration {
 
     /**
      * To be overloaded
-     *
      */
     protected Stream<Module> buildGuiceModules() {
         return Stream.of(new OntopModelModule(this));
@@ -134,6 +133,7 @@ public class OntopModelConfigurationImpl implements OntopModelConfiguration {
         }
     }
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     protected abstract static class DefaultOntopModelBuilderFragment<B extends Builder<B>> implements OntopModelBuilderFragment<B> {
 
         private Optional<Boolean> testMode = Optional.empty();

--- a/core/model/src/test/java/it/unibz/inf/ontop/injection/impl/OntopAbstractModuleTest.java
+++ b/core/model/src/test/java/it/unibz/inf/ontop/injection/impl/OntopAbstractModuleTest.java
@@ -1,0 +1,138 @@
+package it.unibz.inf.ontop.injection.impl;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.BindingAnnotation;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
+import com.google.inject.util.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.annotation.*;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+public class OntopAbstractModuleTest {
+
+    /**
+     * Tests {{@link OntopAbstractModule#getSettingsProperty(Key)}} for different types of {@link Key}.
+     */
+    @Test
+    public void testGetSettingsProperty() {
+
+        // Consider Key(Type, ...) where Type is from following <"expected_property_prefix", Type> map
+        Map<String, Type> types = ImmutableMap.of(
+                "java.lang.String", String.class,
+                "java.util.List<java.lang.String>", Types.newParameterizedType(List.class, String.class),
+                "it.unibz.inf.ontop.injection.impl.OntopAbstractModuleTest.Container<java.lang.String>", Types
+                        .newParameterizedTypeWithOwner(OntopAbstractModuleTest.class, Container.class, String.class)
+        );
+
+        // Consider Key(..., Qualifier) where Qualifier is from following <"expected_property_suffix", Qualifier> map
+        Map<String, Object> qualifiers = ImmutableMap.of(
+                "-name", Names.named("name"),
+                "@it.unibz.inf.ontop.injection.impl.OntopAbstractModuleTest.MarkerAnnotation", getMarkerAnnotation(),
+                "@it.unibz.inf.ontop.injection.impl.OntopAbstractModuleTest.NonMarkerAnnotation(42,value)", getNonMarkerAnnotation()
+        );
+
+        // Test on all <Type, Qualifier> pairs from above maps, trying both Key(Type) alone and Key(Type, Qualifier),
+        // output should be "expected_property_prefix" + "expected_property_suffix"
+        OntopAbstractModule module = create();
+        for (Entry<String, Type> te : types.entrySet()) {
+            Assert.assertEquals(te.getKey(), module.getSettingsProperty(Key.get(te.getValue())));
+            for (Entry<String, Object> qe : qualifiers.entrySet()) {
+                @SuppressWarnings("unchecked")
+                Key<?> key = qe.getValue() instanceof Annotation
+                        ? Key.get(te.getValue(), (Annotation) qe.getValue())
+                        : Key.get(te.getValue(), (Class<? extends Annotation>) qe.getValue());
+                Assert.assertEquals(te.getKey() + qe.getKey(), module.getSettingsProperty(key));
+            }
+        }
+    }
+
+    /**
+     * Helper method instantiating an {@link OntopAbstractModule} anonymous subclass with the given custom settings.
+     *
+     * @param keyValueProperties vararg array of key, value pairs
+     * @return the instantiated module
+     */
+    private static OntopAbstractModule create(String... keyValueProperties) {
+        var properties = new Properties();
+        for (int i = 0; i < keyValueProperties.length; i += 2) {
+            properties.setProperty(keyValueProperties[i], keyValueProperties[i + 1]);
+        }
+        var settings = new OntopModelSettingsImpl(properties);
+        return new OntopAbstractModule(settings) {
+        };
+    }
+
+    /**
+     * Helper method returning an instance of {@link MarkerAnnotation} for testing.
+     *
+     * @return the annotation instance
+     */
+    @MarkerAnnotation
+    private static MarkerAnnotation getMarkerAnnotation() {
+        try {
+            return OntopAbstractModuleTest.class
+                    .getDeclaredMethod("getMarkerAnnotation")
+                    .getAnnotation(MarkerAnnotation.class);
+        } catch (NoSuchMethodException ex) {
+            throw new Error(ex);
+        }
+    }
+
+    /**
+     * Helper method returning an instance of {@link NonMarkerAnnotation} for testing.
+     *
+     * @return the annotation instance
+     */
+    @NonMarkerAnnotation(stringValue = "value", intValue = 42)
+    private static NonMarkerAnnotation getNonMarkerAnnotation() {
+        try {
+            return OntopAbstractModuleTest.class
+                    .getDeclaredMethod("getNonMarkerAnnotation")
+                    .getAnnotation(NonMarkerAnnotation.class);
+        } catch (NoSuchMethodException ex) {
+            throw new Error(ex);
+        }
+    }
+
+    /**
+     * Example of 'marker' annotation, that is, annotation without attributes.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @BindingAnnotation
+    @interface MarkerAnnotation {
+
+    }
+
+    /**
+     * Example of 'non-marker' annotation, that is, annotation with attributes.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @BindingAnnotation
+    @interface NonMarkerAnnotation {
+
+        String stringValue();
+
+        int intValue();
+
+    }
+
+    /**
+     * Example of generic nested abstract type.
+     *
+     * @param <T>
+     */
+    @SuppressWarnings("unused")
+    private interface Container<T> {
+
+    }
+
+}

--- a/core/model/src/test/java/it/unibz/inf/ontop/injection/impl/QuotedIDFactoryInjectionTest.java
+++ b/core/model/src/test/java/it/unibz/inf/ontop/injection/impl/QuotedIDFactoryInjectionTest.java
@@ -1,0 +1,33 @@
+package it.unibz.inf.ontop.injection.impl;
+
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory;
+import it.unibz.inf.ontop.dbschema.impl.SQLStandardQuotedIDFactory;
+import it.unibz.inf.ontop.injection.OntopModelConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.Properties;
+
+public class QuotedIDFactoryInjectionTest {
+
+    /**
+     * Test injection of a qualified {@link QuotedIDFactory} through an injected {@link QuotedIDFactory.Supplier}.
+     */
+    @Test
+    public void testQuotedIDFactoryInjection() {
+
+        Properties props = new Properties();
+        props.setProperty("noisy-property", "useless-value"); // to stress settings parsing method
+
+        OntopModelConfiguration configuration = OntopModelConfiguration.defaultBuilder().properties(props).build();
+
+        QuotedIDFactory.Supplier supplier = configuration.getInjector().getInstance(QuotedIDFactory.Supplier.class);
+        Optional<QuotedIDFactory> factory = supplier.get("STANDARD");
+
+        Assert.assertTrue(factory.isPresent());
+        Assert.assertEquals(SQLStandardQuotedIDFactory.class, factory.get().getClass());
+        Assert.assertEquals("STANDARD", factory.get().getIDFactoryType());
+    }
+
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AbstractBacktickQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AbstractBacktickQuotedIDFactory.java
@@ -1,0 +1,15 @@
+package it.unibz.inf.ontop.dbschema.impl;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+@NonNullByDefault
+public class AbstractBacktickQuotedIDFactory extends SQLStandardQuotedIDFactory {
+
+    protected static final String BACKTICK_QUOTATION_STRING = "`";
+
+    @Override
+    public String getIDQuotationString() {
+        return BACKTICK_QUOTATION_STRING;
+    }
+
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/BigQueryQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/BigQueryQuotedIDFactory.java
@@ -4,27 +4,13 @@ import it.unibz.inf.ontop.dbschema.QuotedID;
 import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import java.util.Objects;
-
 @IDFactoryType("BIGQUERY")
 @NonNullByDefault
-public class BigQueryQuotedIDFactory extends SQLStandardQuotedIDFactory {
-
-    private static final String SQL_QUOTATION_STRING = "`";
+public class BigQueryQuotedIDFactory extends AbstractBacktickQuotedIDFactory {
 
     @Override
     protected QuotedID createFromString(String s) {
-        Objects.requireNonNull(s);
-
-        if (s.startsWith(SQL_QUOTATION_STRING) && s.endsWith(SQL_QUOTATION_STRING))
-            return new QuotedIDImpl(s.substring(1, s.length() - 1), SQL_QUOTATION_STRING, true);
-
-        return new QuotedIDImpl(s, SQL_QUOTATION_STRING, true);
-    }
-
-    @Override
-    public String getIDQuotationString() {
-        return SQL_QUOTATION_STRING;
+        return createFromString(s, BACKTICK_QUOTATION_STRING, i -> i, BACKTICK_QUOTATION_STRING, true);
     }
 
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/BigQueryQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/BigQueryQuotedIDFactory.java
@@ -1,21 +1,19 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
 import it.unibz.inf.ontop.dbschema.QuotedID;
-import it.unibz.inf.ontop.dbschema.RelationID;
-import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
-import java.util.Arrays;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+@IDFactoryType("BIGQUERY")
+@NonNullByDefault
 public class BigQueryQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
     private static final String SQL_QUOTATION_STRING = "`";
 
     @Override
-    protected QuotedID createFromString(@Nonnull String s) {
+    protected QuotedID createFromString(String s) {
         Objects.requireNonNull(s);
 
         if (s.startsWith(SQL_QUOTATION_STRING) && s.endsWith(SQL_QUOTATION_STRING))
@@ -28,4 +26,5 @@ public class BigQueryQuotedIDFactory extends SQLStandardQuotedIDFactory {
     public String getIDQuotationString() {
         return SQL_QUOTATION_STRING;
     }
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DremioQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DremioQuotedIDFactory.java
@@ -1,19 +1,22 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
 import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
 import it.unibz.inf.ontop.dbschema.RelationID;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@IDFactoryType("DREMIO")
+@NonNullByDefault
 public class DremioQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
     @Override
-    protected QuotedID createFromString(@Nonnull String s) {
+    protected QuotedID createFromString(String s) {
         Objects.requireNonNull(s);
 
         if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
@@ -39,4 +42,5 @@ public class DremioQuotedIDFactory extends SQLStandardQuotedIDFactory {
                 .collect(ImmutableCollectors.toList())
                 .reverse());
     }
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DremioQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DremioQuotedIDFactory.java
@@ -1,9 +1,9 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
+import com.google.common.collect.ImmutableList;
 import it.unibz.inf.ontop.dbschema.QuotedID;
 import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
 import it.unibz.inf.ontop.dbschema.RelationID;
-import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 import java.util.Arrays;
@@ -17,12 +17,7 @@ public class DremioQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
     @Override
     protected QuotedID createFromString(String s) {
-        Objects.requireNonNull(s);
-
-        if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
-            return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING, false);
-
-        return new QuotedIDImpl(s, NO_QUOTATION, false);
+        return createFromString(s, QUOTATION_STRING, i -> i, NO_QUOTATION, false);
     }
 
     @Override
@@ -39,7 +34,7 @@ public class DremioQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
         return new RelationIDImpl(stream
                 .map(this::createFromString)
-                .collect(ImmutableCollectors.toList())
+                .collect(ImmutableList.toImmutableList())
                 .reverse());
     }
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DuckDBQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DuckDBQuotedIDFactory.java
@@ -1,14 +1,17 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
 import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
+@IDFactoryType("DUCKDB")
+@NonNullByDefault
 public class DuckDBQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
 	@Override
-	protected QuotedID createFromString(@Nonnull String s) {
+	protected QuotedID createFromString(String s) {
 		Objects.requireNonNull(s);
 
 		if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
@@ -16,4 +19,5 @@ public class DuckDBQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
 		return new QuotedIDImpl(s.toLowerCase(), QUOTATION_STRING, false);
 	}
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DuckDBQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DuckDBQuotedIDFactory.java
@@ -4,20 +4,12 @@ import it.unibz.inf.ontop.dbschema.QuotedID;
 import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import java.util.Objects;
-
 @IDFactoryType("DUCKDB")
 @NonNullByDefault
 public class DuckDBQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
 	@Override
 	protected QuotedID createFromString(String s) {
-		Objects.requireNonNull(s);
-
-		if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
-			return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING, false);
-
-		return new QuotedIDImpl(s.toLowerCase(), QUOTATION_STRING, false);
+		return createFromString(s, QUOTATION_STRING, String::toLowerCase, QUOTATION_STRING, false);
 	}
-
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/MySQLAbstractQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/MySQLAbstractQuotedIDFactory.java
@@ -50,27 +50,19 @@ import java.util.Objects;
  *
  * @author Roman Kontchakov
  */
-@IDFactoryType("MYSQL")
 @NonNullByDefault
-public abstract class MySQLAbstractQuotedIDFactory extends SQLStandardQuotedIDFactory {
+public abstract class MySQLAbstractQuotedIDFactory extends AbstractBacktickQuotedIDFactory {
 
-	private static final String MY_SQL_QUOTATION_STRING = "`";
 
-	protected QuotedID createFromString(String s, boolean caseSensitive) {
+	protected final QuotedID createFromString(String s, boolean caseSensitive) {
 		Objects.requireNonNull(s);
 
-		if (s.startsWith(MY_SQL_QUOTATION_STRING) && s.endsWith(MY_SQL_QUOTATION_STRING))
-			return new QuotedIDImpl(s.substring(1, s.length() - 1), MY_SQL_QUOTATION_STRING, caseSensitive);
+		if (s.startsWith(BACKTICK_QUOTATION_STRING) && s.endsWith(BACKTICK_QUOTATION_STRING))
+			return new QuotedIDImpl(s.substring(1, s.length() - 1), BACKTICK_QUOTATION_STRING, caseSensitive);
 
 		if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
-			return new QuotedIDImpl(s.substring(1, s.length() - 1), MY_SQL_QUOTATION_STRING, caseSensitive);
+			return new QuotedIDImpl(s.substring(1, s.length() - 1), BACKTICK_QUOTATION_STRING, caseSensitive);
 
 		return new QuotedIDImpl(s, NO_QUOTATION, caseSensitive);
 	}
-
-	@Override
-	public String getIDQuotationString() {
-		return MY_SQL_QUOTATION_STRING;
-	}	
-
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/MySQLAbstractQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/MySQLAbstractQuotedIDFactory.java
@@ -1,6 +1,5 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
-
 /*
  * #%L
  * ontop-obdalib-core
@@ -21,10 +20,10 @@ package it.unibz.inf.ontop.dbschema.impl;
  * #L%
  */
 
-
 import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 /**
@@ -50,14 +49,14 @@ import java.util.Objects;
  * string literals must be enclosed within single quotation marks.
  *
  * @author Roman Kontchakov
- *
  */
-
+@IDFactoryType("MYSQL")
+@NonNullByDefault
 public abstract class MySQLAbstractQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
 	private static final String MY_SQL_QUOTATION_STRING = "`";
 
-	protected QuotedID createFromString(@Nonnull String s, boolean caseSensitive) {
+	protected QuotedID createFromString(String s, boolean caseSensitive) {
 		Objects.requireNonNull(s);
 
 		if (s.startsWith(MY_SQL_QUOTATION_STRING) && s.endsWith(MY_SQL_QUOTATION_STRING))
@@ -69,9 +68,9 @@ public abstract class MySQLAbstractQuotedIDFactory extends SQLStandardQuotedIDFa
 		return new QuotedIDImpl(s, NO_QUOTATION, caseSensitive);
 	}
 
-
 	@Override
 	public String getIDQuotationString() {
 		return MY_SQL_QUOTATION_STRING;
 	}	
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/MySQLCaseNotSensitiveTableNamesQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/MySQLCaseNotSensitiveTableNamesQuotedIDFactory.java
@@ -1,17 +1,21 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
 import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
-
+@IDFactoryType("MYSQL-D")
+@NonNullByDefault
 public class MySQLCaseNotSensitiveTableNamesQuotedIDFactory extends MySQLAbstractQuotedIDFactory {
+
     @Override
-    public QuotedID createAttributeID(@Nonnull String s) {
+    public QuotedID createAttributeID(String s) {
         return createFromString(s, false);
     }
 
     @Override
-    protected QuotedID createFromString(@Nonnull String s) {
+    protected QuotedID createFromString(String s) {
         return createFromString(s, false);
     }
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/MySQLCaseSensitiveTableNamesQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/MySQLCaseSensitiveTableNamesQuotedIDFactory.java
@@ -1,17 +1,21 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
 import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
-
+@IDFactoryType("MYSQL-U")
+@NonNullByDefault
 public class MySQLCaseSensitiveTableNamesQuotedIDFactory extends MySQLAbstractQuotedIDFactory {
+
     @Override
-    public QuotedID createAttributeID(@Nonnull String s) {
+    public QuotedID createAttributeID(String s) {
         return createFromString(s, false);
     }
 
     @Override
-    protected QuotedID createFromString(@Nonnull String s) {
+    protected QuotedID createFromString(String s) {
         return createFromString(s, true);
     }
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/PostgreSQLQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/PostgreSQLQuotedIDFactory.java
@@ -24,8 +24,6 @@ import it.unibz.inf.ontop.dbschema.QuotedID;
 import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import java.util.Objects;
-
 /**
  * Creates QuotedIdentifiers following the rules of PostrgeSQL:<br>
  *    - unquoted identifiers are converted into lower case<br>
@@ -53,12 +51,7 @@ public class PostgreSQLQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
 	@Override
 	protected QuotedID createFromString(String s) {
-		Objects.requireNonNull(s);
-
-		if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
-			return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING);
-
-		return new QuotedIDImpl(s.toLowerCase(), NO_QUOTATION);
+		return createFromString(s, QUOTATION_STRING, String::toLowerCase, NO_QUOTATION, true);
 	}
 
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/PostgreSQLQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/PostgreSQLQuotedIDFactory.java
@@ -1,6 +1,5 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
-
 /*
  * #%L
  * ontop-obdalib-core
@@ -21,13 +20,11 @@ package it.unibz.inf.ontop.dbschema.impl;
  * #L%
  */
 
-
 import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
-
-import static it.unibz.inf.ontop.dbschema.impl.SQLStandardQuotedIDFactory.QUOTATION_STRING;
 
 /**
  * Creates QuotedIdentifiers following the rules of PostrgeSQL:<br>
@@ -49,13 +46,13 @@ import static it.unibz.inf.ontop.dbschema.impl.SQLStandardQuotedIDFactory.QUOTAT
  * double quote, without any spaces in between, for example U&"foo".
  *
  * @author Roman Kontchakov
- *
  */
-
+@IDFactoryType("POSTGRESQL")
+@NonNullByDefault
 public class PostgreSQLQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
 	@Override
-	protected QuotedID createFromString(@Nonnull String s) {
+	protected QuotedID createFromString(String s) {
 		Objects.requireNonNull(s);
 
 		if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
@@ -63,4 +60,5 @@ public class PostgreSQLQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
 		return new QuotedIDImpl(s.toLowerCase(), NO_QUOTATION);
 	}
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLServerQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLServerQuotedIDFactory.java
@@ -52,12 +52,12 @@ public class SQLServerQuotedIDFactory extends SQLStandardQuotedIDFactory {
 		Objects.requireNonNull(s);
 
 		if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
-			return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING);
+			return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING, true);
 
 		if (s.startsWith("[") && s.endsWith("]"))
-			return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING);
+			return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING, true);
 
-		return new QuotedIDImpl(s, NO_QUOTATION);
+		return new QuotedIDImpl(s, NO_QUOTATION, true);
 	}
 
 	@Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLServerQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLServerQuotedIDFactory.java
@@ -1,6 +1,5 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
-
 /*
  * #%L
  * ontop-obdalib-core
@@ -21,10 +20,10 @@ package it.unibz.inf.ontop.dbschema.impl;
  * #L%
  */
 
-
 import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 /**
@@ -43,13 +42,13 @@ import java.util.Objects;
  * https://docs.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver15
  *
  * @author Roman Kontchakov
- *
  */
-
+@IDFactoryType("MSSQLSERVER")
+@NonNullByDefault
 public class SQLServerQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
 	@Override
-	protected QuotedID createFromString(@Nonnull String s) {
+	protected QuotedID createFromString(String s) {
 		Objects.requireNonNull(s);
 
 		if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
@@ -65,4 +64,5 @@ public class SQLServerQuotedIDFactory extends SQLStandardQuotedIDFactory {
 	public boolean supportsSquareBracketQuotation() {
 		return true;
 	}
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SparkSQLQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SparkSQLQuotedIDFactory.java
@@ -2,8 +2,10 @@ package it.unibz.inf.ontop.dbschema.impl;
 
 import com.google.common.collect.ImmutableList;
 import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
 import it.unibz.inf.ontop.dbschema.RelationID;
-import javax.annotation.Nonnull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 import java.util.Objects;
 
 /**
@@ -11,22 +13,24 @@ import java.util.Objects;
  *    - double and single quotes are not tolerated for schema and attributes definition
  *    - you need to use backticks
  */
+@IDFactoryType("SPARK")
+@NonNullByDefault
 public class SparkSQLQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
-    private static final String SQL_QUOTATION_STRING = "`";
+    public static final String SQL_QUOTATION_STRING = "`";
 
     @Override
-    public QuotedID createAttributeID(@Nonnull String s) {
+    public QuotedID createAttributeID(String s) {
         return createFromString(s);
     }
 
     @Override
-    public RelationID createRelationID(@Nonnull String tableId) {
+    public RelationID createRelationID(String tableId) {
         return new RelationIDImpl(ImmutableList.of(createFromString(tableId)));
     }
 
     @Override
-    protected QuotedID createFromString(@Nonnull String s) {
+    protected QuotedID createFromString(String s) {
         Objects.requireNonNull(s);
 
         if (s.startsWith(SQL_QUOTATION_STRING) && s.endsWith(SQL_QUOTATION_STRING))
@@ -39,5 +43,5 @@ public class SparkSQLQuotedIDFactory extends SQLStandardQuotedIDFactory {
     public String getIDQuotationString() {
         return SQL_QUOTATION_STRING;
     }
-}
 
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SparkSQLQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SparkSQLQuotedIDFactory.java
@@ -1,12 +1,8 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
-import com.google.common.collect.ImmutableList;
 import it.unibz.inf.ontop.dbschema.QuotedID;
 import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
-import it.unibz.inf.ontop.dbschema.RelationID;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-
-import java.util.Objects;
 
 /**
  * Creates QuotedIdentifiers following the rules of SparkSQL:
@@ -15,33 +11,10 @@ import java.util.Objects;
  */
 @IDFactoryType("SPARK")
 @NonNullByDefault
-public class SparkSQLQuotedIDFactory extends SQLStandardQuotedIDFactory {
-
-    public static final String SQL_QUOTATION_STRING = "`";
-
-    @Override
-    public QuotedID createAttributeID(String s) {
-        return createFromString(s);
-    }
-
-    @Override
-    public RelationID createRelationID(String tableId) {
-        return new RelationIDImpl(ImmutableList.of(createFromString(tableId)));
-    }
+public class SparkSQLQuotedIDFactory extends AbstractBacktickQuotedIDFactory {
 
     @Override
     protected QuotedID createFromString(String s) {
-        Objects.requireNonNull(s);
-
-        if (s.startsWith(SQL_QUOTATION_STRING) && s.endsWith(SQL_QUOTATION_STRING))
-            return new QuotedIDImpl(s.substring(1, s.length() - 1), SQL_QUOTATION_STRING, false);
-
-        return new QuotedIDImpl(s, SQL_QUOTATION_STRING, false);
+        return createFromString(s, BACKTICK_QUOTATION_STRING, i -> i, BACKTICK_QUOTATION_STRING, false);
     }
-
-    @Override
-    public String getIDQuotationString() {
-        return SQL_QUOTATION_STRING;
-    }
-
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/TeiidQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/TeiidQuotedIDFactory.java
@@ -1,14 +1,17 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
 import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
+@IDFactoryType("TEIID")
+@NonNullByDefault
 public class TeiidQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
     @Override
-    protected QuotedID createFromString(@Nonnull String s) {
+    protected QuotedID createFromString(String s) {
         Objects.requireNonNull(s);
 
         if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
@@ -16,4 +19,5 @@ public class TeiidQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
         return new QuotedIDImpl(s, NO_QUOTATION, false);
     }
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/TeiidQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/TeiidQuotedIDFactory.java
@@ -4,20 +4,13 @@ import it.unibz.inf.ontop.dbschema.QuotedID;
 import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import java.util.Objects;
-
 @IDFactoryType("TEIID")
 @NonNullByDefault
 public class TeiidQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
     @Override
     protected QuotedID createFromString(String s) {
-        Objects.requireNonNull(s);
-
-        if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
-            return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING, false);
-
-        return new QuotedIDImpl(s, NO_QUOTATION, false);
+        return createFromString(s, QUOTATION_STRING, i -> i, NO_QUOTATION, false);
     }
 
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/TrinoQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/TrinoQuotedIDFactory.java
@@ -4,20 +4,13 @@ import it.unibz.inf.ontop.dbschema.QuotedID;
 import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import java.util.Objects;
-
 @IDFactoryType("TRINO")
 @NonNullByDefault
 public class TrinoQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
 	@Override
 	protected QuotedID createFromString(String s) {
-		Objects.requireNonNull(s);
-
-		if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
-			return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING);
-
-		return new QuotedIDImpl(s, QUOTATION_STRING);
+		return createFromString(s, QUOTATION_STRING, i -> i, QUOTATION_STRING, true);
 	}
 
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/TrinoQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/TrinoQuotedIDFactory.java
@@ -1,14 +1,17 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
 import it.unibz.inf.ontop.dbschema.QuotedID;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
+@IDFactoryType("TRINO")
+@NonNullByDefault
 public class TrinoQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
 	@Override
-	protected QuotedID createFromString(@Nonnull String s) {
+	protected QuotedID createFromString(String s) {
 		Objects.requireNonNull(s);
 
 		if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
@@ -16,4 +19,5 @@ public class TrinoQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
 		return new QuotedIDImpl(s, QUOTATION_STRING);
 	}
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonMetadata.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonMetadata.java
@@ -1,43 +1,49 @@
 package it.unibz.inf.ontop.dbschema.impl.json;
 
 import com.fasterxml.jackson.annotation.*;
-import com.google.common.collect.ImmutableBiMap;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import it.unibz.inf.ontop.dbschema.*;
-import it.unibz.inf.ontop.dbschema.impl.*;
+import it.unibz.inf.ontop.dbschema.QuotedIDFactory.Supplier;
 import it.unibz.inf.ontop.exception.MetadataExtractionException;
-import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
+import javax.annotation.Nullable;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonPropertyOrder({
         "relations"
 })
+@NonNullByDefault
 public class JsonMetadata extends JsonOpenObject {
+
     public final List<JsonDatabaseTable> relations;
+
     public final Parameters metadata;
 
     @JsonCreator
-    public JsonMetadata(@JsonProperty("relations") List<JsonDatabaseTable> relations,
+    public JsonMetadata(@JsonProperty("relations") @Nullable List<JsonDatabaseTable> relations,
                         @JsonProperty("metadata") Parameters metadata) {
-        this.relations = relations;
-        this.metadata = metadata;
+        this.relations = relations != null ? ImmutableList.copyOf(relations) : ImmutableList.of();
+        this.metadata = Objects.requireNonNull(metadata);
     }
 
     public JsonMetadata(ImmutableMetadata metadata) {
         this.relations = metadata.getAllRelations().stream()
                 .map(JsonDatabaseTable::new)
-                .collect(ImmutableCollectors.toList());
+                .collect(ImmutableList.toImmutableList());
         this.metadata = new Parameters(metadata.getDBParameters());
     }
 
-
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY)
     @JsonPropertyOrder({
             "dbmsProductName",
             "dbmsVersion",
@@ -47,23 +53,45 @@ public class JsonMetadata extends JsonOpenObject {
             "extractionTime"
     })
     public static class Parameters extends JsonOpenObject {
+
+        @Nullable
         public final String dbmsProductName;
+
+        @Nullable
         public final String dbmsVersion;
+
+        @Nullable
         public final String driverName;
+
+        @Nullable
         public final String driverVersion;
+
+        @Nullable
         public final String quotationString;
+
+        @Nullable
         public final String extractionTime;
+
         @JsonInclude(value= JsonInclude.Include.NON_EMPTY)
+        @Nullable
         public final String idFactoryType;
 
+        @Nullable
+        private transient final Supplier idFactorySupplier;
+
+        @Nullable
+        private transient QuotedIDFactory cachedIDFactory;
+
         @JsonCreator
-        public Parameters(@JsonProperty("dbmsProductName") String dbmsProductName,
-                          @JsonProperty("dbmsVersion") String dbmsVersion,
-                          @JsonProperty("driverName") String driverName,
-                          @JsonProperty("driverVersion") String driverVersion,
-                          @JsonProperty("quotationString") String quotationString,
-                          @JsonProperty("extractionTime") String extractionTime,
-                          @JsonProperty("idFactoryType") String idFactoryType) {
+        public Parameters(@JsonProperty("dbmsProductName") @Nullable String dbmsProductName,
+                          @JsonProperty("dbmsVersion") @Nullable String dbmsVersion,
+                          @JsonProperty("driverName") @Nullable String driverName,
+                          @JsonProperty("driverVersion") @Nullable String driverVersion,
+                          @JsonProperty("quotationString") @Nullable String quotationString,
+                          @JsonProperty("extractionTime") @Nullable String extractionTime,
+                          @JsonProperty("idFactoryType") @Nullable String idFactoryType,
+                          @JacksonInject @Nullable Supplier idFactorySupplier
+        ) {
             this.dbmsProductName = dbmsProductName;
             this.dbmsVersion = dbmsVersion;
             this.driverName = driverName;
@@ -71,45 +99,40 @@ public class JsonMetadata extends JsonOpenObject {
             this.quotationString = quotationString;
             this.extractionTime = extractionTime;
             this.idFactoryType = idFactoryType;
+            this.idFactorySupplier = idFactorySupplier;
         }
 
-        private static final ImmutableBiMap<String, Class<? extends QuotedIDFactory>> QUOTED_ID_FACTORIES = ImmutableBiMap.<String, Class<? extends QuotedIDFactory>>builder()
-                .put("STANDARD", SQLStandardQuotedIDFactory.class)
-                .put("DREMIO", DremioQuotedIDFactory.class)
-                .put("MYSQL-U", MySQLCaseSensitiveTableNamesQuotedIDFactory.class)
-                .put("MYSQL-D", MySQLCaseNotSensitiveTableNamesQuotedIDFactory.class)
-                .put("POSTGRESQL", PostgreSQLQuotedIDFactory.class)
-                .put("MSSQLSERVER", SQLServerQuotedIDFactory.class)
-                .put("SPARK", SparkSQLQuotedIDFactory.class)
-                .build();
-
         public Parameters(DBParameters parameters) {
-            dbmsProductName = parameters.getDbmsProductName();
-            dbmsVersion = parameters.getDbmsVersion();
-            driverName = parameters.getDriverName();
-            driverVersion = parameters.getDriverVersion();
-            QuotedIDFactory idFactory = parameters.getQuotedIDFactory();
-            quotationString = idFactory.getIDQuotationString();
-            String idFactoryType = QUOTED_ID_FACTORIES.inverse().get(idFactory.getClass());
-            this.idFactoryType = (idFactoryType != null && !idFactoryType.equals("STANDARD")) ? idFactoryType : null;
+            this.dbmsProductName = parameters.getDbmsProductName();
+            this.dbmsVersion = parameters.getDbmsVersion();
+            this.driverName = parameters.getDriverName();
+            this.driverVersion = parameters.getDriverVersion();
+            this.cachedIDFactory = parameters.getQuotedIDFactory();
+            this.quotationString = this.cachedIDFactory.getIDQuotationString();
+            String idFactoryType = this.cachedIDFactory.getIDFactoryType();
+            this.idFactoryType = !idFactoryType.equals("STANDARD") ? idFactoryType : null;
             DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            extractionTime = dateFormat.format(Calendar.getInstance().getTime());
+            this.extractionTime = dateFormat.format(Calendar.getInstance().getTime());
+            this.idFactorySupplier = null;
         }
 
         public QuotedIDFactory createQuotedIDFactory() throws MetadataExtractionException {
-            try {
-                return QUOTED_ID_FACTORIES.getOrDefault(idFactoryType, SQLStandardQuotedIDFactory.class).newInstance();
+            if (cachedIDFactory == null) {
+                // Delegate to the supplier (will fail if supplier is not available or idFactoryType is unknown)
+                cachedIDFactory = Optional.ofNullable(idFactorySupplier)
+                        .flatMap(s -> s.get(MoreObjects.firstNonNull(idFactoryType, "STANDARD")))
+                        .orElseThrow(() -> new MetadataExtractionException(
+                                "Could not resolve QuotedIDFactory with type identifier " + idFactoryType));
             }
-            catch (InstantiationException | IllegalAccessException e) {
-                throw new MetadataExtractionException(e);
-            }
+            return cachedIDFactory;
         }
+
     }
 
     public static ImmutableList<String> serializeRelationID(RelationID id) {
         return id.getComponents().stream()
                 .map(QuotedID::getSQLRendering)
-                .collect(ImmutableCollectors.toList()).reverse();
+                .collect(ImmutableList.toImmutableList()).reverse();
     }
 
     public static RelationID deserializeRelationID(QuotedIDFactory idFactory, List<String> o) {
@@ -119,7 +142,7 @@ public class JsonMetadata extends JsonOpenObject {
     public static List<String> serializeAttributeList(Stream<Attribute> attributes) {
         return attributes
                 .map(a -> a.getID().getSQLRendering())
-                .collect(ImmutableCollectors.toList());
+                .collect(ImmutableList.toImmutableList());
     }
 
     public interface AttributeConsumer {
@@ -135,4 +158,5 @@ public class JsonMetadata extends JsonOpenObject {
             throw new MetadataExtractionException(e);
         }
     }
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonMetadata.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonMetadata.java
@@ -80,7 +80,7 @@ public class JsonMetadata extends JsonOpenObject {
         private transient final Supplier idFactorySupplier;
 
         @Nullable
-        private transient QuotedIDFactory cachedIDFactory;
+        private transient QuotedIDFactory cachedIdFactory;
 
         @JsonCreator
         public Parameters(@JsonProperty("dbmsProductName") @Nullable String dbmsProductName,
@@ -107,9 +107,9 @@ public class JsonMetadata extends JsonOpenObject {
             this.dbmsVersion = parameters.getDbmsVersion();
             this.driverName = parameters.getDriverName();
             this.driverVersion = parameters.getDriverVersion();
-            this.cachedIDFactory = parameters.getQuotedIDFactory();
-            this.quotationString = this.cachedIDFactory.getIDQuotationString();
-            String idFactoryType = this.cachedIDFactory.getIDFactoryType();
+            this.cachedIdFactory = parameters.getQuotedIDFactory();
+            this.quotationString = this.cachedIdFactory.getIDQuotationString();
+            String idFactoryType = this.cachedIdFactory.getIDFactoryType();
             this.idFactoryType = !idFactoryType.equals("STANDARD") ? idFactoryType : null;
             DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
             this.extractionTime = dateFormat.format(Calendar.getInstance().getTime());
@@ -117,14 +117,14 @@ public class JsonMetadata extends JsonOpenObject {
         }
 
         public QuotedIDFactory createQuotedIDFactory() throws MetadataExtractionException {
-            if (cachedIDFactory == null) {
+            if (cachedIdFactory == null) {
                 // Delegate to the supplier (will fail if supplier is not available or idFactoryType is unknown)
-                cachedIDFactory = Optional.ofNullable(idFactorySupplier)
+                cachedIdFactory = Optional.ofNullable(idFactorySupplier)
                         .flatMap(s -> s.get(MoreObjects.firstNonNull(idFactoryType, "STANDARD")))
                         .orElseThrow(() -> new MetadataExtractionException(
                                 "Could not resolve QuotedIDFactory with type identifier " + idFactoryType));
             }
-            return cachedIDFactory;
+            return cachedIdFactory;
         }
 
     }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/injection/impl/OntopSQLCoreModule.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/injection/impl/OntopSQLCoreModule.java
@@ -1,12 +1,14 @@
 package it.unibz.inf.ontop.injection.impl;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.name.Names;
 import it.unibz.inf.ontop.dbschema.*;
+import it.unibz.inf.ontop.dbschema.impl.*;
 import it.unibz.inf.ontop.generation.algebra.*;
 import it.unibz.inf.ontop.generation.normalization.DialectExtraNormalizer;
 import it.unibz.inf.ontop.generation.serializer.SelectFromWhereSerializer;
-import it.unibz.inf.ontop.dbschema.impl.JDBCMetadataProviderFactory;
 import it.unibz.inf.ontop.injection.OntopSQLCoreConfiguration;
 import it.unibz.inf.ontop.injection.OntopSQLCoreSettings;
 import it.unibz.inf.ontop.iq.transform.IQTree2NativeNodeGenerator;
@@ -64,5 +66,22 @@ public class OntopSQLCoreModule extends OntopAbstractModule {
 
         Module mdProvider = buildFactory(ImmutableList.of(DBMetadataProvider.class), JDBCMetadataProviderFactory.class);
         install(mdProvider);
+
+        for (var c : ImmutableList.of(
+                BigQueryQuotedIDFactory.class,
+                DremioQuotedIDFactory.class,
+                DuckDBQuotedIDFactory.class,
+                MySQLCaseNotSensitiveTableNamesQuotedIDFactory.class,
+                MySQLCaseSensitiveTableNamesQuotedIDFactory.class,
+                PostgreSQLQuotedIDFactory.class,
+                SQLServerQuotedIDFactory.class,
+                SparkSQLQuotedIDFactory.class,
+                TeiidQuotedIDFactory.class,
+                TrinoQuotedIDFactory.class
+        )) {
+            String idFactoryType = QuotedIDFactory.getIDFactoryType(c);
+            bindFromSettings(Key.get(QuotedIDFactory.class, Names.named(idFactoryType)), c);
+        }
     }
+
 }

--- a/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/injection/impl/OntopReformulationPostModule.java
+++ b/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/injection/impl/OntopReformulationPostModule.java
@@ -17,7 +17,6 @@ import it.unibz.inf.ontop.injection.TranslationFactory;
  * POST-module: to be loaded after that all the dependencies of concrete implementations have been defined
  *
  */
-@SuppressWarnings("unchecked")
 public class OntopReformulationPostModule extends OntopAbstractModule {
 
     private final OntopReformulationSettings settings;
@@ -30,7 +29,8 @@ public class OntopReformulationPostModule extends OntopAbstractModule {
     @Override
     protected void configure() {
         if (settings.isExistentialReasoningEnabled()) {
-            bind(QueryRewriter.class).to(getImplementation(ExistentialQueryRewriter.class));
+            bindFromSettings(ExistentialQueryRewriter.class);
+            bind(QueryRewriter.class).to(ExistentialQueryRewriter.class);
         }
         else {
             bind(QueryRewriter.class).to(DummyRewriter.class);

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,7 @@
         <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <logback.version>1.2.9</logback.version>
+        <nullanno.version>3.0.0</nullanno.version>
         <opencsv.version>5.7.1</opencsv.version>
         <owlapi.version>5.1.20</owlapi.version>
         <proj4j.version>1.1.1</proj4j.version>
@@ -906,11 +907,16 @@
                 <version>${javax-inject.version}</version>
             </dependency>
 
-            <!-- Javax Annotations (JSR 305) -->
+            <!-- Javax Annotations (JSR 305, nullanno) -->
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>${jsr305.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.solf</groupId>
+                <artifactId>nullanno</artifactId>
+                <version>${nullanno.version}</version>
             </dependency>
 
             <!-- Guava -->
@@ -1000,6 +1006,11 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-guava</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
 

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/athena/CastAthenaTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/athena/CastAthenaTest.java
@@ -51,6 +51,22 @@ public class CastAthenaTest extends AbstractCastFunctionsTest {
         super.testCastDateFromDateTime2();
     }
 
+    //TODO: Trino timestamp denormalizer missing
+    @Override
+    @Test
+    @Disabled("Lack of Trino timestamp denormalizer")
+    public void testCastDateTimeFromDate2() {
+        super.testCastDateTimeFromDate2();
+    }
+
+    //TODO: Trino timestamp denormalizer missing
+    @Override
+    @Test
+    @Disabled("Lack of Trino timestamp denormalizer")
+    public void testCastDateTimeFromDate3() {
+        super.testCastDateTimeFromDate3();
+    }
+
     @Override
     protected ImmutableMultiset<String> getCastFloatFromDecimal1ExpectedValues() {
         return ImmutableMultiset.of("\"0.2\"^^xsd:float", "\"0.25\"^^xsd:float", "\"0.2\"^^xsd:float",


### PR DESCRIPTION
This PR introduces a mechanism to link a `QuotedIDFactory` to a *factory type* string via [`QuotedIDFactory.@IDFactoryType`](https://github.com/ontop/ontop/blob/feature/quoted-id-factory-refactoring/core/model/src/main/java/it/unibz/inf/ontop/dbschema/QuotedIDFactory.java#L127) annotations, and to lookup a `QuotedIDFactory` instance via a [`QuotedIDFactory.Supplier`](https://github.com/ontop/ontop/blob/feature/quoted-id-factory-refactoring/core/model/src/main/java/it/unibz/inf/ontop/dbschema/QuotedIDFactory.java#L147) interface obtainable via injection.

`QuotedIDFactory.Supplier` injection leverages the a refactoring of [`OntopAbstractModule`](https://github.com/ontop/ontop/blob/feature/quoted-id-factory-refactoring/core/model/src/main/java/it/unibz/inf/ontop/injection/impl/OntopAbstractModule.java) that now allows the binding (overridable in settings file) of an implementation class to an arbitrary Guice *<class, qualifier>* key (instead of an *abstract class* key only), where the qualifier denotes here the factory type and allows having multiple coexisting `QuotedIDFactory` bindings for different type qualifiers. Specifically, `QuotedIDFactory` implementation classes are bound in [`OntopSQLCoreModule`](https://github.com/ontop/ontop/blob/feature/quoted-id-factory-refactoring/db/rdb/src/main/java/it/unibz/inf/ontop/injection/impl/OntopSQLCoreModule.java#L70) while an implementation of `QuotedIDFactory.Supplier` delegating to Guice `Injector` is bound in [`OntopModelModule`](https://github.com/ontop/ontop/blob/feature/quoted-id-factory-refactoring/core/model/src/main/java/it/unibz/inf/ontop/injection/impl/OntopModelModule.java#L128).

Note that the extension of `OntopAbstractModule` is general and can be used for similar use cases. Two unit tests are provided in [`OntopAbstractModuleTest`](https://github.com/ontop/ontop/blob/feature/quoted-id-factory-refactoring/core/model/src/test/java/it/unibz/inf/ontop/injection/impl/OntopAbstractModuleTest.java) and [`QuotedIDFactoryInjectionTest`](https://github.com/ontop/ontop/blob/feature/quoted-id-factory-refactoring/core/model/src/test/java/it/unibz/inf/ontop/injection/impl/QuotedIDFactoryInjectionTest.java), respectively for the handling of generic *<class, qualifier>* keys and its use for `QuotedIDFactory.Supplier`.

A `QuotedIDFactory.Supplier` is now injected into [`JsonMetadata`](https://github.com/ontop/ontop/blob/feature/quoted-id-factory-refactoring/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonMetadata.java#L93) when deserializing from JSON (via Jackson injection from [`JsonSerializedMetadataProvider`](https://github.com/ontop/ontop/blob/feature/quoted-id-factory-refactoring/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/JsonSerializedMetadataProvider.java#L96)). This allows obtaining a `QuotedIDFactory` instance for the factory type occurring in the JSON by ultimately delegating to Guice (where knowledge about object instantiation resides), instead of hard-coding a *<type, implementation class>* `BiMap` and directly using `Class.newInstance()`.

Other changes in the PR are related to minor cleanup of other involved files (e.g., simplified binding expression in `OntopReformulationPostModule`, nullability handling in `QuotedIDImpl`) and in the use of a `@NonNullByDefault` annotation (taken from [io.github.solf:nullanno](https://github.com/solf/nullanno) just not to define it in Ontop code) to simplify and improve consistency - and thus improve IDE nullability analysis - of null-related annotations: when used on a class/package (as in classes modified in the PR), everything has to be non-null except where otherwise specified with `@Nullable`.