### PR TITLE
Fixed issue that made lenses lose UCs under certain conditions

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/LensMetadataProviderImpl.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/LensMetadataProviderImpl.java
@@ -17,10 +17,7 @@ import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
 
 public class LensMetadataProviderImpl implements LensMetadataProvider {
@@ -35,6 +32,8 @@ public class LensMetadataProviderImpl implements LensMetadataProvider {
 
     // "Processed": constraints already inserted
     private final Set<RelationID> alreadyProcessedViews = new HashSet<>();
+
+    private final Map<RelationID, NamedRelationDefinition> cachedLenses = new HashMap<>();
 
     // Lazy (built lately)
     @Nullable
@@ -106,8 +105,12 @@ public class LensMetadataProviderImpl implements LensMetadataProvider {
     @Override
     public NamedRelationDefinition getRelation(RelationID id) throws MetadataExtractionException {
         JsonLens jsonLens = jsonMap.get(id);
-        if (jsonLens != null)
-            return jsonLens.createViewDefinition(getDBParameters(), dependencyCacheMetadataLookup.getCachingMetadataLookupFor(id));
+        if (jsonLens != null) {
+            if (!cachedLenses.containsKey(id))
+                cachedLenses.put(id, jsonLens.createViewDefinition(getDBParameters(), dependencyCacheMetadataLookup.getCachingMetadataLookupFor(id)));
+            return cachedLenses.get(id);
+        }
+
 
         return parentCachingMetadataLookup.getRelation(id);
     }

--- a/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/MultilevelLensUniqueConstraintTest.java
+++ b/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/MultilevelLensUniqueConstraintTest.java
@@ -1,0 +1,39 @@
+package it.unibz.inf.ontop.dbschema;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class MultilevelLensUniqueConstraintTest {
+    private static final String LENS_FILE = "src/test/resources/multilevel-uc/multilevel-uc-lenses.json";
+    private static final String DBMETADATA_FILE = "src/test/resources/multilevel-uc/multilevel-uc.db-extract.json";
+
+    private final ImmutableSet<Lens> lensDefinitions = LensParsingTest.loadLensesH2(LENS_FILE, DBMETADATA_FILE);
+    private final ImmutableMap<String, Lens> lensMap;
+
+    public MultilevelLensUniqueConstraintTest() throws Exception {
+        lensMap = lensDefinitions.stream().collect(ImmutableCollectors.<Lens, String, Lens>toMap(
+                l -> String.join(".", l.getID().getComponents().reverse().stream().map(c -> c.getName()).collect(Collectors.toList())),
+                l -> l
+        ));
+    }
+
+    @Test
+    public void testLevel1UC() {
+        var constraints = lensMap.get("lenses.l1").getUniqueConstraints();
+        assertEquals(1, constraints.size());
+        assertEquals(ImmutableSet.of("id"), constraints.get(0).getAttributes().stream().map(a -> a.getID().getName()).collect(ImmutableCollectors.toSet()));
+    }
+
+    @Test
+    public void testLevel2UC() {
+        var constraints = lensMap.get("lenses.l2").getUniqueConstraints();
+        assertEquals(1, constraints.size());
+        assertEquals(ImmutableSet.of("id"), constraints.get(0).getAttributes().stream().map(a -> a.getID().getName()).collect(ImmutableCollectors.toSet()));
+    }
+}

--- a/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/NestedViewsPersonTest.java
+++ b/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/NestedViewsPersonTest.java
@@ -37,7 +37,7 @@ public class NestedViewsPersonTest {
                 .map(RelationDefinition::getOtherFunctionalDependencies)
                 .flatMap(Collection::stream)
                 .collect(ImmutableCollectors.toSet());
-        assertEquals(1, fds.size());
+        assertEquals(2, fds.size());
 
         FunctionalDependency fd = fds.stream().findFirst().get();
         ImmutableSet<String> determinants = fd.getDeterminants().stream()
@@ -59,7 +59,7 @@ public class NestedViewsPersonTest {
                 .map(RelationDefinition::getForeignKeys)
                 .flatMap(Collection::stream)
                 .collect(ImmutableCollectors.toSet());
-        assertEquals(2, fks.size());
+        assertEquals(4, fks.size());
 
         ForeignKeyConstraint fk = fks.stream().findFirst().get();
         String target = fk.getReferencedRelation().getID().getSQLRendering();

--- a/db/rdb/src/test/resources/multilevel-uc/multilevel-uc-lenses.json
+++ b/db/rdb/src/test/resources/multilevel-uc/multilevel-uc-lenses.json
@@ -1,0 +1,22 @@
+{
+  "relations": [
+    {
+      "name": ["\"lenses\"", "\"l1\""],
+      "baseRelation": ["\"base_table\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"l2\""],
+      "baseRelation": ["\"lenses\"", "\"l1\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    }
+  ]
+}

--- a/db/rdb/src/test/resources/multilevel-uc/multilevel-uc.db-extract.json
+++ b/db/rdb/src/test/resources/multilevel-uc/multilevel-uc.db-extract.json
@@ -1,0 +1,40 @@
+{
+  "relations": [
+    {
+      "uniqueConstraints": [
+        {
+          "name": "CONSTRAINT_1",
+          "determinants": [
+            "\"id\""
+          ],
+          "isPrimaryKey": true
+        }
+      ],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"base_table\""
+      ]
+    }
+  ],
+  "metadata": {
+    "dbmsProductName": "H2",
+    "dbmsVersion": "1.4.199 (2019-03-13)",
+    "driverName": "H2 JDBC Driver",
+    "driverVersion": "1.4.199 (2019-03-13)",
+    "quotationString": "\"",
+    "extractionTime": "2020-11-12T17:24:30"
+  }
+}


### PR DESCRIPTION
With the current implementation of the `LensMetadataProviderImpl` class, there are cases when lenses could "lose" their integrity constraints if they are in a multi-level hierarchy of lenses. This can happen under the following circumstances:

Imagine two basic lenses, `L1` and `L2`, where `L2` uses `L1` as a base relation, and `L1` has a table with one attribute `id` as its base. `id` is UNIQUE.

Now, ontop reaches the point where the integrity constraints are computed (`LensMetadataProviderImpl.insertIntegrityConstraints(...)`). It iterates over the list of lenses (*loop 1) and computes the constraints for each of them.
If it starts with `L2`, then the method will notice that it uses `L1` as its base relation. It will take the LensImpl object for `L1` from `L2`'s base relations and call `insertIntegrityConstraints(...)` on it first. Once this step is complete, the RelationID of `L1` is added to the `alreadyProcessedViews` list.
Next, *loop 1 continues and `insertIntegrityConstraints(...)` is called on the Lens `L1`. As the RelationID of `L1` is already in `alreadyProcessedViews`, it will not compute L1's integrity constraints again. However, this LensImpl object of `L1`, and the one taken from L2's base relation were _different instances_, because the `getRelation(...)` method in `LensMetadataProviderImpl` constructs a new `LensImpl` object each time it is called. Because of that, this `L1` instance will keep its integrity constraints empty.
If *loop 1 were to start with `L1` instead, the same thing would happen in the different direction: L2's base relation `L1` instance will not receive any UCs, and so `L2` cannot infer them.

I fixed this by adding a cache to `LensMetadataProviderImpl` so that `getRelation(...)` will not always construct new instances, and instead reuse existing instanses of `LensImpls` if `getRelation(...)` is called multiple times for the same RelationID.