### PR TITLE
Added new test case for the Issue 627 fix

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/UnionVariableRenameTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/UnionVariableRenameTest.java
@@ -1,0 +1,71 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+
+public class UnionVariableRenameTest extends AbstractRDF4JTest {
+
+    private static final String OBDA_FILE = "/union-variable-rename/mapping.obda";
+    private static final String SQL_SCRIPT = "/union-variable-rename/query.sql";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+    @Test
+    public void testQuery() {
+        int count = runQueryAndCount("select ?x WHERE \n" +
+                "{\n" +
+                "  {\n" +
+                "    ?s1 ?x ?o  .\n" +
+                "  }\n" +
+                "  UNION \n" +
+                "  {\n" +
+                "    {\n" +
+                "      ?s1 ?x ?o .\n" +
+                "    }\n" +
+                "    {\n" +
+                "      ?s1 ?x ?o  .\n" +
+                "    }\n" +
+                "    UNION \n" +
+                "    {\n" +
+                "      ?s2 ?x ?o  .\n" +
+                "    } \n" +
+                "    UNION \n" +
+                "    {\n" +
+                "      {\n" +
+                "        ?s3 ?x ?o .\n" +
+                "      }\n" +
+                "      {\n" +
+                "        ?s3 ?x ?o  .\n" +
+                "      }\n" +
+                "      UNION \n" +
+                "      {\n" +
+                "        {\n" +
+                "          ?s3 ?x ?o .\n" +
+                "        }\n" +
+                "        {\n" +
+                "          ?s3 ?x ?o  .\n" +
+                "        } \n" +
+                "        UNION \n" +
+                "        {\n" +
+                "          ?s4 ?x ?o .\n" +
+                "        } \n" +
+                "      }  \n" +
+                "    }  \n" +
+                "  }\n" +
+                "}");
+        assertEquals(192, count);
+    }
+}

--- a/binding/rdf4j/src/test/resources/union-variable-rename/mapping.obda
+++ b/binding/rdf4j/src/test/resources/union-variable-rename/mapping.obda
@@ -1,0 +1,10 @@
+[PrefixDeclaration]
+: http://example.org/
+rdfs: http://www.w3.org/2000/01/rdf-schema#
+rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+
+[MappingDeclaration]` @collection [[
+mappingId	mapTest
+target		:data/{id} a :Test ; :value1 {value1} ; :value2 {value2} ; :value3 {value3} .
+source		select id, value1, value2, value3 from test
+]]

--- a/binding/rdf4j/src/test/resources/union-variable-rename/query.sql
+++ b/binding/rdf4j/src/test/resources/union-variable-rename/query.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (id integer, value1 integer, value2 integer, value3 integer);
+
+INSERT INTO test (id, value1, value2, value3) VALUES (1, 10, 15, 30);
+INSERT INTO test (id, value1, value2, value3) VALUES (2, 20, 150, 23);
+INSERT INTO test (id, value1, value2, value3) VALUES (3, 30, 1500, 13);
+INSERT INTO test (id, value1, value2, value3) VALUES (4, 40, 15000, 3);


### PR DESCRIPTION
The translation process for this query happens to rename a variable of a sub-query in such a way, that it end up having the same name as one of the union variables. This way, when it is renamed during the translation of the UNION, the un-fixed version of the RDF4JTupleExprTranslator would also rename the UNION variable, causing the query to fail, while the version that includes the bugfix will never attempt to rename a UNION variable.