### PR TITLE
Added index type of FlattenNode as LargeInteger

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FlattenNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FlattenNodeImpl.java
@@ -98,7 +98,7 @@ public class FlattenNodeImpl extends CompositeQueryNodeImpl implements FlattenNo
 
     @Override
     public Optional<TermType> getIndexVariableType() {
-        return Optional.empty();
+        return Optional.of(termFactory.getTypeFactory().getDBTypeFactory().getDBLargeIntegerType());
     }
 
     @Override

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/AbstractNestedDataTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/AbstractNestedDataTest.java
@@ -24,7 +24,7 @@ public abstract class AbstractNestedDataTest extends AbstractDockerRDF4JTest {
                 "\n" +
                 "SELECT  ?v " +
                 "WHERE {" +
-                "?p :index ?v . \n" +
+                "?v :income ?i . \n" +
                 "}";
 
         String ontopSQLtranslation = reformulate(query);

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/AbstractNestedDataTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/AbstractNestedDataTest.java
@@ -1,6 +1,7 @@
 package it.unibz.inf.ontop.docker.lightweight;
 
 import com.google.common.collect.ImmutableMultiset;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +17,19 @@ public abstract class AbstractNestedDataTest extends AbstractDockerRDF4JTest {
     protected static final String OWL_FILE = null;
 
     Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+
+    @Test
+    public void testUniqueConstraintsPreserved() {
+        String query = "PREFIX : <http://nested.example.org/>" +
+                "\n" +
+                "SELECT  ?v " +
+                "WHERE {" +
+                "?p :index ?v . \n" +
+                "}";
+
+        String ontopSQLtranslation = reformulate(query);
+        Assertions.assertFalse(supportsPositionVariable() && ontopSQLtranslation.toUpperCase().contains("DISTINCT"), "UniqueConstraints not preserved.");
+    }
 
     @Test
     public void testFlattenWithPosition() throws Exception {
@@ -169,5 +183,7 @@ public abstract class AbstractNestedDataTest extends AbstractDockerRDF4JTest {
     protected int getSPOExpectedCount() {
         return 89;
     }
+
+    protected boolean supportsPositionVariable() { return true; }
 
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/dremio/NestedDataDremioTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/dremio/NestedDataDremioTest.java
@@ -64,4 +64,9 @@ public class NestedDataDremioTest extends AbstractNestedDataTest {
     protected int getSPOExpectedCount() {
         return 76;
     }
+
+    @Override
+    protected boolean supportsPositionVariable() {
+        return false;
+    }
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mssql/NestedDataSQLServerTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mssql/NestedDataSQLServerTest.java
@@ -54,4 +54,9 @@ public class NestedDataSQLServerTest extends AbstractNestedDataTest {
     protected int getSPOExpectedCount() {
         return 76;
     }
+
+    @Override
+    protected boolean supportsPositionVariable() {
+        return false;
+    }
 }

--- a/test/lightweight-tests/src/test/resources/nested/athena/nested-lenses-array.json
+++ b/test/lightweight-tests/src/test/resources/nested/athena/nested-lenses-array.json
@@ -1,8 +1,21 @@
 {
   "relations": [
     {
+      "name": [ "lenses", "company_data_arrays" ],
+      "baseRelation": ["nested", "company_data_arrays" ],
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [ "id" ]
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
       "name": ["lenses","flattened_dates"],
-      "baseRelation": ["nested","company_data_arrays"],
+      "baseRelation": ["lenses","company_data_arrays"],
       "flattenedColumn": {
         "name": "days",
         "datatype": "array<timestamp>"
@@ -18,7 +31,7 @@
     },
     {
       "name": ["lenses","flattened_income"],
-      "baseRelation": ["nested", "company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "income",
         "datatype": "array<integer>"
@@ -34,7 +47,7 @@
     },
     {
       "name": ["lenses","flattened_workers_mid"],
-      "baseRelation": ["nested", "company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "workers",
         "datatype": "array<array<varchar>>"
@@ -66,7 +79,7 @@
     },
     {
       "name": ["lenses","flattened_managers"],
-      "baseRelation": ["nested", "company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "managers",
         "datatype": "array<varchar>"

--- a/test/lightweight-tests/src/test/resources/nested/bigquery/nested-lenses-array.json
+++ b/test/lightweight-tests/src/test/resources/nested/bigquery/nested-lenses-array.json
@@ -1,8 +1,21 @@
 {
   "relations": [
     {
+      "name": [ "lenses", "company_data_arrays" ],
+      "baseRelation": ["nested", "company_data_arrays" ],
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [ "id" ]
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
       "name": ["lenses","flattened_dates"],
-      "baseRelation": ["nested","company_data_arrays"],
+      "baseRelation": ["lenses","company_data_arrays"],
       "flattenedColumn": {
         "name": "days",
         "datatype": "array<timestamp>"
@@ -18,7 +31,7 @@
     },
     {
       "name": ["lenses","flattened_income"],
-      "baseRelation": ["nested", "company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "income",
         "datatype": "array<integer>"
@@ -34,7 +47,7 @@
     },
     {
       "name": ["lenses","flattened_workers_mid"],
-      "baseRelation": ["nested", "company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "workers",
         "datatype": "array<array<string>>"
@@ -82,7 +95,7 @@
     },
     {
       "name": ["lenses","flattened_managers"],
-      "baseRelation": ["nested", "company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "managers",
         "datatype": "array<string>"

--- a/test/lightweight-tests/src/test/resources/nested/dremio/nested-lenses-array.json
+++ b/test/lightweight-tests/src/test/resources/nested/dremio/nested-lenses-array.json
@@ -1,8 +1,21 @@
 {
   "relations": [
     {
+      "name": [ "lenses", "company_data_arrays" ],
+      "baseRelation": ["company_data_arrays" ],
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [ "id" ]
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
       "name": ["lenses","flattened_dates_mid"],
-      "baseRelation": ["company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "days",
         "datatype": "list"

--- a/test/lightweight-tests/src/test/resources/nested/spark/nested-lenses-array.json
+++ b/test/lightweight-tests/src/test/resources/nested/spark/nested-lenses-array.json
@@ -1,8 +1,21 @@
 {
   "relations": [
     {
+      "name": [ "lenses", "company_data_arrays" ],
+      "baseRelation": [ "company_data_arrays" ],
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [ "id" ]
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
       "name": ["lenses","flattened_dates"],
-      "baseRelation": ["company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "days",
         "datatype": "array<timestamp>"
@@ -18,7 +31,7 @@
     },
     {
       "name": ["lenses","flattened_income"],
-      "baseRelation": ["company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "income",
         "datatype": "array<integer>"
@@ -34,7 +47,7 @@
     },
     {
       "name": ["lenses","flattened_workers_mid"],
-      "baseRelation": ["company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "workers",
         "datatype": "array<array<string>>"
@@ -66,7 +79,7 @@
     },
     {
       "name": ["lenses","flattened_managers"],
-      "baseRelation": ["company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "managers",
         "datatype": "array<string>"

--- a/test/lightweight-tests/src/test/resources/nested/spark/nested-lenses-json.json
+++ b/test/lightweight-tests/src/test/resources/nested/spark/nested-lenses-json.json
@@ -1,8 +1,21 @@
 {
   "relations": [
     {
+      "name": [ "lenses", "company_data" ],
+      "baseRelation": [ "company_data" ],
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [ "id" ]
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
       "name": ["lenses","flattened_dates_mid"],
-      "baseRelation": ["company_data"],
+      "baseRelation": ["lenses", "company_data"],
       "flattenedColumn": {
         "name": "days",
         "datatype": "string"
@@ -18,7 +31,7 @@
     },
     {
       "name": ["lenses","flattened_income_mid"],
-      "baseRelation": ["company_data"],
+      "baseRelation": ["lenses", "company_data"],
       "flattenedColumn": {
         "name": "income",
         "datatype": "string"
@@ -34,7 +47,7 @@
     },
     {
       "name": ["lenses","flattened_workers_mid"],
-      "baseRelation": ["company_data"],
+      "baseRelation": ["lenses", "company_data"],
       "flattenedColumn": {
         "name": "workers",
         "datatype": "string"
@@ -66,7 +79,7 @@
     },
     {
       "name": ["lenses","flattened_managers"],
-      "baseRelation": ["company_data"],
+      "baseRelation": ["lenses", "company_data"],
       "flattenedColumn": {
         "name": "managers",
         "datatype": "string"

--- a/test/lightweight-tests/src/test/resources/nested/trino/nested-lenses-array.json
+++ b/test/lightweight-tests/src/test/resources/nested/trino/nested-lenses-array.json
@@ -1,8 +1,21 @@
 {
   "relations": [
     {
+      "name": [ "lenses", "company_data_arrays" ],
+      "baseRelation": [ "company_data_arrays" ],
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [ "id" ]
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
       "name": ["lenses","flattened_dates"],
-      "baseRelation": ["company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "days",
         "datatype": "array(timestamp)"
@@ -18,7 +31,7 @@
     },
     {
       "name": ["lenses","flattened_income"],
-      "baseRelation": ["company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "income",
         "datatype": "array(integer)"
@@ -34,7 +47,7 @@
     },
     {
       "name": ["lenses","flattened_workers_mid"],
-      "baseRelation": ["company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "workers",
         "datatype": "array(array(varchar))"
@@ -66,7 +79,7 @@
     },
     {
       "name": ["lenses","flattened_managers"],
-      "baseRelation": ["company_data_arrays"],
+      "baseRelation": ["lenses", "company_data_arrays"],
       "flattenedColumn": {
         "name": "managers",
         "datatype": "array(json)"


### PR DESCRIPTION
Currently, the `getIndexVariableType()` method returns `Optional.empty()`.
However, this can cause problems: When used as part of an IRI template, the variable has to be cast to `STRING`. Since we don't know what the base-type is, it will use a `DefaultSimpleDBCastFunctionSymbol`. For this function symbol,
`isAlwaysInjectiveInTheAbsenceOfNonInjectiveFunctionalTerms()` returns false if the input type is unknown.

This way, the `analyzeInjectivity(...)` method in `FunctionSymbolImpl` will not return a decomposition; therefore, the `ConstructionNode` will not know that the Unique Constraint that may have been holding before the IRI construction will still hold, which prevents the query from being optimised.

Adding an expected type for the index variable prevents all of this, and the unique constraint will be carried over.

I chose `DBLargeInteger` as the type, as this is the most reasonable one. It works with all currently supported databases, and there is no reason to assume an index of the `FLATTEN` function for any different database may be of a non-integer type.

