### PR TITLE
Added exception if directory for --separate-files materialization does not exist

### DIFF
--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/Ontop.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/Ontop.java
@@ -18,7 +18,7 @@ public class Ontop {
             command.run();
         } catch (ParseCommandMissingException e) {
             main("help");
-        } catch (ParseArgumentsUnexpectedException | ParseOptionMissingException e) {
+        } catch (ParseArgumentsUnexpectedException | ParseOptionMissingException | ParseArgumentsIllegalValueException e) {
             System.err.println("Error: " + e.getMessage());
             String commandName = args[0];
             System.err.format("Run `ontop help %s` to see the help for the command `%s`\n", commandName, commandName);

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMaterialize.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMaterialize.java
@@ -5,6 +5,7 @@ import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.OptionType;
 import com.github.rvesse.airline.annotations.restrictions.AllowedEnumValues;
+import com.github.rvesse.airline.parser.errors.ParseArgumentsIllegalValueException;
 import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.exception.InvalidOntopConfigurationException;
 import it.unibz.inf.ontop.exception.OBDASpecificationException;
@@ -30,9 +31,11 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -168,10 +171,31 @@ public class OntopMaterialize extends OntopMappingOntologyRelatedCommand {
 
     private void runWithSeparateFiles(RDF4JMaterializer materializer) {
         try {
+            validateBaseDirectory();
             materializeClassesByFile(materializer);
             materializePropertiesByFile(materializer);
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * If --separate-files is set, this method checks the correctness of the outputFile path,
+     * which has to be a directory. If the directory does not exist, but its parent does,
+     * it is created. Otherwise, a ParseArgumentsIllegalValueException is thrown.
+     * @throws IOException
+     * @throws ParseArgumentsIllegalValueException
+     */
+    private void validateBaseDirectory() throws IOException, ParseArgumentsIllegalValueException {
+        Path outputPath = Paths.get(removeExtension(outputFile));
+        if(!Files.isDirectory(outputPath)) {
+            if(Files.isDirectory(outputPath.getParent()))
+            {
+                Files.createDirectory(outputPath);
+            }
+            else {
+                throw new ParseArgumentsIllegalValueException("output", outputFile, Set.of("output must be an existing directory if '--separate-files' is set."));
+            }
         }
     }
 


### PR DESCRIPTION
From previous feedback, it seems not always clear that the `output` parameter for the "materialize" procedure must be a directory if `--separate-files` was set.

Added new functionality to create the directory if it does not exist yet and it is easily possible to create it, and otherwise output an understandable error message