### PR TITLE
Possible fix for "CONSTRUCT queries with unions and different variables return empty results" issue

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/AbstractRDF4JTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/AbstractRDF4JTest.java
@@ -189,6 +189,26 @@ public class AbstractRDF4JTest {
         assertEquals(expectedGraph, statementBuilder.build());
     }
 
+    protected int runGraphQueryAndCount(String queryString) {
+        return runGraphQueryAndCount(queryString, new MapBindingSet());
+    }
+
+    protected int runGraphQueryAndCount(String queryString,
+                                           BindingSet bindings) {
+        GraphQuery query = REPO_CONNECTION.prepareGraphQuery(QueryLanguage.SPARQL, queryString);
+        bindings.getBindingNames()
+                .forEach(n -> query.setBinding(n, bindings.getValue(n)));
+
+        GraphQueryResult result = query.evaluate();
+        int count = 0;
+        while (result.hasNext()) {
+            count++;
+            result.next();
+        }
+        result.close();
+        return count;
+    }
+
     protected TupleQueryResult evaluate(String queryString) {
         TupleQuery query = REPO_CONNECTION.prepareTupleQuery(QueryLanguage.SPARQL, queryString);
         return query.evaluate();

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/ConstructEmptyUnionTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/ConstructEmptyUnionTest.java
@@ -1,0 +1,47 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.GenericStatement;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConstructEmptyUnionTest extends AbstractRDF4JTest {
+
+    private static final String OBDA_FILE = "/construct-empty-union/mapping.obda";
+    private static final String SQL_SCRIPT = "/construct-empty-union/database.sql";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    /**
+     the issue was fixed in the meta-mapping expander overhaul in April 2020
+     */
+
+    @Test
+    public void testConstructEmptyUnion()  {
+
+        String query = "PREFIX : <http://foobar.abc/ontology/demo#>" +
+                        "CONSTRUCT { ?s :id2 ?o } WHERE {" +
+                        "{ }" +
+                        "UNION" +
+                        "{ ?s :id ?o . }" +
+                        "}";
+        assertEquals(4, runGraphQueryAndCount(query));
+    }
+
+}

--- a/binding/rdf4j/src/test/resources/construct-empty-union/database.sql
+++ b/binding/rdf4j/src/test/resources/construct-empty-union/database.sql
@@ -1,0 +1,6 @@
+create table test (id integer);
+
+insert into test (id) values (1);
+insert into test (id) values (2);
+insert into test (id) values (3);
+insert into test (id) values (4);

--- a/binding/rdf4j/src/test/resources/construct-empty-union/mapping.obda
+++ b/binding/rdf4j/src/test/resources/construct-empty-union/mapping.obda
@@ -1,0 +1,10 @@
+[PrefixDeclaration]
+:    http://foobar.abc/ontology/demo#
+
+[MappingDeclaration] @collection [[
+
+mappingId  mytable
+target     :data/{id} a :Test ; :id {id}^^xsd:integer .
+source     SELECT id FROM test
+
+]]

--- a/engine/system/core/src/main/java/it/unibz/inf/ontop/query/resultset/impl/DefaultSimpleGraphResultSet.java
+++ b/engine/system/core/src/main/java/it/unibz/inf/ontop/query/resultset/impl/DefaultSimpleGraphResultSet.java
@@ -122,22 +122,24 @@ public class DefaultSimpleGraphResultSet implements GraphResultSet {
 
 		private void addStatementFromResultSet() throws OntopConnectionException, OntopResultConversionException {
 			try {
-				OntopBindingSet bindingSet = resultSet.next();
-				for (ProjectionElemList peList : constructTemplate.getProjectionElemList()) {
-					int size = peList.getElements().size();
-					for (int i = 0; i < size / 3; i++) {
-						ObjectConstant subjectConstant =
-								(ObjectConstant) getConstant(peList.getElements().get(i * 3), bindingSet);
-						IRIConstant propertyConstant =
-								(IRIConstant) getConstant(peList.getElements().get(i * 3 + 1), bindingSet);
-						RDFConstant objectConstant =
-								(RDFConstant) getConstant(peList.getElements().get(i * 3 + 2), bindingSet);
-						if (subjectConstant != null && propertyConstant != null && objectConstant != null) {
-							statementBuffer.add(
-									RDFFact.createTripleFact(subjectConstant, propertyConstant, objectConstant));
+                do {
+					OntopBindingSet bindingSet = resultSet.next();
+					for (ProjectionElemList peList : constructTemplate.getProjectionElemList()) {
+						int size = peList.getElements().size();
+						for (int i = 0; i < size / 3; i++) {
+							ObjectConstant subjectConstant =
+									(ObjectConstant) getConstant(peList.getElements().get(i * 3), bindingSet);
+							IRIConstant propertyConstant =
+									(IRIConstant) getConstant(peList.getElements().get(i * 3 + 1), bindingSet);
+							RDFConstant objectConstant =
+									(RDFConstant) getConstant(peList.getElements().get(i * 3 + 2), bindingSet);
+							if (subjectConstant != null && propertyConstant != null && objectConstant != null) {
+								statementBuffer.add(
+										RDFFact.createTripleFact(subjectConstant, propertyConstant, objectConstant));
+							}
 						}
 					}
-				}
+				} while (statementBuffer.isEmpty() && resultSet.hasNext());
 			} catch (OntopResultConversionException e) {
 				if (!excludeInvalidTriples)
 					throw e;


### PR DESCRIPTION
This is a bugfix for the issue on the ontop-issues GitLab repository "CONSTRUCT queries with unions and different variables return empty results".

The bug was caused by the following procedure. Imagine a UNION of the type
```SPARQL
{ }
UNION
{ ?s ?p ?o . }
```
The way UNIONs work in SQL, all operands of a UNION need the same columns. Therefore, null-values are added to the first set, and then the UNION is performed.
Because of this, the first row of the SQL result set will be a row of NULLs.

Now, the results will be stored as a `DefaultSimpleGraphResultSet` by ontop. When calling `next()` on this result set, it will access the first row of the SQL result first. Because of this, all values will be null in the first try, so this row will not be added to the `statementBuffer`. However, this now means that the `statementBuffer` will remain empty, and because of that, `hasNext()` will return `false`, and it will appear as if there is no result at all. 

I fixed this by adding a `do ... while` in the `next()` call of the `DefaultSimpleGraphResultSet`. The procedure will repeat if the `statementBuffer` has been left empty even though the SQL result set is not empty.

Unfortunately, I am not fully sure if doing this would cause any unwanted consequences, as I do not have a full overview of the exact tasks the `DefaultSimpleGraphResultSet` is supposed to perform