### PR TITLE
Merge right children of left-joins nested on the left

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/DestinationTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/DestinationTest.java
@@ -188,4 +188,30 @@ public class DestinationTest extends AbstractRDF4JTest {
         assertEquals(2, StringUtils.countMatches(sql, "LEFT OUTER JOIN"));
     }
 
+    @Test
+    public void testMergeLJs() {
+        String sparql = "PREFIX schema: <http://schema.org/>\n" +
+                "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\n" +
+                "PREFIX : <http://noi.example.org/ontology/odh#>\n" +
+                "\n" +
+                "SELECT *\n" +
+                "WHERE {\n" +
+                "  ?r a schema:Accommodation ;\n" +
+                "       schema:containedInPlace ?h .\n" +
+                "  OPTIONAL { \n" +
+                "    ?h schema:name ?en . \n" +
+                "    FILTER (lang(?en) = 'en')\n" +
+                "  }\n" +
+                "  OPTIONAL { \n" +
+                "    ?h schema:name ?it . \n" +
+                "    FILTER (lang(?it) = 'it')\n" +
+                "  }\n" +
+                "}\n";
+
+        String sql = reformulateIntoNativeQuery(sparql);
+        // The non-simplifiable LJs are those between the accommodations and the lodging businesses (2 sources)
+        // due to the absence of FKs
+        assertEquals(2, StringUtils.countMatches(sql, "LEFT OUTER JOIN"));
+    }
+
 }

--- a/binding/rdf4j/src/test/resources/destination/schema.sql
+++ b/binding/rdf4j/src/test/resources/destination/schema.sql
@@ -46,7 +46,7 @@ CREATE TABLE "source1_rooms" (
 CREATE TABLE "source2_hotels" (
                                 id varchar(100) primary key NOT NULL,
                                 english text NOT NULL,
-                                italian text NULL,
+                                italian text NOT NULL,
                                 german text NOT NULL,
                                 htype integer NULL,
                                 lat float NOT NULL,
@@ -58,7 +58,7 @@ CREATE TABLE "source2_hotels" (
 
 CREATE TABLE "source2_accommodation" (
                                        id varchar(100) primary key NOT NULL,
-                                       english_title text NOT NULL,
+                                       english_title text NULL,
                                        german_title text NOT NULL,
                                        italian_title text NOT NULL,
                                        acco_type integer NOT NULL,

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/DefaultCompositeLeftJoinIQOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/DefaultCompositeLeftJoinIQOptimizer.java
@@ -8,6 +8,7 @@ import it.unibz.inf.ontop.iq.optimizer.LeftJoinIQOptimizer;
 import it.unibz.inf.ontop.iq.optimizer.impl.lj.CardinalityInsensitiveJoinTransferLJOptimizer;
 import it.unibz.inf.ontop.iq.optimizer.impl.lj.CardinalitySensitiveJoinTransferLJOptimizer;
 import it.unibz.inf.ontop.iq.optimizer.impl.lj.LJWithNestingOnRightToInnerJoinOptimizer;
+import it.unibz.inf.ontop.iq.optimizer.impl.lj.MergeLJOptimizer;
 
 public class DefaultCompositeLeftJoinIQOptimizer implements LeftJoinIQOptimizer {
 
@@ -17,11 +18,13 @@ public class DefaultCompositeLeftJoinIQOptimizer implements LeftJoinIQOptimizer 
     private DefaultCompositeLeftJoinIQOptimizer(
             CardinalitySensitiveJoinTransferLJOptimizer cardinalitySensitiveJoinTransferLJOptimizer,
             CardinalityInsensitiveJoinTransferLJOptimizer cardinalityInsensitiveJoinTransferLJOptimizer,
-            LJWithNestingOnRightToInnerJoinOptimizer ljWithNestingOnRightToInnerJoinOptimizer) {
+            LJWithNestingOnRightToInnerJoinOptimizer ljWithNestingOnRightToInnerJoinOptimizer,
+            MergeLJOptimizer mergeLJOptimizer) {
         this.optimizers = ImmutableList.of(
                 cardinalitySensitiveJoinTransferLJOptimizer,
                 cardinalityInsensitiveJoinTransferLJOptimizer,
-                ljWithNestingOnRightToInnerJoinOptimizer);
+                ljWithNestingOnRightToInnerJoinOptimizer,
+                mergeLJOptimizer);
 
     }
 

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/LJWithNestingOnRightToInnerJoinOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/LJWithNestingOnRightToInnerJoinOptimizer.java
@@ -3,6 +3,7 @@ package it.unibz.inf.ontop.iq.optimizer.impl.lj;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import it.unibz.inf.ontop.injection.CoreSingletons;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.BinaryNonCommutativeIQTree;
@@ -28,6 +29,7 @@ import java.util.Set;
  * Typical case optimized: self-left-join with LJ nesting on the right (and possibly on the left)
  *
  */
+@Singleton
 public class LJWithNestingOnRightToInnerJoinOptimizer implements LeftJoinIQOptimizer {
 
     private final RightProvenanceNormalizer rightProvenanceNormalizer;

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/MergeLJOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/MergeLJOptimizer.java
@@ -1,0 +1,175 @@
+package it.unibz.inf.ontop.iq.optimizer.impl.lj;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import it.unibz.inf.ontop.exception.MinorOntopInternalBugException;
+import it.unibz.inf.ontop.injection.CoreSingletons;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.BinaryNonCommutativeIQTree;
+import it.unibz.inf.ontop.iq.IQ;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.node.LeftJoinNode;
+import it.unibz.inf.ontop.iq.node.QueryNode;
+import it.unibz.inf.ontop.iq.node.normalization.impl.RightProvenanceNormalizer;
+import it.unibz.inf.ontop.iq.optimizer.LeftJoinIQOptimizer;
+import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeVisitingTransformer;
+import it.unibz.inf.ontop.model.atom.AtomFactory;
+import it.unibz.inf.ontop.model.atom.DistinctVariableOnlyDataAtom;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Tries to merge LJs nested on the left
+ *
+ */
+public class MergeLJOptimizer implements LeftJoinIQOptimizer {
+
+    private final RightProvenanceNormalizer rightProvenanceNormalizer;
+    private final CoreSingletons coreSingletons;
+    private final IntermediateQueryFactory iqFactory;
+    private final CardinalitySensitiveJoinTransferLJOptimizer otherLJOptimizer;
+
+    @Inject
+    protected MergeLJOptimizer(RightProvenanceNormalizer rightProvenanceNormalizer,
+                               CoreSingletons coreSingletons,
+                               CardinalitySensitiveJoinTransferLJOptimizer otherLJOptimizer) {
+        this.rightProvenanceNormalizer = rightProvenanceNormalizer;
+        this.coreSingletons = coreSingletons;
+        this.iqFactory = coreSingletons.getIQFactory();
+        this.otherLJOptimizer = otherLJOptimizer;
+    }
+
+    @Override
+    public IQ optimize(IQ query) {
+        IQTree initialTree = query.getTree();
+
+        Transformer transformer = new Transformer(
+                query.getVariableGenerator(),
+                rightProvenanceNormalizer,
+                coreSingletons,
+                otherLJOptimizer);
+
+        IQTree newTree = initialTree.acceptTransformer(transformer);
+
+        return newTree.equals(initialTree)
+                ? query
+                : iqFactory.createIQ(query.getProjectionAtom(), newTree);
+    }
+
+    protected static class Transformer extends DefaultRecursiveIQTreeVisitingTransformer {
+
+        private final VariableGenerator variableGenerator;
+        private final RightProvenanceNormalizer rightProvenanceNormalizer;
+        private final TermFactory termFactory;
+        private final CardinalitySensitiveJoinTransferLJOptimizer otherLJOptimizer;
+        private final AtomFactory atomFactory;
+
+        protected Transformer(VariableGenerator variableGenerator, RightProvenanceNormalizer rightProvenanceNormalizer,
+                              CoreSingletons coreSingletons, CardinalitySensitiveJoinTransferLJOptimizer otherLJOptimizer) {
+            super(coreSingletons);
+            this.variableGenerator = variableGenerator;
+            this.rightProvenanceNormalizer = rightProvenanceNormalizer;
+            this.termFactory = coreSingletons.getTermFactory();
+            this.otherLJOptimizer = otherLJOptimizer;
+            this.atomFactory = coreSingletons.getAtomFactory();
+        }
+
+        @Override
+        public IQTree transformLeftJoin(IQTree tree, LeftJoinNode rootNode, IQTree leftChild, IQTree rightChild) {
+            if (rootNode.getOptionalFilterCondition().isPresent())
+                return super.transformLeftJoin(tree, rootNode, leftChild, rightChild)
+                        .normalizeForOptimization(variableGenerator);
+
+            IQTree newLeftChild = transform(leftChild);
+            IQTree newRightChild = transform(rightChild);
+
+            Optional<IQTree> simplifiedTree = tryToSimplify(newLeftChild, newRightChild, new LinkedList<>());
+
+            return simplifiedTree
+                    .orElseGet(() -> newLeftChild.equals(leftChild) && newRightChild.equals(rightChild)
+                            ? tree
+                            : iqFactory.createBinaryNonCommutativeIQTree(rootNode, newLeftChild, newRightChild)
+                            .normalizeForOptimization(variableGenerator));
+        }
+
+        private Optional<IQTree> tryToSimplify(IQTree leftDescendent, IQTree rightChildToMerge, List<Ancestor> ancestors) {
+            QueryNode leftRootNode = leftDescendent.getRootNode();
+            if (!(leftRootNode instanceof LeftJoinNode))
+                return Optional.empty();
+
+            LeftJoinNode leftJoinNode = (LeftJoinNode) leftRootNode;
+            BinaryNonCommutativeIQTree leftJoinTree = (BinaryNonCommutativeIQTree) leftDescendent;
+            IQTree leftSubTree = leftJoinTree.getLeftChild();
+            IQTree rightSubTree = leftJoinTree.getRightChild();
+
+            // No optimization if outside the "well-designed fragment"
+            if (!Sets.intersection(
+                    Sets.difference(rightSubTree.getVariables(), leftSubTree.getVariables()),
+                    rightChildToMerge.getVariables()).isEmpty())
+                return Optional.empty();
+
+            /*
+             * If cannot be merged with this right child, continue the search on the left.
+             */
+            if (leftJoinNode.getOptionalFilterCondition().isPresent()
+                    || (!canBeMerged(rightSubTree, rightChildToMerge))) {
+              ancestors.add(0, new Ancestor(leftJoinNode, rightSubTree));
+              return tryToSimplify(leftSubTree, rightChildToMerge, ancestors);
+            }
+
+            IQTree newSubTree = iqFactory.createBinaryNonCommutativeIQTree(
+                    leftJoinNode,
+                    leftSubTree,
+                    iqFactory.createNaryIQTree(
+                            iqFactory.createInnerJoinNode(),
+                            ImmutableList.of(rightSubTree, rightChildToMerge)));
+
+            IQTree newTree = ancestors.stream()
+                    .reduce(newSubTree, (t, a) -> iqFactory.createBinaryNonCommutativeIQTree(a.rootNode, t, a.right),
+                            (t1, t2) -> {
+                                throw new MinorOntopInternalBugException("Parallelization is not supported here");
+                            });
+
+            return Optional.of(newTree);
+        }
+
+        private boolean canBeMerged(IQTree subRightChild, IQTree rightChildToMerge) {
+            return isTreeIncluded(subRightChild, rightChildToMerge) && isTreeIncluded(rightChildToMerge, subRightChild);
+        }
+
+        private boolean isTreeIncluded(IQTree tree, IQTree otherTree) {
+            RightProvenanceNormalizer.RightProvenance rightProvenance = rightProvenanceNormalizer.normalizeRightProvenance(
+                    otherTree, tree.getVariables(), Optional.empty(), variableGenerator);
+
+            IQTree minusTree = iqFactory.createUnaryIQTree(
+                    iqFactory.createFilterNode(termFactory.getDBIsNull(rightProvenance.getProvenanceVariable())),
+                    iqFactory.createBinaryNonCommutativeIQTree(
+                            iqFactory.createLeftJoinNode(),
+                            tree, rightProvenance.getRightTree()));
+
+            // Hack
+            DistinctVariableOnlyDataAtom minusFakeProjectionAtom = atomFactory.getDistinctVariableOnlyDataAtom(
+                    atomFactory.getRDFAnswerPredicate(minusTree.getVariables().size()),
+                    ImmutableList.copyOf(minusTree.getVariables()));
+
+            return otherLJOptimizer.optimize(iqFactory.createIQ(minusFakeProjectionAtom, minusTree))
+                    .normalizeForOptimization().getTree()
+                    .isDeclaredAsEmpty();
+        }
+    }
+
+    protected static class Ancestor {
+        public final LeftJoinNode rootNode;
+        public final IQTree right;
+
+        protected Ancestor(LeftJoinNode rootNode, IQTree right) {
+            this.rootNode = rootNode;
+            this.right = right;
+        }
+    }
+}

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/OptimizationTestingTools.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/OptimizationTestingTools.java
@@ -65,6 +65,7 @@ public class OptimizationTestingTools {
     public static final Variable C;
     public static final Variable CF0;
     public static final Variable D;
+    public static final Variable DF0;
     public static final Variable E;
     public static final Variable F;
     public static final Variable F0;
@@ -141,6 +142,7 @@ public class OptimizationTestingTools {
         C = TERM_FACTORY.getVariable("c");
         CF0 = TERM_FACTORY.getVariable("cf0");
         D = TERM_FACTORY.getVariable("d");
+        DF0 = TERM_FACTORY.getVariable("df0");
         E = TERM_FACTORY.getVariable("e");
         F = TERM_FACTORY.getVariable("f");
         F6 = TERM_FACTORY.getVariable("f6");

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/OptimizationTestingTools.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/OptimizationTestingTools.java
@@ -67,8 +67,11 @@ public class OptimizationTestingTools {
     public static final Variable D;
     public static final Variable DF0;
     public static final Variable DF1;
+    public static final Variable DF2;
     public static final Variable E;
+    public static final Variable EF1;
     public static final Variable F;
+    public static final Variable FF3;
     public static final Variable F0;
     public static final Variable F0F1;
     public static final Variable F1;
@@ -145,8 +148,11 @@ public class OptimizationTestingTools {
         D = TERM_FACTORY.getVariable("d");
         DF0 = TERM_FACTORY.getVariable("df0");
         DF1 = TERM_FACTORY.getVariable("df1");
+        DF2 = TERM_FACTORY.getVariable("df2");
         E = TERM_FACTORY.getVariable("e");
+        EF1 = TERM_FACTORY.getVariable("ef1");
         F = TERM_FACTORY.getVariable("f");
+        FF3 = TERM_FACTORY.getVariable("ff3");
         F6 = TERM_FACTORY.getVariable("f6");
         F0 = TERM_FACTORY.getVariable("f0");
         F0F1 = TERM_FACTORY.getVariable("f0f1");

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/OptimizationTestingTools.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/OptimizationTestingTools.java
@@ -66,6 +66,7 @@ public class OptimizationTestingTools {
     public static final Variable CF0;
     public static final Variable D;
     public static final Variable DF0;
+    public static final Variable DF1;
     public static final Variable E;
     public static final Variable F;
     public static final Variable F0;
@@ -143,6 +144,7 @@ public class OptimizationTestingTools {
         CF0 = TERM_FACTORY.getVariable("cf0");
         D = TERM_FACTORY.getVariable("d");
         DF0 = TERM_FACTORY.getVariable("df0");
+        DF1 = TERM_FACTORY.getVariable("df1");
         E = TERM_FACTORY.getVariable("e");
         F = TERM_FACTORY.getVariable("f");
         F6 = TERM_FACTORY.getVariable("f6");

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -2338,6 +2338,7 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
+    @Ignore("TODO: try to lift the condition")
     @Test
     public void testMergeLJs2() {
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -2365,7 +2365,7 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
-    @Ignore("TODO: try to lift the condition")
+    @Ignore("TODO: try to lift the implicit condition")
     @Test
     public void testMergeLJs2() {
 
@@ -2510,6 +2510,312 @@ public class LeftJoinOptimizationTest {
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
 
         optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testMergeLJs6() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(6), ImmutableList.of(A, B, C, D, E, F));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE4, ImmutableMap.of(0, A, 1, E));
+        ExtensionalDataNode dataNode4 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 2, D));
+        ExtensionalDataNode dataNode5 = IQ_FACTORY.createExtensionalDataNode(TABLE4, ImmutableMap.of(0, A, 2, F));
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, C, ONE)),
+                dataNode1,
+                IQ_FACTORY.createNaryIQTree(
+                        IQ_FACTORY.createInnerJoinNode(),
+                        ImmutableList.of(dataNode2, dataNode3)));
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, D, ONE)),
+                subLJTree,
+                IQ_FACTORY.createNaryIQTree(
+                        IQ_FACTORY.createInnerJoinNode(),
+                        ImmutableList.of(dataNode4, dataNode5)));
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        IQTree newRightChild = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createInnerJoinNode(),
+                ImmutableList.of(
+                        IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, CF0,2, DF2)),
+                        IQ_FACTORY.createExtensionalDataNode(TABLE4, ImmutableMap.of(0, A, 1, EF1,2, FF3))));
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                SUBSTITUTION_FACTORY.getSubstitution(
+                        C, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, CF0, ONE), CF0),
+                        E, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, CF0, ONE), EF1),
+                        D, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, DF2, ONE), DF2),
+                        F, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, DF2, ONE), FF3)));
+
+        IQTree newTree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                        dataNode1, newRightChild));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testMergeLJs7() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(5), ImmutableList.of(A, B, C, D, E));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, A, 2, E));
+        ExtensionalDataNode dataNode4 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 2, D));
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree midTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                subLJTree,
+                dataNode3);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                midTree,
+                dataNode4);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        ExtensionalDataNode newMergedDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, C,2, D));
+
+        IQTree newMidTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, newMergedDataNode);
+
+        BinaryNonCommutativeIQTree newTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                newMidTree,
+                dataNode3);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testMergeLJs8() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(5), ImmutableList.of(A, B, C, D, E));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 2, D));
+        ExtensionalDataNode dataNode4 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 3, E));
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree midTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, D, ONE)),
+                subLJTree,
+                dataNode3);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                midTree,
+                dataNode4);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, C,2, DF0, 3, E));
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                SUBSTITUTION_FACTORY.getSubstitution(D, TERM_FACTORY.getIfElseNull(
+                        TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, DF0, ONE),
+                        DF0)));
+
+        IQTree newTree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                        dataNode1, newRightDataNode));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Ignore("TODO: is it realistic? Shall we support it?")
+    @Test
+    public void testMergeLJs9() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(5), ImmutableList.of(A, B, C, D, E));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, A, 1, E, 2, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, A, 1, E,2, D));
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                subLJTree,
+                dataNode3);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, A, 1, E, 2, C));
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                SUBSTITUTION_FACTORY.getSubstitution(D, C));
+
+        IQTree newTree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                        dataNode1, newRightDataNode));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testMergeLJs10() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, A, 1, B, 2, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, A, 1, B,2, D));
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                subLJTree,
+                dataNode3);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, A, 1, B, 2, D));
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                SUBSTITUTION_FACTORY.getSubstitution(C, D));
+
+        IQTree newTree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                        dataNode1, newRightDataNode));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testMergeLJs11() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, ONE, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, ONE, 2, D));
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                subLJTree,
+                dataNode3);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, ONE, 1, C,2, D));
+
+        IQTree newTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, newRightDataNode);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testMergeLJs12() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(6), ImmutableList.of(A, B, C, D, E, F));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, A, 1, A, 2, E));
+        ExtensionalDataNode dataNode4 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 2, D));
+        ExtensionalDataNode dataNode5 = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, A, 1, A, 2, F));
+
+        var rightNestedLJ1 = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode2, dataNode3);
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, rightNestedLJ1);
+
+        var rightNestedLJ2 = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode4, dataNode5);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                subLJTree,
+                rightNestedLJ2);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        IQTree newRightTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, C,2, D)),
+                dataNode3);
+
+        IQTree topLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, newRightTree);
+
+        IQTree newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(), SUBSTITUTION_FACTORY.getSubstitution(F, E)),
+                topLJTree);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    /**
+     * FK is only one direction (no cycle)
+     */
+    @Test
+    public void testNonMergeLJs1() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE2, ImmutableMap.of(0, D, 1, A));
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                subLJTree,
+                dataNode3);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        optimizeAndCompare(initialIQ, initialIQ);
     }
 
 


### PR DESCRIPTION
In the absence of foreign keys (e.g. from the accommodation table and to lodging business table), often not all the left-joins can be eliminated. However, there is opportunity for their right children together.

Example of a SPARQL query:
```sparql
PREFIX schema: <http://schema.org/>

SELECT * WHERE {
 ?r a schema:Accommodation ; ?r schema:containedInPlace ?h .
 OPTIONAL {
     ?h schema:geo ?geo 
 }
 OPTIONAL {
    ?h schema:name ?name .
    FILTER (lang(?name) = 'it')
 }
}
```

At the algebraic level:
```
LJ NUM_LT(d,"1"^^LARGE_INT)
   LJ
      EXTENSIONAL TABLE1(0:a,2:b)
      EXTENSIONAL TABLE1A(0:a,1:c)
   EXTENSIONAL TABLE1A(0:a,2:d)
```
can be simplified as
```
CONSTRUCT [a, b, c, d] [injective d/IF_ELSE_NULL(NUM_LT(df0,"1"^^LARGE_INT),df0)]
   LJ
      EXTENSIONAL TABLE1(0:a,2:b)
      EXTENSIONAL TABLE1A(0:a,1:c,2:df0)
```
as the first column of `TABLE1A` is a primary key.

The current implementation is robust to left-join conditions but not yet to implicit conditions (e.g. constants in data nodes).

Combined with the existing optimisations (including #662), it is able to simplify
```
LJ
   LJ
      EXTENSIONAL TABLE1(0:a,2:b)
      LJ
         EXTENSIONAL TABLE1A(0:a,1:c)
         EXTENSIONAL TABLE3(0:a,1:a,2:e)
   LJ
      EXTENSIONAL TABLE1A(0:a,2:d)
      EXTENSIONAL TABLE3(0:a,1:a,2:f)
```
into 
```
CONSTRUCT [a, b, c, d, f, e] [f/e]
   LJ
      EXTENSIONAL TABLE1(0:a,2:b)
      LJ
         EXTENSIONAL TABLE1A(0:a,1:c,2:d)
         EXTENSIONAL TABLE3(0:a,1:a,2:e)
```
