### PR TITLE
New left join optimisation: reduce the left-join to an inner join in the presence of a left join on the right

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/DestinationTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/DestinationTest.java
@@ -164,4 +164,28 @@ public class DestinationTest extends AbstractRDF4JTest {
         assertEquals(0, StringUtils.countMatches(sql.toUpperCase(), "DISTINCT"));
     }
 
+    @Test
+    public void testOneLJElimination() {
+        String sparql = "PREFIX schema: <http://schema.org/>\n" +
+                "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\n" +
+                "PREFIX : <http://noi.example.org/ontology/odh#>\n" +
+                "\n" +
+                "SELECT *\n" +
+                "WHERE {\n" +
+                "  ?r a schema:Accommodation .\n" +
+                "  OPTIONAL { \n" +
+                "   ?r schema:containedInPlace ?h .\n" +
+                "   OPTIONAL { \n" +
+                "     ?h schema:name ?n . \n" +
+                "     FILTER (lang(?n) = 'en')\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n";
+
+        String sql = reformulateIntoNativeQuery(sparql);
+        // The non-simplifiable LJs are those between the accommodations and the lodging businesses (2 sources)
+        // due to the absence of FKs
+        assertEquals(2, StringUtils.countMatches(sql, "LEFT OUTER JOIN"));
+    }
+
 }

--- a/binding/rdf4j/src/test/resources/destination/schema.sql
+++ b/binding/rdf4j/src/test/resources/destination/schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE "source1_hospitality" (
 insert into "source1_hospitality" (h_id, name_en, name_it, name_de, h_type, m_id) values ('aaa', 'Hotel 1', 'ee', 'eee', 'Camping', '212');
 
 CREATE TABLE "source1_rooms" (
-                               r_id varchar(100) NOT NULL,
+                               r_id varchar(100) primary key NOT NULL,
                                name_en text NOT NULL,
                                name_de text NOT NULL,
                                name_it text NOT NULL,
@@ -57,7 +57,7 @@ CREATE TABLE "source2_hotels" (
 );
 
 CREATE TABLE "source2_accommodation" (
-                                       id varchar(100) NOT NULL,
+                                       id varchar(100) primary key NOT NULL,
                                        english_title text NOT NULL,
                                        german_title text NOT NULL,
                                        italian_title text NOT NULL,

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/DefaultCompositeLeftJoinIQOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/DefaultCompositeLeftJoinIQOptimizer.java
@@ -7,6 +7,7 @@ import it.unibz.inf.ontop.iq.IQ;
 import it.unibz.inf.ontop.iq.optimizer.LeftJoinIQOptimizer;
 import it.unibz.inf.ontop.iq.optimizer.impl.lj.CardinalityInsensitiveJoinTransferLJOptimizer;
 import it.unibz.inf.ontop.iq.optimizer.impl.lj.CardinalitySensitiveJoinTransferLJOptimizer;
+import it.unibz.inf.ontop.iq.optimizer.impl.lj.LJWithNestingOnRightToInnerJoinOptimizer;
 
 public class DefaultCompositeLeftJoinIQOptimizer implements LeftJoinIQOptimizer {
 
@@ -15,10 +16,12 @@ public class DefaultCompositeLeftJoinIQOptimizer implements LeftJoinIQOptimizer 
     @Inject
     private DefaultCompositeLeftJoinIQOptimizer(
             CardinalitySensitiveJoinTransferLJOptimizer cardinalitySensitiveJoinTransferLJOptimizer,
-            CardinalityInsensitiveJoinTransferLJOptimizer cardinalityInsensitiveJoinTransferLJOptimizer) {
+            CardinalityInsensitiveJoinTransferLJOptimizer cardinalityInsensitiveJoinTransferLJOptimizer,
+            LJWithNestingOnRightToInnerJoinOptimizer ljWithNestingOnRightToInnerJoinOptimizer) {
         this.optimizers = ImmutableList.of(
                 cardinalitySensitiveJoinTransferLJOptimizer,
-                cardinalityInsensitiveJoinTransferLJOptimizer);
+                cardinalityInsensitiveJoinTransferLJOptimizer,
+                ljWithNestingOnRightToInnerJoinOptimizer);
 
     }
 

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/LJWithNestingOnRightToInnerJoinOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/LJWithNestingOnRightToInnerJoinOptimizer.java
@@ -1,0 +1,175 @@
+package it.unibz.inf.ontop.iq.optimizer.impl.lj;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import it.unibz.inf.ontop.injection.CoreSingletons;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.BinaryNonCommutativeIQTree;
+import it.unibz.inf.ontop.iq.IQ;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.node.ConstructionNode;
+import it.unibz.inf.ontop.iq.node.LeftJoinNode;
+import it.unibz.inf.ontop.iq.node.QueryNode;
+import it.unibz.inf.ontop.iq.node.normalization.impl.RightProvenanceNormalizer;
+import it.unibz.inf.ontop.iq.optimizer.LeftJoinIQOptimizer;
+import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeVisitingTransformer;
+import it.unibz.inf.ontop.model.atom.AtomFactory;
+import it.unibz.inf.ontop.model.atom.DistinctVariableOnlyDataAtom;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Restricted to LJs on the right to limit overlap with existing techniques.
+ * Typical case optimized: self-left-join with LJ nesting on the right (and possibly on the left)
+ *
+ */
+public class LJWithNestingOnRightToInnerJoinOptimizer implements LeftJoinIQOptimizer {
+
+    private final RightProvenanceNormalizer rightProvenanceNormalizer;
+    private final CoreSingletons coreSingletons;
+    private final IntermediateQueryFactory iqFactory;
+    private final CardinalitySensitiveJoinTransferLJOptimizer otherLJOptimizer;
+
+    @Inject
+    protected LJWithNestingOnRightToInnerJoinOptimizer(RightProvenanceNormalizer rightProvenanceNormalizer,
+                                                       CoreSingletons coreSingletons,
+                                                       CardinalitySensitiveJoinTransferLJOptimizer otherLJOptimizer) {
+        this.rightProvenanceNormalizer = rightProvenanceNormalizer;
+        this.coreSingletons = coreSingletons;
+        this.iqFactory = coreSingletons.getIQFactory();
+        this.otherLJOptimizer = otherLJOptimizer;
+    }
+
+    @Override
+    public IQ optimize(IQ query) {
+        IQTree initialTree = query.getTree();
+
+        Transformer transformer = new Transformer(
+                query.getVariableGenerator(),
+                rightProvenanceNormalizer,
+                coreSingletons,
+                otherLJOptimizer);
+
+        IQTree newTree = initialTree.acceptTransformer(transformer);
+
+        return newTree.equals(initialTree)
+                ? query
+                : iqFactory.createIQ(query.getProjectionAtom(), newTree);
+    }
+
+    protected static class Transformer extends DefaultRecursiveIQTreeVisitingTransformer {
+
+        private final VariableGenerator variableGenerator;
+        private final RightProvenanceNormalizer rightProvenanceNormalizer;
+        private final TermFactory termFactory;
+        private final CardinalitySensitiveJoinTransferLJOptimizer otherLJOptimizer;
+        private final AtomFactory atomFactory;
+
+        protected Transformer(VariableGenerator variableGenerator, RightProvenanceNormalizer rightProvenanceNormalizer,
+                              CoreSingletons coreSingletons, CardinalitySensitiveJoinTransferLJOptimizer otherLJOptimizer) {
+            super(coreSingletons);
+            this.variableGenerator = variableGenerator;
+            this.rightProvenanceNormalizer = rightProvenanceNormalizer;
+            this.termFactory = coreSingletons.getTermFactory();
+            this.otherLJOptimizer = otherLJOptimizer;
+            this.atomFactory = coreSingletons.getAtomFactory();
+        }
+
+        @Override
+        public IQTree transformLeftJoin(IQTree tree, LeftJoinNode rootNode, IQTree leftChild, IQTree rightChild) {
+            if (rootNode.getOptionalFilterCondition().isPresent())
+                return super.transformLeftJoin(tree, rootNode, leftChild, rightChild)
+                        .normalizeForOptimization(variableGenerator);
+
+            IQTree newLeftChild = transform(leftChild);
+            IQTree newRightChild = transform(rightChild);
+
+            Optional<ConstructionNode> rightConstructionNode = Optional.of(newRightChild.getRootNode())
+                    .filter(n -> n instanceof ConstructionNode)
+                    .map(n -> (ConstructionNode) n);
+
+            Optional<BinaryNonCommutativeIQTree> rightLJ = rightConstructionNode
+                    .map(c -> newRightChild.getChildren().get(0))
+                    .or(() -> Optional.of(newRightChild))
+                    .filter(t -> t.getRootNode() instanceof LeftJoinNode)
+                    .map(t -> (BinaryNonCommutativeIQTree) t);
+
+            Optional<IQTree> simplifiedTree = rightLJ
+                    .flatMap(rLJ -> tryToSimplify(newLeftChild, rLJ, rightConstructionNode));
+
+            return simplifiedTree
+                    .orElseGet(() -> newLeftChild.equals(leftChild) && newRightChild.equals(rightChild)
+                            ? tree
+                            : iqFactory.createBinaryNonCommutativeIQTree(rootNode, newLeftChild, newRightChild)
+                            .normalizeForOptimization(variableGenerator));
+        }
+
+        private Optional<IQTree> tryToSimplify(IQTree leftChild, BinaryNonCommutativeIQTree rightLJ,
+                                               Optional<ConstructionNode> rightConstructionNode) {
+            ImmutableSet<Variable> leftVariables = leftChild.getVariables();
+
+            Set<Variable> rightVariablesInteractingWithLeft = rightConstructionNode
+                    .map(c -> (Set<Variable>) Sets.intersection(c.getVariables(), leftVariables).stream()
+                            .flatMap(v -> c.getSubstitution().apply(v).getVariableStream())
+                            .collect(ImmutableCollectors.toSet()))
+                    .orElseGet(() -> Sets.intersection(leftVariables, rightLJ.getVariables()));
+
+            Optional<IQTree> safeLeftOfRightDescendant = extractSafeLeftOfRightDescendantTree(
+                    rightLJ.getLeftChild(), rightVariablesInteractingWithLeft);
+
+            return safeLeftOfRightDescendant
+                    .filter(r -> canLJBeReduced(leftChild, r))
+                    // Reduces the LJ to an inner join
+                    .map(r -> iqFactory.createNaryIQTree(iqFactory.createInnerJoinNode(),
+                            ImmutableList.of(leftChild,
+                                    rightConstructionNode
+                                            .map(c -> (IQTree) iqFactory.createUnaryIQTree(c, rightLJ))
+                                            .orElse(rightLJ))))
+                    .map(t -> t.normalizeForOptimization(variableGenerator));
+        }
+
+        private boolean canLJBeReduced(IQTree leftChild, IQTree safeLeftOfRightDescendant) {
+            RightProvenanceNormalizer.RightProvenance rightProvenance = rightProvenanceNormalizer.normalizeRightProvenance(
+                    safeLeftOfRightDescendant, leftChild.getVariables(), Optional.empty(), variableGenerator);
+
+            IQTree minusTree = iqFactory.createUnaryIQTree(
+                    iqFactory.createFilterNode(termFactory.getDBIsNull(rightProvenance.getProvenanceVariable())),
+                    iqFactory.createBinaryNonCommutativeIQTree(
+                            iqFactory.createLeftJoinNode(),
+                            leftChild, rightProvenance.getRightTree()));
+
+            // Hack
+            DistinctVariableOnlyDataAtom minusFakeProjectionAtom = atomFactory.getDistinctVariableOnlyDataAtom(
+                    atomFactory.getRDFAnswerPredicate(minusTree.getVariables().size()),
+                    ImmutableList.copyOf(minusTree.getVariables()));
+
+            return otherLJOptimizer.optimize(iqFactory.createIQ(minusFakeProjectionAtom, minusTree))
+                    .normalizeForOptimization().getTree()
+                    .isDeclaredAsEmpty();
+        }
+
+        /**
+         * Finds the first non-LJ descendant on the left. If it exposes all the variables interacting with the left, returns it
+         */
+        private Optional<IQTree> extractSafeLeftOfRightDescendantTree(IQTree leftChild, Set<Variable> rightVariablesInteractingWithLeft) {
+            // To be safe, we want all these variables to be present on the left
+            // Otherwise, we don't apply this optimization
+            if (!leftChild.getVariables().containsAll(rightVariablesInteractingWithLeft))
+                return Optional.empty();
+
+            QueryNode rootNode = leftChild.getRootNode();
+            if (rootNode instanceof LeftJoinNode)
+                // Recursive
+                return extractSafeLeftOfRightDescendantTree(leftChild.getChildren().get(0), rightVariablesInteractingWithLeft);
+            else
+                return Optional.of(leftChild);
+        }
+    }
+}

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -2083,7 +2083,7 @@ public class LeftJoinOptimizationTest {
         IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
 
         IQTree newLeftTree = IQ_FACTORY.createNaryIQTree(IQ_FACTORY.createInnerJoinNode(),
-                ImmutableList.of(dataNode1, dataNode2));
+                ImmutableList.of(dataNode2, dataNode1));
 
         IQTree newTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
                 newLeftTree, dataNode3);
@@ -2123,6 +2123,7 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
+    @Ignore("Join transfer is currently not supported for LJ on the right")
     @Test
     public void testLJReductionWithLJOnTheRight4() {
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -2032,6 +2032,95 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
+    @Test
+    public void testLJReductionWithLJOnTheRight1() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, C));
+
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, D));
+
+        IQTree rightTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode2, dataNode3);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                rightTree);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, C,2, B));
+
+        IQTree newTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                newDataNode, dataNode3);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testLJReductionWithLJOnTheRight2() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE2, ImmutableMap.of(0, B, 1, A));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, C));
+
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, D));
+
+        IQTree rightTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode2, dataNode3);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                rightTree);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        IQTree newLeftTree = IQ_FACTORY.createNaryIQTree(IQ_FACTORY.createInnerJoinNode(),
+                ImmutableList.of(dataNode1, dataNode2));
+
+        IQTree newTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                newLeftTree, dataNode3);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+
+    /**
+     * Could be further simplified in the future. At the moment, makes sure invalid optimizations are not applied.
+     */
+    @Test
+    public void testNonLJReductionWithLJOnTheRight1() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, B, C));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, C));
+
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, A));
+
+        IQTree rightTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode2, dataNode3);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                rightTree);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        optimizeAndCompare(initialIQ, initialIQ);
+    }
+
 
     private static void optimizeAndCompare(IQ initialIQ, IQ expectedIQ) {
         System.out.println("Initial query: "+ initialIQ);

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -2239,7 +2239,6 @@ public class LeftJoinOptimizationTest {
                 IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(), substitution),
                 newLJTree);
 
-
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
 
         optimizeAndCompare(initialIQ, expectedIQ);

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -2166,6 +2166,33 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
+    /**
+     * TODO: could be simplified by reducing the nested LJ on the right as an inner join.
+     * At the moment, is here to prevent incorrect optimizations.
+     */
+    @Test
+    public void testNonLJReductionWithLJOnTheRight1() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, B, C));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, C));
+
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, B));
+
+        IQTree rightTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode2, dataNode3);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                rightTree);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        optimizeAndCompare(initialIQ, initialIQ);
+    }
+
 
     private static void optimizeAndCompare(IQ initialIQ, IQ expectedIQ) {
         System.out.println("Initial query: "+ initialIQ);


### PR DESCRIPTION
The presence of a left-join on the right of a left-join currently prevents the existing semantic left join optimisations to apply.

It is for instance not correct to use join transfer for the following query, where `EXTENSIONAL TABLE1(0:a,1:c)` would be replaced by `TRUE` and a provenance variable would be added to the nested left-join:
```
LJ
   EXTENSIONAL TABLE1(0:a,2:b)
   LJ
      EXTENSIONAL TABLE1(0:a,1:c)
      EXTENSIONAL TABLE1A(0:a,1:d)
```
NB: there is a unique constraint over the first column of `TABLE1`.

Therefore we implemented a new optimization that, in this example, simply replaces the top left join by an inner join after proving it is possible.

As a result, after applying this optimization and the existing ones we obtain:
```
LJ
   EXTENSIONAL TABLE1(0:a,1:c,2:b)
   EXTENSIONAL TABLE1A(0:a,1:d)
```

Here is a real-world SPARQL query motivating this optimization:
```sparql
PREFIX schema: <http://schema.org/>
SELECT *
WHERE {
   ?r a schema:Accommodation .
  OPTIONAL { 
      ?r schema:containedInPlace ?h .
      OPTIONAL {
         ?h schema:name ?n .
         FILTER (lang(?n) = 'en')
       }
   }
}
```
in the absence of a foreign key from the accommodation to the lodging business.
