### PR TITLE
Fixed incorrect implementation of "Ignore Invalid Mapping Entries" functionality

### DIFF
--- a/mapping/sql/core/src/main/java/it/unibz/inf/ontop/spec/mapping/pp/impl/SQLPPMappingConverterImpl.java
+++ b/mapping/sql/core/src/main/java/it/unibz/inf/ontop/spec/mapping/pp/impl/SQLPPMappingConverterImpl.java
@@ -65,8 +65,14 @@ public class SQLPPMappingConverterImpl implements SQLPPMappingConverter {
                 Function<Variable, Optional<ImmutableTerm>> lookup = placeholderLookup(assertion, metadataLookup.getQuotedIDFactory(), re.getUnqualifiedAttributes());
 
                 for (TargetAtom target : assertion.getTargetAtoms()) {
-                    PPMappingAssertionProvenance provenance = assertion.getMappingAssertionProvenance(target);
-                    builder.add(convert(target, lookup, provenance, tree));
+                    try {
+                        PPMappingAssertionProvenance provenance = assertion.getMappingAssertionProvenance(target);
+                        builder.add(convert(target, lookup, provenance, tree));
+                    } catch (InvalidMappingSourceQueriesException e) {
+                        if(!ignoreInvalidMappingEntries)
+                            throw e;
+                        LOGGER.warn("Target atom {} was ignored due to an issue: {}", target.toString(), e.getMessage());
+                    }
                 }
             }
             /*


### PR DESCRIPTION
Now, there are two try-catch blocks:
  - One large try-catch block for the out for loop to make sure all issues found in the processing of the mapping in general are covered (same as before)
  - One try-catch block inside the inner loop that catches issues on individual target atoms and only ignores those failing atoms (new)