### PR TITLE
Added missing cast functions to if-branch without primary keys for RDB2RDF

### DIFF
--- a/mapping/sql/owlapi/src/main/java/it/unibz/inf/ontop/spec/mapping/bootstrap/impl/DirectMappingAxiomProducer.java
+++ b/mapping/sql/owlapi/src/main/java/it/unibz/inf/ontop/spec/mapping/bootstrap/impl/DirectMappingAxiomProducer.java
@@ -266,6 +266,7 @@ public class DirectMappingAxiomProducer {
 		else {
 			ImmutableList<ImmutableTerm> vars = td.getAttributes().stream()
 					.map(a -> termFactory.getVariable(varNamePrefix + a.getID().getName()))
+					.map(termFactory::getPartiallyDefinedConversionToString)
 					.collect(ImmutableCollectors.toList());
 
 			/*


### PR DESCRIPTION
Fixes a problem in RDB2RDF where an integer variable used in an IRI of a bnode would fail, as it didn't cast the integer to a string first, making the variable incompatible with the REPLACE function used for IRI encoding. 

This error only occurred for tables that don't have a primary key, as the code branches depending on if there is a primary key or not. In the "else" case, it seems like the addition of casting functions was forgotten.

This should fix [Issue 593](https://github.com/ontop/ontop/issues/593)