### PR TITLE
Make right nested LJ reduction to inner join robust to explicit conditions

### DIFF
--- a/binding/owlapi/src/test/resources/marriage/create-db.sql
+++ b/binding/owlapi/src/test/resources/marriage/create-db.sql
@@ -1,7 +1,7 @@
 CREATE TABLE "person" (
 "id" INT NOT NULL PRIMARY KEY,
-"first_name" VARCHAR(40),
-"last_name" VARCHAR(40),
+"first_name" VARCHAR(40) NULL,
+"last_name" VARCHAR(40) NOT NULL,
 "spouse" INT
 );
 

--- a/binding/rdf4j/src/test/resources/destination/schema.sql
+++ b/binding/rdf4j/src/test/resources/destination/schema.sql
@@ -40,7 +40,7 @@ CREATE TABLE "source1_rooms" (
                                capacity integer NULL,
                                description_de text NULL,
                                description_it text NULL,
-                               h_id text NOT NULL
+                               h_id text NULL
 );
 
 CREATE TABLE "source2_hotels" (

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
@@ -389,12 +389,22 @@ public class LeftJoinNodeImpl extends JoinLikeNodeImpl implements LeftJoinNode {
         return iqFactory.createBinaryNonCommutativeIQTree(this, newLeftChild, newRightChild, newTreeCache);
     }
 
-    /**
-     * TODO: implement it seriously
-     */
     @Override
     public ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(IQTree leftChild, IQTree rightChild) {
-        return ImmutableSet.of();
+        var leftChildConstraints = leftChild.inferUniqueConstraints();
+        if (leftChildConstraints.isEmpty())
+            return ImmutableSet.of();
+
+        var rightChildConstraints = rightChild.inferUniqueConstraints();
+        if (rightChildConstraints.isEmpty())
+            return ImmutableSet.of();
+
+        var commonVariables = Sets.intersection(leftChild.getVariables(), rightChild.getVariables());
+
+        if (commonVariables.isEmpty() || rightChildConstraints.stream().noneMatch(commonVariables::containsAll))
+            return ImmutableSet.of();
+
+        return leftChildConstraints;
     }
 
     @Override

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/LeftJoinAnalysisTools.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/LeftJoinAnalysisTools.java
@@ -1,0 +1,19 @@
+package it.unibz.inf.ontop.iq.optimizer.impl.lj;
+
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.model.term.ImmutableExpression;
+
+import java.util.Optional;
+
+public class LeftJoinAnalysisTools {
+
+    /**
+     * A LJ condition can be handled if it can safely be lifting, which requires that the LJ operates over a
+     * unique constraint on the right side
+     */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public static boolean tolerateLJConditionLifting(Optional<ImmutableExpression> optionalLJCondition, IQTree leftChild, IQTree rightChild) {
+        return optionalLJCondition.isEmpty() || rightChild.inferUniqueConstraints().stream()
+                .anyMatch(uc -> leftChild.getVariables().containsAll(uc));
+    }
+}

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -2283,11 +2283,11 @@ public class LeftJoinOptimizationTest {
         ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, D));
 
         IQTree rightTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
-                IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, C, TWO)),
+                IQ_FACTORY.createLeftJoinNode(),
                 dataNode2, dataNode3);
 
         BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
-                IQ_FACTORY.createLeftJoinNode(),
+                IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, C, TWO)),
                 dataNode1,
                 rightTree);
 
@@ -2301,6 +2301,39 @@ public class LeftJoinOptimizationTest {
                                 TERM_FACTORY.getIfElseNull(
                                         TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, CF0, TWO), CF0))),
                 IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(), newDataNode, dataNode3));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testLJReductionWithLJOnTheRight8() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, C));
+
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, D));
+
+        ImmutableExpression condition = TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, C, TWO);
+
+        IQTree rightTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(condition),
+                dataNode2, dataNode3);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                rightTree);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, C,2, B));
+
+        IQTree newTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(condition), newDataNode, dataNode3);
 
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -22,10 +22,6 @@ import org.junit.Test;
 import static it.unibz.inf.ontop.OptimizationTestingTools.*;
 import static org.junit.Assert.assertEquals;
 
-/**
- * TODO: explain
- */
-
 public class LeftJoinOptimizationTest {
 
     private final static NamedRelationDefinition TABLE1;
@@ -1468,9 +1464,6 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, initialIQ);
     }
 
-    /**
-     * TODO: remove the top distinct in the expected query
-     */
     @Test
     public void testJoinTransferFD1() {
 
@@ -1503,7 +1496,6 @@ public class LeftJoinOptimizationTest {
         ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
                 SUBSTITUTION_FACTORY.getSubstitution(B, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(C), BF0)));
 
-        // TODO: get rid of the distinct here
         UnaryIQTree newTree = IQ_FACTORY.createUnaryIQTree(distinctNode,
                 IQ_FACTORY.createUnaryIQTree(constructionNode, newLeftJoinTree));
 
@@ -1537,9 +1529,6 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
-    /**
-     * TODO: remove the top distinct in the expected query
-     */
     @Test
     public void testJoinTransferFD3() {
 
@@ -1583,9 +1572,6 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
-    /**
-     * TODO: remove the top distinct in the expected query
-     */
     @Test
     public void testJoinTransferFD4() {
 
@@ -1679,9 +1665,6 @@ public class LeftJoinOptimizationTest {
     }
 
 
-    /**
-     * TODO: remove the top distinct in the expected query
-     */
     @Test
     public void testJoinTransferFD6() {
 
@@ -1721,7 +1704,6 @@ public class LeftJoinOptimizationTest {
         ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
                 SUBSTITUTION_FACTORY.getSubstitution(B, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(C), BF0)));
 
-        // TODO: get rid of the distinct here
         UnaryIQTree newTree = IQ_FACTORY.createUnaryIQTree(distinctNode,
                 IQ_FACTORY.createUnaryIQTree(constructionNode, newLeftJoinTree));
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -1474,9 +1474,9 @@ public class LeftJoinOptimizationTest {
     @Test
     public void testJoinTransferFD1() {
 
-        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, B, C));
 
-        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE21, ImmutableMap.of(0, D, 1, A));
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE21, ImmutableMap.of(1, A));
         ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE21, ImmutableMap.of(1, A,2, B));
         ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, B,1, C));
 
@@ -1493,7 +1493,7 @@ public class LeftJoinOptimizationTest {
 
         IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(distinctNode, leftJoinTree));
 
-        ExtensionalDataNode dataNode4 = IQ_FACTORY.createExtensionalDataNode(TABLE21, ImmutableMap.of(0, D, 1, A, 2, BF0));
+        ExtensionalDataNode dataNode4 = IQ_FACTORY.createExtensionalDataNode(TABLE21, ImmutableMap.of(1, A, 2, BF0));
         ExtensionalDataNode dataNode5 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, BF0,1, C));
 
         BinaryNonCommutativeIQTree newLeftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
@@ -1576,9 +1576,7 @@ public class LeftJoinOptimizationTest {
         ConstructionNode newConstructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
                 SUBSTITUTION_FACTORY.getSubstitution(B, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(C), BF0)));
 
-        // TODO: get rid of the distinct here
-        UnaryIQTree newTree = IQ_FACTORY.createUnaryIQTree(distinctNode,
-                IQ_FACTORY.createUnaryIQTree(newConstructionNode, newLeftJoinTree));
+        IQTree newTree = IQ_FACTORY.createUnaryIQTree(newConstructionNode, newLeftJoinTree);
 
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
 
@@ -1624,10 +1622,8 @@ public class LeftJoinOptimizationTest {
         ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
                 SUBSTITUTION_FACTORY.getSubstitution(B, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(C), BF0)));
 
-        // TODO: get rid of the distinct here
-        UnaryIQTree newTree = IQ_FACTORY.createUnaryIQTree(distinctNode,
-                IQ_FACTORY.createUnaryIQTree(constructionNode,
-                        IQ_FACTORY.createUnaryIQTree(filterNode, newLeftJoinTree)));
+        IQTree newTree = IQ_FACTORY.createUnaryIQTree(constructionNode,
+                        IQ_FACTORY.createUnaryIQTree(filterNode, newLeftJoinTree));
 
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
 
@@ -2294,13 +2290,16 @@ public class LeftJoinOptimizationTest {
         IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
 
         ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, CF0,2, B));
+        ExtensionalDataNode newDataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, DF1));
 
         IQTree newTree = IQ_FACTORY.createUnaryIQTree(
                 IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
-                        SUBSTITUTION_FACTORY.getSubstitution(C,
-                                TERM_FACTORY.getIfElseNull(
-                                        TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, CF0, TWO), CF0))),
-                IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(), newDataNode, dataNode3));
+                        SUBSTITUTION_FACTORY.getSubstitution(
+                                C, TERM_FACTORY.getIfElseNull(
+                                        TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, CF0, TWO), CF0),
+                                D, TERM_FACTORY.getIfElseNull(
+                                        TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, CF0, TWO), DF1))),
+                IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(), newDataNode, newDataNode3));
 
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
 
@@ -2341,7 +2340,7 @@ public class LeftJoinOptimizationTest {
     }
 
     @Test
-    public void testNonLJReductionWithLJOnTheRight1() {
+    public void testLJReductionWithLJOnTheRight9() {
 
         DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
                 ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
@@ -2367,12 +2366,23 @@ public class LeftJoinOptimizationTest {
 
         IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
 
-        BinaryNonCommutativeIQTree newTopTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
-                IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getStrictEquality(B, concat)),
-                dataNode1,
-                rightLeftJoin);
+        ExtensionalDataNode newDataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, CF0, 2, B));
+        ExtensionalDataNode newDataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, DF1));
 
-        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTopTree);
+        BinaryNonCommutativeIQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                newDataNode1,
+                newDataNode3);
+
+        ImmutableExpression condition = TERM_FACTORY.getStrictEquality(B, TERM_FACTORY.getNullRejectingDBConcatFunctionalTerm(ImmutableList.of(CF0, CF0)));
+
+        ConstructionNode topConstruction = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                SUBSTITUTION_FACTORY.getSubstitution(
+                        C, TERM_FACTORY.getIfElseNull(condition, CF0),
+                        D, TERM_FACTORY.getIfElseNull(condition, DF1)));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom,
+                IQ_FACTORY.createUnaryIQTree(topConstruction, newLJTree));
 
         optimizeAndCompare(initialIQ, expectedIQ);
     }
@@ -2382,7 +2392,7 @@ public class LeftJoinOptimizationTest {
      * At the moment, is here to prevent incorrect optimizations.
      */
     @Test
-    public void testNonLJReductionWithLJOnTheRight2() {
+    public void testNonLJReductionWithLJOnTheRight1() {
 
         DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, B, C));
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -2272,6 +2272,42 @@ public class LeftJoinOptimizationTest {
     }
 
     @Test
+    public void testLJReductionWithLJOnTheRight7() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, C));
+
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, D));
+
+        IQTree rightTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, C, TWO)),
+                dataNode2, dataNode3);
+
+        BinaryNonCommutativeIQTree topTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                rightTree);
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, topTree);
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, CF0,2, B));
+
+        IQTree newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(C,
+                                TERM_FACTORY.getIfElseNull(
+                                        TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, CF0, TWO), CF0))),
+                IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(), newDataNode, dataNode3));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
     public void testNonLJReductionWithLJOnTheRight1() {
 
         DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(


### PR DESCRIPTION
Improves #662 by applying the optimisation in the presence of a left-join condition if some additional criteria are satisfied.

Makes it in particular more robust to the presence of `IS_NOT_NULL` conditions due to nullable columns.

At this occasion, `LeftJoinNode.inferUniqueConstraints()` has been properly implemented, which allowed to further simplify existing unit tests.