### PR TITLE
Added support for additional input file for facts

### DIFF
--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/AbstractOWLAPITest.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/AbstractOWLAPITest.java
@@ -52,8 +52,14 @@ public class AbstractOWLAPITest {
         initOBDA(createDbFile, obdaFile, ontologyFile, propertiesFile, null);
     }
 
+    protected static void initOBDA(String createDbFile, String obdaFile, @Nullable String ontologyFile, @Nullable String propertiesFile,
+                                   @Nullable String factsFile)
+            throws SQLException, IOException {
+        initOBDA(createDbFile, obdaFile, ontologyFile, propertiesFile, factsFile, null);
+    }
+
     protected static void initOBDA(String createDbFile, String obdaFile, @Nullable String ontologyFile,
-                                   @Nullable String propertiesFile, @Nullable String factsFile)
+                                   @Nullable String propertiesFile, @Nullable String factsFile, @Nullable String factsBaseURI)
             throws SQLException, IOException {
         String jdbcUrl = URL_PREFIX + UUID.randomUUID();
 
@@ -72,6 +78,9 @@ public class AbstractOWLAPITest {
 
         if (factsFile != null)
             builder.factsFile(AbstractOWLAPITest.class.getResource(factsFile).getPath());
+
+        if (factsBaseURI != null)
+            builder.factsBaseURI(factsBaseURI);
 
         if (propertiesFile != null)
             builder.propertyFile(AbstractOWLAPITest.class.getResource(propertiesFile).getPath());

--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/AbstractOWLAPITest.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/AbstractOWLAPITest.java
@@ -59,7 +59,7 @@ public class AbstractOWLAPITest {
     }
 
     protected static void initOBDA(String createDbFile, String obdaFile, @Nullable String ontologyFile,
-                                   @Nullable String propertiesFile, @Nullable String factsFile, @Nullable String factsBaseURI)
+                                   @Nullable String propertiesFile, @Nullable String factsFile, @Nullable String factsBaseIRI)
             throws SQLException, IOException {
         String jdbcUrl = URL_PREFIX + UUID.randomUUID();
 
@@ -79,8 +79,8 @@ public class AbstractOWLAPITest {
         if (factsFile != null)
             builder.factsFile(AbstractOWLAPITest.class.getResource(factsFile).getPath());
 
-        if (factsBaseURI != null)
-            builder.factsBaseURI(factsBaseURI);
+        if (factsBaseIRI != null)
+            builder.factsBaseIRI(factsBaseIRI);
 
         if (propertiesFile != null)
             builder.propertyFile(AbstractOWLAPITest.class.getResource(propertiesFile).getPath());

--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/AbstractOWLAPITest.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/AbstractOWLAPITest.java
@@ -47,8 +47,13 @@ public class AbstractOWLAPITest {
         initOBDA(createDbFile, obdaFile, ontologyFile, null);
     }
 
+    protected static void initOBDA(String createDbFile, String obdaFile, @Nullable String ontologyFile, @Nullable String propertiesFile)
+            throws SQLException, IOException {
+        initOBDA(createDbFile, obdaFile, ontologyFile, propertiesFile, null);
+    }
+
     protected static void initOBDA(String createDbFile, String obdaFile, @Nullable String ontologyFile,
-                                   @Nullable String propertiesFile)
+                                   @Nullable String propertiesFile, @Nullable String factsFile)
             throws SQLException, IOException {
         String jdbcUrl = URL_PREFIX + UUID.randomUUID();
 
@@ -64,6 +69,9 @@ public class AbstractOWLAPITest {
 
         if (ontologyFile != null)
             builder.ontologyFile(AbstractOWLAPITest.class.getResource(ontologyFile).getPath());
+
+        if (factsFile != null)
+            builder.factsFile(AbstractOWLAPITest.class.getResource(factsFile).getPath());
 
         if (propertiesFile != null)
             builder.propertyFile(AbstractOWLAPITest.class.getResource(propertiesFile).getPath());

--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTest.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTest.java
@@ -1,0 +1,46 @@
+package it.unibz.inf.ontop.owlapi;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/***
+ * A test querying triples provided by an external "facts" file.
+ */
+public class FactsFileTest extends AbstractOWLAPITest {
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		initOBDA("/facts/facts-h2.sql",
+				"/facts/mapping.obda",
+				"/facts/ontology.ttl",
+				null,
+				"/facts/facts.ttl");
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		release();
+	}
+
+	@Test
+	public void testFactsIncluded() throws Exception {
+		String query = "PREFIX owl: <http://www.w3.org/2002/07/owl#>\n" +
+				"PREFIX beam:   <https://data.beamery.com/ontologies/talent#>\n" +
+				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n" +
+				"PREFIX dct:    <http://purl.org/dc/terms/>\n" +
+				"PREFIX schema: <https://schema.org/>\n" +
+				"PREFIX : <http://www.semanticweb.org/ontop-facts#>\n" +
+				"\n" +
+				"SELECT DISTINCT * WHERE {\n" +
+				"  ?c a :Company .\n" +
+				"  ?c :name ?v.\n" +
+				"} ORDER BY ?v\n";
+
+		checkReturnedValues(query, "v", ImmutableList.of(
+				"\"Big Company\"^^xsd:string",
+				"\"Some Factory\"^^xsd:string",
+				"\"The Fact Company\"^^xsd:string"));
+	}
+}

--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTest.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTest.java
@@ -5,18 +5,29 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
+
 /***
  * A test querying triples provided by an external "facts" file.
  */
-public class FactsFileTestNQuads extends FactsFileTest {
+public abstract class FactsFileTest extends AbstractOWLAPITest {
 
-	@BeforeClass
-	public static void setUp() throws Exception {
-		init("/facts/facts.nq", null);
+	@AfterClass
+	public static void tearDown() throws Exception {
+		release();
+	}
+
+	protected static void init(@Nullable String factsFile, @Nullable String factsBaseIRI) throws Exception {
+		initOBDA("/facts/facts-h2.sql",
+				"/facts/mapping.obda",
+				"/facts/ontology.ttl",
+				null,
+				factsFile,
+				factsBaseIRI);
 	}
 
 	@Test
-	public void testSubgraph() throws Exception {
+	public void testFactsIncluded() throws Exception {
 		String query = "PREFIX owl: <http://www.w3.org/2002/07/owl#>\n" +
 				"PREFIX beam:   <https://data.beamery.com/ontologies/talent#>\n" +
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n" +
@@ -25,10 +36,13 @@ public class FactsFileTestNQuads extends FactsFileTest {
 				"PREFIX : <http://www.semanticweb.org/ontop-facts#>\n" +
 				"\n" +
 				"SELECT DISTINCT * WHERE {\n" +
-				"  GRAPH :extra { ?s ?p ?v . } \n" +
+				"  ?c a :Company .\n" +
+				"  ?c :name ?v.\n" +
 				"} ORDER BY ?v\n";
 
 		checkReturnedValues(query, "v", ImmutableList.of(
-				"\"2022\"^^xsd:integer"));
+				"\"Big Company\"^^xsd:string",
+				"\"Some Factory\"^^xsd:string",
+				"\"The Fact Company\"^^xsd:string"));
 	}
 }

--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTestNQuads.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTestNQuads.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 /***
  * A test querying triples provided by an external "facts" file.
  */
-public class FactsFileTest extends AbstractOWLAPITest {
+public class FactsFileTestNQuads extends AbstractOWLAPITest {
 
 	@BeforeClass
 	public static void setUp() throws Exception {
@@ -16,7 +16,7 @@ public class FactsFileTest extends AbstractOWLAPITest {
 				"/facts/mapping.obda",
 				"/facts/ontology.ttl",
 				null,
-				"/facts/facts.ttl");
+				"/facts/facts.nq");
 	}
 
 	@AfterClass
@@ -26,13 +26,7 @@ public class FactsFileTest extends AbstractOWLAPITest {
 
 	@Test
 	public void testFactsIncluded() throws Exception {
-		String query = "PREFIX owl: <http://www.w3.org/2002/07/owl#>\n" +
-				"PREFIX beam:   <https://data.beamery.com/ontologies/talent#>\n" +
-				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n" +
-				"PREFIX dct:    <http://purl.org/dc/terms/>\n" +
-				"PREFIX schema: <https://schema.org/>\n" +
-				"PREFIX : <http://www.semanticweb.org/ontop-facts#>\n" +
-				"\n" +
+		String query = "PREFIX : <http://www.semanticweb.org/ontop-facts#>\n" +
 				"SELECT DISTINCT * WHERE {\n" +
 				"  ?c a :Company .\n" +
 				"  ?c :name ?v.\n" +
@@ -42,5 +36,22 @@ public class FactsFileTest extends AbstractOWLAPITest {
 				"\"Big Company\"^^xsd:string",
 				"\"Some Factory\"^^xsd:string",
 				"\"The Fact Company\"^^xsd:string"));
+	}
+
+	@Test
+	public void testSubgraph() throws Exception {
+		String query = "PREFIX owl: <http://www.w3.org/2002/07/owl#>\n" +
+				"PREFIX beam:   <https://data.beamery.com/ontologies/talent#>\n" +
+				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n" +
+				"PREFIX dct:    <http://purl.org/dc/terms/>\n" +
+				"PREFIX schema: <https://schema.org/>\n" +
+				"PREFIX : <http://www.semanticweb.org/ontop-facts#>\n" +
+				"\n" +
+				"SELECT DISTINCT * WHERE {\n" +
+				"  GRAPH :extra { ?s ?p ?v . } \n" +
+				"} ORDER BY ?v\n";
+
+		checkReturnedValues(query, "v", ImmutableList.of(
+				"\"2022\"^^xsd:integer"));
 	}
 }

--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTestRDF.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTestRDF.java
@@ -1,0 +1,48 @@
+package it.unibz.inf.ontop.owlapi;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/***
+ * A test querying triples provided by an external "facts" file.
+ */
+public class FactsFileTestRDF extends AbstractOWLAPITest {
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		initOBDA("/facts/facts-h2.sql",
+				"/facts/mapping.obda",
+				"/facts/ontology.ttl",
+				null,
+				"/facts/facts.rdf",
+				"http://ontop-vkg.org/facts#");
+
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		release();
+	}
+
+	@Test
+	public void testFactsIncluded() throws Exception {
+		String query = "PREFIX owl: <http://www.w3.org/2002/07/owl#>\n" +
+				"PREFIX beam:   <https://data.beamery.com/ontologies/talent#>\n" +
+				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n" +
+				"PREFIX dct:    <http://purl.org/dc/terms/>\n" +
+				"PREFIX schema: <https://schema.org/>\n" +
+				"PREFIX : <http://www.semanticweb.org/ontop-facts#>\n" +
+				"\n" +
+				"SELECT DISTINCT * WHERE {\n" +
+				"  ?c a :Company .\n" +
+				"  ?c :name ?v.\n" +
+				"} ORDER BY ?v\n";
+
+		checkReturnedValues(query, "v", ImmutableList.of(
+				"\"Big Company\"^^xsd:string",
+				"\"Some Factory\"^^xsd:string",
+				"\"The Fact Company\"^^xsd:string"));
+	}
+}

--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTestRDF.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTestRDF.java
@@ -8,41 +8,11 @@ import org.junit.Test;
 /***
  * A test querying triples provided by an external "facts" file.
  */
-public class FactsFileTestRDF extends AbstractOWLAPITest {
+public class FactsFileTestRDF extends FactsFileTest {
 
 	@BeforeClass
 	public static void setUp() throws Exception {
-		initOBDA("/facts/facts-h2.sql",
-				"/facts/mapping.obda",
-				"/facts/ontology.ttl",
-				null,
-				"/facts/facts.rdf",
-				"http://ontop-vkg.org/facts#");
-
+		init("/facts/facts.rdf", "http://ontop-vkg.org/facts#");
 	}
 
-	@AfterClass
-	public static void tearDown() throws Exception {
-		release();
-	}
-
-	@Test
-	public void testFactsIncluded() throws Exception {
-		String query = "PREFIX owl: <http://www.w3.org/2002/07/owl#>\n" +
-				"PREFIX beam:   <https://data.beamery.com/ontologies/talent#>\n" +
-				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n" +
-				"PREFIX dct:    <http://purl.org/dc/terms/>\n" +
-				"PREFIX schema: <https://schema.org/>\n" +
-				"PREFIX : <http://www.semanticweb.org/ontop-facts#>\n" +
-				"\n" +
-				"SELECT DISTINCT * WHERE {\n" +
-				"  ?c a :Company .\n" +
-				"  ?c :name ?v.\n" +
-				"} ORDER BY ?v\n";
-
-		checkReturnedValues(query, "v", ImmutableList.of(
-				"\"Big Company\"^^xsd:string",
-				"\"Some Factory\"^^xsd:string",
-				"\"The Fact Company\"^^xsd:string"));
-	}
 }

--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTestTurtle.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTestTurtle.java
@@ -1,0 +1,46 @@
+package it.unibz.inf.ontop.owlapi;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/***
+ * A test querying triples provided by an external "facts" file.
+ */
+public class FactsFileTestTurtle extends AbstractOWLAPITest {
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		initOBDA("/facts/facts-h2.sql",
+				"/facts/mapping.obda",
+				"/facts/ontology.ttl",
+				null,
+				"/facts/facts.ttl");
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		release();
+	}
+
+	@Test
+	public void testFactsIncluded() throws Exception {
+		String query = "PREFIX owl: <http://www.w3.org/2002/07/owl#>\n" +
+				"PREFIX beam:   <https://data.beamery.com/ontologies/talent#>\n" +
+				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n" +
+				"PREFIX dct:    <http://purl.org/dc/terms/>\n" +
+				"PREFIX schema: <https://schema.org/>\n" +
+				"PREFIX : <http://www.semanticweb.org/ontop-facts#>\n" +
+				"\n" +
+				"SELECT DISTINCT * WHERE {\n" +
+				"  ?c a :Company .\n" +
+				"  ?c :name ?v.\n" +
+				"} ORDER BY ?v\n";
+
+		checkReturnedValues(query, "v", ImmutableList.of(
+				"\"Big Company\"^^xsd:string",
+				"\"Some Factory\"^^xsd:string",
+				"\"The Fact Company\"^^xsd:string"));
+	}
+}

--- a/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTestTurtle.java
+++ b/binding/owlapi/src/test/java/it/unibz/inf/ontop/owlapi/FactsFileTestTurtle.java
@@ -8,39 +8,10 @@ import org.junit.Test;
 /***
  * A test querying triples provided by an external "facts" file.
  */
-public class FactsFileTestTurtle extends AbstractOWLAPITest {
+public class FactsFileTestTurtle extends FactsFileTest {
 
 	@BeforeClass
 	public static void setUp() throws Exception {
-		initOBDA("/facts/facts-h2.sql",
-				"/facts/mapping.obda",
-				"/facts/ontology.ttl",
-				null,
-				"/facts/facts.ttl");
-	}
-
-	@AfterClass
-	public static void tearDown() throws Exception {
-		release();
-	}
-
-	@Test
-	public void testFactsIncluded() throws Exception {
-		String query = "PREFIX owl: <http://www.w3.org/2002/07/owl#>\n" +
-				"PREFIX beam:   <https://data.beamery.com/ontologies/talent#>\n" +
-				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n" +
-				"PREFIX dct:    <http://purl.org/dc/terms/>\n" +
-				"PREFIX schema: <https://schema.org/>\n" +
-				"PREFIX : <http://www.semanticweb.org/ontop-facts#>\n" +
-				"\n" +
-				"SELECT DISTINCT * WHERE {\n" +
-				"  ?c a :Company .\n" +
-				"  ?c :name ?v.\n" +
-				"} ORDER BY ?v\n";
-
-		checkReturnedValues(query, "v", ImmutableList.of(
-				"\"Big Company\"^^xsd:string",
-				"\"Some Factory\"^^xsd:string",
-				"\"The Fact Company\"^^xsd:string"));
+		init("/facts/facts.ttl", null);
 	}
 }

--- a/binding/owlapi/src/test/resources/facts/facts-h2.sql
+++ b/binding/owlapi/src/test/resources/facts/facts-h2.sql
@@ -1,0 +1,13 @@
+CREATE TABLE company (
+    id integer NOT NULL,
+    name character varying(100),
+    founding_year integer
+);
+
+INSERT INTO company VALUES (1, 'Big Company', 2013);
+INSERT INTO company VALUES (2, 'Some Factory', 1970);
+
+
+ALTER TABLE company
+    ADD CONSTRAINT company_pkey PRIMARY KEY (id);
+

--- a/binding/owlapi/src/test/resources/facts/facts.nq
+++ b/binding/owlapi/src/test/resources/facts/facts.nq
@@ -1,0 +1,4 @@
+<http://www.semanticweb.org/ontop-facts#factCompany> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.semanticweb.org/ontop-facts#Company> .
+<http://www.semanticweb.org/ontop-facts#factCompany> <http://www.semanticweb.org/ontop-facts#id> "3"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://www.semanticweb.org/ontop-facts#factCompany> <http://www.semanticweb.org/ontop-facts#foundingYear> "2022"^^<http://www.w3.org/2001/XMLSchema#integer> <http://www.semanticweb.org/ontop-facts#extra>.
+<http://www.semanticweb.org/ontop-facts#factCompany> <http://www.semanticweb.org/ontop-facts#name> "The Fact Company"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/binding/owlapi/src/test/resources/facts/facts.rdf
+++ b/binding/owlapi/src/test/resources/facts/facts.rdf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.semanticweb.org/ontop-facts#">
+
+    <rdf:Description rdf:about="http://www.semanticweb.org/ontop-facts#factCompany">
+        <rdf:type rdf:resource="http://www.semanticweb.org/ontop-facts#Company"/>
+        <ns0:id rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</ns0:id>
+        <ns0:foundingYear rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2022</ns0:foundingYear>
+        <ns0:name rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The Fact Company</ns0:name>
+    </rdf:Description>
+
+</rdf:RDF>

--- a/binding/owlapi/src/test/resources/facts/facts.ttl
+++ b/binding/owlapi/src/test/resources/facts/facts.ttl
@@ -1,0 +1,11 @@
+@prefix : <http://www.semanticweb.org/ontop-facts#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:factCompany a :Company ;
+    :id "3"^^xsd:integer ;
+    :foundingYear "2022"^^xsd:integer ;
+    :name "The Fact Company"^^xsd:string .

--- a/binding/owlapi/src/test/resources/facts/mapping.obda
+++ b/binding/owlapi/src/test/resources/facts/mapping.obda
@@ -1,0 +1,15 @@
+[PrefixDeclaration]
+:		http://www.semanticweb.org/ontop-facts#
+owl:		http://www.w3.org/2002/07/owl#
+rdf:		http://www.w3.org/1999/02/22-rdf-syntax-ns#
+xml:		http://www.w3.org/XML/1998/namespace
+xsd:		http://www.w3.org/2001/XMLSchema#
+rdfs:		http://www.w3.org/2000/01/rdf-schema#
+
+[MappingDeclaration] @collection [[
+mappingId	Companies
+target		:Company/{id} a :Company ; :id {id} ; :foundingYear {founding_year} ; :name {name} .
+source		SELECT id, founding_year, name FROM company;
+
+]]
+

--- a/binding/owlapi/src/test/resources/facts/ontology.ttl
+++ b/binding/owlapi/src/test/resources/facts/ontology.ttl
@@ -1,0 +1,15 @@
+@prefix : <http://www.semanticweb.org/ontop-facts#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:foundingYear rdf:type owl:DatatypeProperty ;
+      rdfs:range xsd:integer .
+:id rdf:type owl:DatatypeProperty ;
+      rdfs:range xsd:integer .
+:name rdf:type owl:DatatypeProperty ;
+      rdfs:range xsd:string .
+
+:Company rdf:type owl:Class .

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopEndpoint.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopEndpoint.java
@@ -91,7 +91,7 @@ public class OntopEndpoint extends OntopMappingOntologyRelatedCommand {
             argList.add("--fact-format=" + this.factFormat.getExtension());
 
         if (this.factsBaseIRI != null)
-            argList.add("--facts-base-uri=" + this.factsBaseIRI);
+            argList.add("--facts-base-iri=" + this.factsBaseIRI);
 
         if (this.xmlCatalogFile != null)
             argList.add("--xml-catalog=" + this.xmlCatalogFile);

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopEndpoint.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopEndpoint.java
@@ -90,8 +90,8 @@ public class OntopEndpoint extends OntopMappingOntologyRelatedCommand {
         if (this.factFormat != null)
             argList.add("--fact-format=" + this.factFormat.getExtension());
 
-        if (this.factsBaseURI != null)
-            argList.add("--facts-base-uri=" + this.factsBaseURI);
+        if (this.factsBaseIRI != null)
+            argList.add("--facts-base-uri=" + this.factsBaseIRI);
 
         if (this.xmlCatalogFile != null)
             argList.add("--xml-catalog=" + this.xmlCatalogFile);

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopEndpoint.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopEndpoint.java
@@ -84,6 +84,9 @@ public class OntopEndpoint extends OntopMappingOntologyRelatedCommand {
         if (this.owlFile != null)
             argList.add("--ontology=" + this.owlFile);
 
+        if (this.factFile != null)
+            argList.add("--facts=" + this.factFile);
+
         if (this.xmlCatalogFile != null)
             argList.add("--xml-catalog=" + this.xmlCatalogFile);
 

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopEndpoint.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopEndpoint.java
@@ -87,6 +87,12 @@ public class OntopEndpoint extends OntopMappingOntologyRelatedCommand {
         if (this.factFile != null)
             argList.add("--facts=" + this.factFile);
 
+        if (this.factFormat != null)
+            argList.add("--fact-format=" + this.factFormat.getExtension());
+
+        if (this.factsBaseURI != null)
+            argList.add("--facts-base-uri=" + this.factsBaseURI);
+
         if (this.xmlCatalogFile != null)
             argList.add("--xml-catalog=" + this.xmlCatalogFile);
 

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMappingOntologyRelatedCommand.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMappingOntologyRelatedCommand.java
@@ -14,6 +14,11 @@ abstract class OntopMappingOntologyRelatedCommand extends AbstractOntopCommand i
     @BashCompletion(behaviour = CompletionBehaviour.FILENAMES)
     String owlFile;
 
+    @Option(type = OptionType.COMMAND, name = {"-a", "--facts"}, title = "fact file",
+            description = "RDF fact file")
+    @BashCompletion(behaviour = CompletionBehaviour.FILENAMES)
+    String factFile;
+
     @Option(type = OptionType.COMMAND, name = {"-m", "--mapping"}, title = "mapping file",
             description = "Mapping file in R2RML (.ttl) or in Ontop native format (.obda)")
     @Required

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMappingOntologyRelatedCommand.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMappingOntologyRelatedCommand.java
@@ -25,8 +25,8 @@ abstract class OntopMappingOntologyRelatedCommand extends AbstractOntopCommand i
     @AllowedEnumValues(RDFFormatTypes.class)
     RDFFormatTypes factFormat;
 
-    @Option(type = OptionType.COMMAND, name = {"--facts-base-uri"}, title = "base URI of facts in fact file",
-            description = "The base URI of facts in the fact file to resolve relative URIs.")
+    @Option(type = OptionType.COMMAND, name = {"--facts-base-iri"}, title = "base IRI of facts in fact file",
+            description = "The base IRI of facts in the fact file to resolve relative IRIs. If not provided, a random IRI is generated.")
     String factsBaseIRI;
 
     @Option(type = OptionType.COMMAND, name = {"-m", "--mapping"}, title = "mapping file",

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMappingOntologyRelatedCommand.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMappingOntologyRelatedCommand.java
@@ -4,6 +4,7 @@ package it.unibz.inf.ontop.cli;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.OptionType;
 import com.github.rvesse.airline.annotations.help.BashCompletion;
+import com.github.rvesse.airline.annotations.restrictions.AllowedEnumValues;
 import com.github.rvesse.airline.annotations.restrictions.Required;
 import com.github.rvesse.airline.help.cli.bash.CompletionBehaviour;
 
@@ -18,6 +19,15 @@ abstract class OntopMappingOntologyRelatedCommand extends AbstractOntopCommand i
             description = "RDF fact file")
     @BashCompletion(behaviour = CompletionBehaviour.FILENAMES)
     String factFile;
+
+    @Option(type = OptionType.COMMAND, name = {"--fact-format"}, title = "format of facts file",
+            description = "The format of the 'facts' input file.")
+    @AllowedEnumValues(RDFFormatTypes.class)
+    RDFFormatTypes factFormat;
+
+    @Option(type = OptionType.COMMAND, name = {"--facts-base-uri"}, title = "base URI of facts in fact file",
+            description = "The base URI of facts in the fact file to resolve relative URIs.")
+    String factsBaseURI;
 
     @Option(type = OptionType.COMMAND, name = {"-m", "--mapping"}, title = "mapping file",
             description = "Mapping file in R2RML (.ttl) or in Ontop native format (.obda)")

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMappingOntologyRelatedCommand.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMappingOntologyRelatedCommand.java
@@ -27,7 +27,7 @@ abstract class OntopMappingOntologyRelatedCommand extends AbstractOntopCommand i
 
     @Option(type = OptionType.COMMAND, name = {"--facts-base-uri"}, title = "base URI of facts in fact file",
             description = "The base URI of facts in the fact file to resolve relative URIs.")
-    String factsBaseURI;
+    String factsBaseIRI;
 
     @Option(type = OptionType.COMMAND, name = {"-m", "--mapping"}, title = "mapping file",
             description = "Mapping file in R2RML (.ttl) or in Ontop native format (.obda)")

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMaterialize.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMaterialize.java
@@ -67,31 +67,6 @@ public class OntopMaterialize extends OntopMappingOntologyRelatedCommand {
 
     private static final int TRIPLE_LIMIT_PER_FILE = 500000;
     private static final String DEFAULT_FETCH_SIZE = "50000";
-
-    public enum OutputFormat {
-        rdfxml(".rdf", RDFXMLWriter::new),
-        turtle(".ttl", w ->  new TurtleWriter(w).set(BasicWriterSettings.PRETTY_PRINT, false)),
-        ntriples(".nt", w ->  new NTriplesWriter(w).set(BasicWriterSettings.PRETTY_PRINT, false)),
-        nquads(".nq", w ->  new NQuadsWriter(w).set(BasicWriterSettings.PRETTY_PRINT, false)),
-        trig(".trig", TriGWriter::new),
-        jsonld(".jsonld", JSONLDWriter::new);
-
-        private final String extension;
-        private final Function<BufferedWriter, RDFHandler> rdfHandlerProvider;
-
-        OutputFormat(String extension, Function<BufferedWriter, RDFHandler> rdfHandlerProvider) {
-            this.extension = extension;
-            this.rdfHandlerProvider = rdfHandlerProvider;
-        }
-
-        String getExtension() {
-            return extension;
-        }
-
-        RDFHandler createRDFHandler(BufferedWriter writer) {
-            return rdfHandlerProvider.apply(writer);
-        }
-    }
     
     @Option(type = OptionType.COMMAND, override = true, name = {"-o", "--output"},
             title = "output", description = "output file (default) or prefix (only for --separate-files)")
@@ -102,8 +77,8 @@ public class OntopMaterialize extends OntopMappingOntologyRelatedCommand {
             description = "The format of the materialized ontology. " +
                     //" Options: rdfxml, turtle. " +
                     "Default: rdfxml")
-    @AllowedEnumValues(OutputFormat.class)
-    public OutputFormat format = OutputFormat.rdfxml;
+    @AllowedEnumValues(RDFFormatTypes.class)
+    public RDFFormatTypes format = RDFFormatTypes.rdfxml;
 
     @Option(type = OptionType.COMMAND, name = {"--separate-files"}, title = "output to separate files",
             description = "generating separate files for different classes/properties. This is useful for" +
@@ -298,6 +273,12 @@ public class OntopMaterialize extends OntopMappingOntologyRelatedCommand {
 
         if (factFile != null)
             configBuilder.factsFile(factFile);
+
+        if (factFormat != null)
+            configBuilder.factFormat(factFormat.getExtension());
+
+        if (factsBaseURI != null)
+            configBuilder.factsBaseURI(factsBaseURI);
 
         if (isR2rmlFile(mappingFile)) {
             configBuilder.r2rmlMappingFile(mappingFile);

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMaterialize.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMaterialize.java
@@ -296,6 +296,9 @@ public class OntopMaterialize extends OntopMappingOntologyRelatedCommand {
         if (owlFile != null)
             configBuilder.ontologyFile(owlFile);
 
+        if (factFile != null)
+            configBuilder.factsFile(factFile);
+
         if (isR2rmlFile(mappingFile)) {
             configBuilder.r2rmlMappingFile(mappingFile);
         } else {

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMaterialize.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopMaterialize.java
@@ -277,8 +277,8 @@ public class OntopMaterialize extends OntopMappingOntologyRelatedCommand {
         if (factFormat != null)
             configBuilder.factFormat(factFormat.getExtension());
 
-        if (factsBaseURI != null)
-            configBuilder.factsBaseURI(factsBaseURI);
+        if (factsBaseIRI != null)
+            configBuilder.factsBaseIRI(factsBaseIRI);
 
         if (isR2rmlFile(mappingFile)) {
             configBuilder.r2rmlMappingFile(mappingFile);

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopQuery.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopQuery.java
@@ -55,6 +55,12 @@ public class OntopQuery extends OntopMappingOntologyRelatedCommand {
         if (factFile != null)
             configurationBuilder.factsFile(factFile);
 
+        if (factFormat != null)
+            configurationBuilder.factFormat(factFormat.getExtension());
+
+        if (factsBaseURI != null)
+            configurationBuilder.factsBaseURI(factsBaseURI);
+
         if (propertiesFile != null) {
             configurationBuilder.propertyFile(propertiesFile);
         }

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopQuery.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopQuery.java
@@ -58,8 +58,8 @@ public class OntopQuery extends OntopMappingOntologyRelatedCommand {
         if (factFormat != null)
             configurationBuilder.factFormat(factFormat.getExtension());
 
-        if (factsBaseURI != null)
-            configurationBuilder.factsBaseURI(factsBaseURI);
+        if (factsBaseIRI != null)
+            configurationBuilder.factsBaseIRI(factsBaseIRI);
 
         if (propertiesFile != null) {
             configurationBuilder.propertyFile(propertiesFile);

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopQuery.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopQuery.java
@@ -52,6 +52,9 @@ public class OntopQuery extends OntopMappingOntologyRelatedCommand {
         if (owlFile != null)
             configurationBuilder.ontologyFile(owlFile);
 
+        if (factFile != null)
+            configurationBuilder.factsFile(factFile);
+
         if (propertiesFile != null) {
             configurationBuilder.propertyFile(propertiesFile);
         }

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopValidate.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopValidate.java
@@ -34,6 +34,7 @@ public class OntopValidate extends OntopMappingOntologyRelatedCommand {
         OntopSQLOWLAPIConfiguration.Builder<?> builder =
                 OntopSQLOWLAPIConfiguration.defaultBuilder()
                         .ontologyFile(owlFile)
+                        .factsFile(factFile)
                         .enableOntologyAnnotationQuerying(enableAnnotations);
 
         if (propertiesFile != null)
@@ -82,6 +83,16 @@ public class OntopValidate extends OntopMappingOntologyRelatedCommand {
         catch (Exception ex) {
             System.out.format("ERROR: OntopOWL reasoner cannot be initialized\n");
             ex.printStackTrace();
+            System.exit(1);
+        }
+
+        try {
+            config.loadInputFacts();
+        }
+        catch (OWLOntologyCreationException e) {
+            //TODO-Damian more than this syntax check required?
+            System.out.format("ERROR: There is a problem loading the fact file: %s\n", factFile);
+            e.printStackTrace();
             System.exit(1);
         }
 

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopValidate.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopValidate.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import it.unibz.inf.ontop.exception.OBDASpecificationException;
 import it.unibz.inf.ontop.injection.OntopSQLOWLAPIConfiguration;
+import it.unibz.inf.ontop.injection.impl.FactsException;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLNamedObject;
 import org.semanticweb.owlapi.model.OWLOntology;
@@ -89,8 +90,7 @@ public class OntopValidate extends OntopMappingOntologyRelatedCommand {
         try {
             config.loadInputFacts();
         }
-        catch (OWLOntologyCreationException e) {
-            //TODO-Damian more than this syntax check required?
+        catch (OBDASpecificationException e) {
             System.out.format("ERROR: There is a problem loading the fact file: %s\n", factFile);
             e.printStackTrace();
             System.exit(1);

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopValidate.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopValidate.java
@@ -43,8 +43,8 @@ public class OntopValidate extends OntopMappingOntologyRelatedCommand {
         if(factFormat != null)
             builder.factFormat(factFormat.getExtension());
 
-        if (factsBaseURI != null)
-            builder.factsBaseURI(factsBaseURI);
+        if (factsBaseIRI != null)
+            builder.factsBaseIRI(factsBaseIRI);
 
         if (propertiesFile != null)
             builder.propertyFile(propertiesFile);

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopValidate.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/OntopValidate.java
@@ -35,8 +35,16 @@ public class OntopValidate extends OntopMappingOntologyRelatedCommand {
         OntopSQLOWLAPIConfiguration.Builder<?> builder =
                 OntopSQLOWLAPIConfiguration.defaultBuilder()
                         .ontologyFile(owlFile)
-                        .factsFile(factFile)
                         .enableOntologyAnnotationQuerying(enableAnnotations);
+
+        if(factFile != null)
+            builder.factsFile(factFile);
+
+        if(factFormat != null)
+            builder.factFormat(factFormat.getExtension());
+
+        if (factsBaseURI != null)
+            builder.factsBaseURI(factsBaseURI);
 
         if (propertiesFile != null)
             builder.propertyFile(propertiesFile);

--- a/client/cli/src/main/java/it/unibz/inf/ontop/cli/RDFFormatTypes.java
+++ b/client/cli/src/main/java/it/unibz/inf/ontop/cli/RDFFormatTypes.java
@@ -1,0 +1,38 @@
+package it.unibz.inf.ontop.cli;
+
+import org.eclipse.rdf4j.rio.RDFHandler;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.jsonld.JSONLDWriter;
+import org.eclipse.rdf4j.rio.nquads.NQuadsWriter;
+import org.eclipse.rdf4j.rio.ntriples.NTriplesWriter;
+import org.eclipse.rdf4j.rio.rdfxml.RDFXMLWriter;
+import org.eclipse.rdf4j.rio.trig.TriGWriter;
+import org.eclipse.rdf4j.rio.turtle.TurtleWriter;
+
+import java.io.BufferedWriter;
+import java.util.function.Function;
+
+public enum RDFFormatTypes {
+    rdfxml(".rdf", RDFXMLWriter::new),
+    turtle(".ttl", w ->  new TurtleWriter(w).set(BasicWriterSettings.PRETTY_PRINT, false)),
+    ntriples(".nt", w ->  new NTriplesWriter(w).set(BasicWriterSettings.PRETTY_PRINT, false)),
+    nquads(".nq", w ->  new NQuadsWriter(w).set(BasicWriterSettings.PRETTY_PRINT, false)),
+    trig(".trig", TriGWriter::new),
+    jsonld(".jsonld", JSONLDWriter::new);
+
+    private final String extension;
+    private final Function<BufferedWriter, RDFHandler> rdfHandlerProvider;
+
+    RDFFormatTypes(String extension, Function<BufferedWriter, RDFHandler> rdfHandlerProvider) {
+        this.extension = extension;
+        this.rdfHandlerProvider = rdfHandlerProvider;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public RDFHandler createRDFHandler(BufferedWriter writer) {
+        return rdfHandlerProvider.apply(writer);
+    }
+}

--- a/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/beans/OntopVirtualRepositoryBean.java
+++ b/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/beans/OntopVirtualRepositoryBean.java
@@ -16,6 +16,8 @@ public class OntopVirtualRepositoryBean {
     private OntopSystemConfiguration setupOntopConfiguration(@Value("${mapping}") String mappings,
                                                              @Value("${ontology:#{null}}") String ontology,
                                                              @Value("${facts:#{null}}") String facts,
+                                                             @Value("${fact-format:#{null}}") String factFormat,
+                                                             @Value("${facts-base-uri:#{null}}") String factsBaseURI,
                                                              @Value("${xml-catalog:#{null}}") String xmlCatalog,
                                                              @Value("${properties:#{null}}") String properties,
                                                              @Value("${constraint:#{null}}") String constraint,
@@ -41,6 +43,12 @@ public class OntopVirtualRepositoryBean {
 
         if ((facts != null) && (!facts.isEmpty()))
             builder.factsFile(facts);
+
+        if ((factFormat != null) && (!factFormat.isEmpty()))
+            builder.factFormat(factFormat);
+
+        if ((factsBaseURI != null) && (!factsBaseURI.isEmpty()))
+            builder.factsBaseURI(factsBaseURI);
 
         if ((xmlCatalog != null) && (!xmlCatalog.isEmpty()))
             builder.xmlCatalogFile(xmlCatalog);

--- a/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/beans/OntopVirtualRepositoryBean.java
+++ b/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/beans/OntopVirtualRepositoryBean.java
@@ -17,7 +17,7 @@ public class OntopVirtualRepositoryBean {
                                                              @Value("${ontology:#{null}}") String ontology,
                                                              @Value("${facts:#{null}}") String facts,
                                                              @Value("${fact-format:#{null}}") String factFormat,
-                                                             @Value("${facts-base-uri:#{null}}") String factsBaseURI,
+                                                             @Value("${facts-base-uri:#{null}}") String factsBaseIRI,
                                                              @Value("${xml-catalog:#{null}}") String xmlCatalog,
                                                              @Value("${properties:#{null}}") String properties,
                                                              @Value("${constraint:#{null}}") String constraint,
@@ -47,8 +47,8 @@ public class OntopVirtualRepositoryBean {
         if ((factFormat != null) && (!factFormat.isEmpty()))
             builder.factFormat(factFormat);
 
-        if ((factsBaseURI != null) && (!factsBaseURI.isEmpty()))
-            builder.factsBaseURI(factsBaseURI);
+        if ((factsBaseIRI != null) && (!factsBaseIRI.isEmpty()))
+            builder.factsBaseIRI(factsBaseIRI);
 
         if ((xmlCatalog != null) && (!xmlCatalog.isEmpty()))
             builder.xmlCatalogFile(xmlCatalog);

--- a/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/beans/OntopVirtualRepositoryBean.java
+++ b/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/beans/OntopVirtualRepositoryBean.java
@@ -17,7 +17,7 @@ public class OntopVirtualRepositoryBean {
                                                              @Value("${ontology:#{null}}") String ontology,
                                                              @Value("${facts:#{null}}") String facts,
                                                              @Value("${fact-format:#{null}}") String factFormat,
-                                                             @Value("${facts-base-uri:#{null}}") String factsBaseIRI,
+                                                             @Value("${facts-base-iri:#{null}}") String factsBaseIRI,
                                                              @Value("${xml-catalog:#{null}}") String xmlCatalog,
                                                              @Value("${properties:#{null}}") String properties,
                                                              @Value("${constraint:#{null}}") String constraint,

--- a/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/beans/OntopVirtualRepositoryBean.java
+++ b/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/beans/OntopVirtualRepositoryBean.java
@@ -15,6 +15,7 @@ public class OntopVirtualRepositoryBean {
     @Bean
     private OntopSystemConfiguration setupOntopConfiguration(@Value("${mapping}") String mappings,
                                                              @Value("${ontology:#{null}}") String ontology,
+                                                             @Value("${facts:#{null}}") String facts,
                                                              @Value("${xml-catalog:#{null}}") String xmlCatalog,
                                                              @Value("${properties:#{null}}") String properties,
                                                              @Value("${constraint:#{null}}") String constraint,
@@ -37,6 +38,9 @@ public class OntopVirtualRepositoryBean {
 
         if ((ontology != null) && (!ontology.isEmpty()))
             builder.ontologyFile(ontology);
+
+        if ((facts != null) && (!facts.isEmpty()))
+            builder.factsFile(facts);
 
         if ((xmlCatalog != null) && (!xmlCatalog.isEmpty()))
             builder.xmlCatalogFile(xmlCatalog);

--- a/engine/system/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopSQLOWLAPIConfigurationImpl.java
+++ b/engine/system/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopSQLOWLAPIConfigurationImpl.java
@@ -41,7 +41,7 @@ public class OntopSQLOWLAPIConfigurationImpl extends OntopStandaloneSQLConfigura
     }
 
     @Override
-    public Optional<ImmutableSet<RDFFact>> loadInputFacts() throws OWLOntologyCreationException {
+    public Optional<ImmutableSet<RDFFact>> loadInputFacts() throws OBDASpecificationException {
         return mappingOWLConfiguration.loadInputFacts();
     }
 

--- a/engine/system/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopSQLOWLAPIConfigurationImpl.java
+++ b/engine/system/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopSQLOWLAPIConfigurationImpl.java
@@ -112,8 +112,8 @@ public class OntopSQLOWLAPIConfigurationImpl extends OntopStandaloneSQLConfigura
         }
 
         @Override
-        public B factsBaseURI(@Nonnull String factsBaseURI) {
-            return ontologyBuilderFragment.factsBaseURI(factsBaseURI);
+        public B factsBaseIRI(@Nonnull String factsBaseIRI) {
+            return ontologyBuilderFragment.factsBaseIRI(factsBaseIRI);
         }
 
         @Override

--- a/engine/system/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopSQLOWLAPIConfigurationImpl.java
+++ b/engine/system/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopSQLOWLAPIConfigurationImpl.java
@@ -1,5 +1,6 @@
 package it.unibz.inf.ontop.injection.impl;
 
+import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.exception.OBDASpecificationException;
 import it.unibz.inf.ontop.exception.InvalidOntopConfigurationException;
 import it.unibz.inf.ontop.injection.OntopSQLOWLAPIConfiguration;
@@ -7,6 +8,7 @@ import it.unibz.inf.ontop.injection.OntopStandaloneSQLSettings;
 import it.unibz.inf.ontop.injection.impl.OntopMappingOntologyBuilders.OntopMappingOntologyOptions;
 import it.unibz.inf.ontop.injection.impl.OntopMappingOntologyBuilders.StandardMappingOntologyBuilderFragment;
 import it.unibz.inf.ontop.spec.OBDASpecification;
+import it.unibz.inf.ontop.spec.ontology.RDFFact;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
@@ -30,12 +32,17 @@ public class OntopSQLOWLAPIConfigurationImpl extends OntopStandaloneSQLConfigura
 
     @Override
     public OBDASpecification loadOBDASpecification() throws OBDASpecificationException {
-        return loadSpecification(mappingOWLConfiguration::loadOntology);
+        return loadSpecification(mappingOWLConfiguration::loadOntology, mappingOWLConfiguration::loadInputFacts);
     }
 
     @Override
     public Optional<OWLOntology> loadInputOntology() throws OWLOntologyCreationException {
         return mappingOWLConfiguration.loadInputOntology();
+    }
+
+    @Override
+    public Optional<ImmutableSet<RDFFact>> loadInputFacts() throws OWLOntologyCreationException {
+        return mappingOWLConfiguration.loadInputFacts();
     }
 
     static class OntopSQLOWLAPIOptions {
@@ -92,6 +99,26 @@ public class OntopSQLOWLAPIConfigurationImpl extends OntopStandaloneSQLConfigura
         @Override
         public B ontologyReader(@Nonnull Reader reader) {
             return ontologyBuilderFragment.ontologyReader(reader);
+        }
+
+        @Override
+        public B factsFile(@Nonnull String urlOrPath) {
+            return ontologyBuilderFragment.factsFile(urlOrPath);
+        }
+
+        @Override
+        public B factsFile(@Nonnull URL url) {
+            return ontologyBuilderFragment.factsFile(url);
+        }
+
+        @Override
+        public B factsFile(@Nonnull File owlFile) {
+            return ontologyBuilderFragment.factsFile(owlFile);
+        }
+
+        @Override
+        public B factsReader(@Nonnull Reader reader) {
+            return ontologyBuilderFragment.factsReader(reader);
         }
 
         protected final void declareOntologyDefined() {

--- a/engine/system/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopSQLOWLAPIConfigurationImpl.java
+++ b/engine/system/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopSQLOWLAPIConfigurationImpl.java
@@ -107,6 +107,16 @@ public class OntopSQLOWLAPIConfigurationImpl extends OntopStandaloneSQLConfigura
         }
 
         @Override
+        public B factFormat(@Nonnull String factFormat) {
+            return ontologyBuilderFragment.factFormat(factFormat);
+        }
+
+        @Override
+        public B factsBaseURI(@Nonnull String factsBaseURI) {
+            return ontologyBuilderFragment.factsBaseURI(factsBaseURI);
+        }
+
+        @Override
         public B factsFile(@Nonnull URL url) {
             return ontologyBuilderFragment.factsFile(url);
         }

--- a/mapping/core/pom.xml
+++ b/mapping/core/pom.xml
@@ -97,6 +97,10 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.sourceforge.owlapi</groupId>
+            <artifactId>owlapi-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/mapping/core/pom.xml
+++ b/mapping/core/pom.xml
@@ -97,10 +97,6 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>net.sourceforge.owlapi</groupId>
-            <artifactId>owlapi-api</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/injection/impl/FactsException.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/injection/impl/FactsException.java
@@ -1,0 +1,14 @@
+package it.unibz.inf.ontop.injection.impl;
+
+
+import it.unibz.inf.ontop.exception.OBDASpecificationException;
+
+public class FactsException extends OBDASpecificationException {
+    public FactsException(String message) {
+        super(message);
+    }
+
+    public FactsException(Exception e) {
+        super(e);
+    }
+}

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/injection/impl/FactsException.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/injection/impl/FactsException.java
@@ -11,4 +11,8 @@ public class FactsException extends OBDASpecificationException {
     public FactsException(Exception e) {
         super(e);
     }
+
+    public FactsException(String message, Exception e) {
+        super(message, e);
+    }
 }

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/injection/impl/FactsSupplier.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/injection/impl/FactsSupplier.java
@@ -1,0 +1,15 @@
+package it.unibz.inf.ontop.injection.impl;
+
+
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.exception.OntologyException;
+import it.unibz.inf.ontop.spec.ontology.RDFFact;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+
+import java.util.Optional;
+
+@FunctionalInterface
+public interface FactsSupplier {
+
+    Optional<ImmutableSet<RDFFact>> get() throws OntologyException, OWLOntologyCreationException;
+}

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/injection/impl/FactsSupplier.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/injection/impl/FactsSupplier.java
@@ -2,14 +2,13 @@ package it.unibz.inf.ontop.injection.impl;
 
 
 import com.google.common.collect.ImmutableSet;
-import it.unibz.inf.ontop.exception.OntologyException;
+import it.unibz.inf.ontop.exception.OBDASpecificationException;
 import it.unibz.inf.ontop.spec.ontology.RDFFact;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
 import java.util.Optional;
 
 @FunctionalInterface
 public interface FactsSupplier {
 
-    Optional<ImmutableSet<RDFFact>> get() throws OntologyException, OWLOntologyCreationException;
+    Optional<ImmutableSet<RDFFact>> get() throws OBDASpecificationException;
 }

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingConfigurationImpl.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingConfigurationImpl.java
@@ -17,7 +17,6 @@ import it.unibz.inf.ontop.spec.mapping.pp.PreProcessedTriplesMap;
 import it.unibz.inf.ontop.spec.ontology.Ontology;
 import it.unibz.inf.ontop.spec.ontology.RDFFact;
 import org.apache.commons.rdf.api.Graph;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
 import javax.annotation.Nonnull;
 import java.io.File;
@@ -93,13 +92,7 @@ public class OntopMappingConfigurationImpl extends OntopKGQueryConfigurationImpl
         OBDASpecificationExtractor extractor = getInjector().getInstance(OBDASpecificationExtractor.class);
 
         Optional<Ontology> optionalOntology = ontologySupplier.get();
-        ImmutableSet<RDFFact> optionalFacts = null;
-
-        try {
-            optionalFacts = factsSupplier.get().orElse(ImmutableSet.of());
-        } catch (OWLOntologyCreationException e) {
-            throw new FactsException(e);
-        }
+        ImmutableSet<RDFFact> optionalFacts = factsSupplier.get().orElse(ImmutableSet.of());
 
         /*
          * Pre-processed mapping

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/spec/OBDASpecificationExtractor.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/spec/OBDASpecificationExtractor.java
@@ -1,10 +1,12 @@
 package it.unibz.inf.ontop.spec;
 
 
+import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.exception.OBDASpecificationException;
 import it.unibz.inf.ontop.spec.mapping.pp.PreProcessedTriplesMap;
 import it.unibz.inf.ontop.spec.ontology.Ontology;
 import it.unibz.inf.ontop.spec.mapping.pp.PreProcessedMapping;
+import it.unibz.inf.ontop.spec.ontology.RDFFact;
 
 import javax.annotation.Nonnull;
 import java.util.Optional;
@@ -12,11 +14,12 @@ import java.util.Optional;
 public interface OBDASpecificationExtractor {
 
     OBDASpecification extract(@Nonnull OBDASpecInput specInput,
-                              @Nonnull Optional<Ontology> ontology)
+                              @Nonnull Optional<Ontology> ontology,
+                              @Nonnull ImmutableSet<RDFFact> facts)
             throws OBDASpecificationException;
 
     OBDASpecification extract(@Nonnull OBDASpecInput specInput, @Nonnull PreProcessedMapping<? extends PreProcessedTriplesMap> ppMapping,
-                              @Nonnull Optional<Ontology> ontology)
+                              @Nonnull Optional<Ontology> ontology, @Nonnull ImmutableSet<RDFFact> facts)
             throws OBDASpecificationException;
 
 }

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/spec/fact/FactExtractor.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/spec/fact/FactExtractor.java
@@ -13,10 +13,4 @@ public interface FactExtractor {
      */
     ImmutableSet<RDFFact> extractAndSelect(Optional<Ontology> ontology);
 
-    /**
-     * The user is allowed to override the `queryAnnotation` field from the settings when calling
-     * this signature to extract facts from an Ontology file.
-     */
-    ImmutableSet<RDFFact> extractAndSelect(Optional<Ontology> ontology, boolean queryAnnotation);
-
 }

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/spec/fact/FactExtractor.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/spec/fact/FactExtractor.java
@@ -13,4 +13,10 @@ public interface FactExtractor {
      */
     ImmutableSet<RDFFact> extractAndSelect(Optional<Ontology> ontology);
 
+    /**
+     * The user is allowed to override the `queryAnnotation` field from the settings when calling
+     * this signature to extract facts from an Ontology file.
+     */
+    ImmutableSet<RDFFact> extractAndSelect(Optional<Ontology> ontology, boolean queryAnnotation);
+
 }

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/spec/fact/impl/AbstractFactExtractor.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/spec/fact/impl/AbstractFactExtractor.java
@@ -19,10 +19,15 @@ public abstract class AbstractFactExtractor implements FactExtractor {
 
     @Override
     public ImmutableSet<RDFFact> extractAndSelect(Optional<Ontology> ontology) {
+        return extractAndSelect(ontology, settings.isOntologyAnnotationQueryingEnabled());
+    }
+
+    @Override
+    public ImmutableSet<RDFFact> extractAndSelect(Optional<Ontology> ontology, boolean queryAnnotation) {
         // TODO: consider other facts
         return ontology
                 .map(o -> Stream.concat(
-                        selectABox(o),
+                        selectABox(o, queryAnnotation),
                         extractTBox(o.tbox()))
                         .collect(ImmutableCollectors.toSet()))
                 .orElseGet(ImmutableSet::of);
@@ -30,8 +35,8 @@ public abstract class AbstractFactExtractor implements FactExtractor {
 
     protected abstract Stream<RDFFact> extractTBox(ClassifiedTBox tbox);
 
-    protected Stream<RDFFact> selectABox(Ontology ontology) {
-        if (settings.isOntologyAnnotationQueryingEnabled())
+    protected Stream<RDFFact> selectABox(Ontology ontology, boolean queryAnnotation) {
+        if (queryAnnotation)
             return ontology.abox().stream();
 
         OntologyVocabularyCategory<AnnotationProperty> annotationProperties = ontology.annotationProperties();

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/spec/fact/impl/AbstractFactExtractor.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/spec/fact/impl/AbstractFactExtractor.java
@@ -19,15 +19,10 @@ public abstract class AbstractFactExtractor implements FactExtractor {
 
     @Override
     public ImmutableSet<RDFFact> extractAndSelect(Optional<Ontology> ontology) {
-        return extractAndSelect(ontology, settings.isOntologyAnnotationQueryingEnabled());
-    }
-
-    @Override
-    public ImmutableSet<RDFFact> extractAndSelect(Optional<Ontology> ontology, boolean queryAnnotation) {
         // TODO: consider other facts
         return ontology
                 .map(o -> Stream.concat(
-                        selectABox(o, queryAnnotation),
+                        selectABox(o, settings.isOntologyAnnotationQueryingEnabled()),
                         extractTBox(o.tbox()))
                         .collect(ImmutableCollectors.toSet()))
                 .orElseGet(ImmutableSet::of);

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/spec/impl/DefaultOBDASpecificationExtractor.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/spec/impl/DefaultOBDASpecificationExtractor.java
@@ -2,6 +2,7 @@ package it.unibz.inf.ontop.spec.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import it.unibz.inf.ontop.exception.MappingIOException;
 import it.unibz.inf.ontop.exception.MetadataExtractionException;
 import it.unibz.inf.ontop.exception.OBDASpecificationException;
@@ -42,9 +43,9 @@ public class DefaultOBDASpecificationExtractor implements OBDASpecificationExtra
 
     @Override
     public OBDASpecification extract(@Nonnull OBDASpecInput specInput,
-                                     @Nonnull Optional<Ontology> optionalOntology)
+                                     @Nonnull Optional<Ontology> optionalOntology, @Nonnull ImmutableSet<RDFFact> previousFacts)
             throws OBDASpecificationException {
-        ImmutableSet<RDFFact> facts = factExtractor.extractAndSelect(optionalOntology);
+        ImmutableSet<RDFFact> facts = Sets.union(factExtractor.extractAndSelect(optionalOntology), previousFacts).immutableCopy();
 
         try {
             MappingAndDBParameters mappingAndDBMetadata = mappingExtractor.extract(specInput, optionalOntology);
@@ -60,13 +61,13 @@ public class DefaultOBDASpecificationExtractor implements OBDASpecificationExtra
 
     @Override
     public OBDASpecification extract(@Nonnull OBDASpecInput specInput, @Nonnull PreProcessedMapping<? extends PreProcessedTriplesMap> ppMapping,
-                                     @Nonnull Optional<Ontology> optionalOntology) throws OBDASpecificationException {
+                                     @Nonnull Optional<Ontology> optionalOntology, @Nonnull ImmutableSet<RDFFact> previousFacts) throws OBDASpecificationException {
 
         try {
             MappingAndDBParameters mappingAndDBMetadata = mappingExtractor.extract(ppMapping, specInput, optionalOntology);
             ImmutableList<IQ> rules = ruleExtractor.extract(specInput);
 
-            ImmutableSet<RDFFact> facts = factExtractor.extractAndSelect(optionalOntology);
+            ImmutableSet<RDFFact> facts = Sets.union(factExtractor.extractAndSelect(optionalOntology), previousFacts).immutableCopy();
 
             return mappingTransformer.transform(
                     mappingAndDBMetadata.getMapping(), mappingAndDBMetadata.getDBParameters(), optionalOntology, facts,

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/spec/mapping/transformer/impl/ABoxFactIntoMappingConverterImpl.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/spec/mapping/transformer/impl/ABoxFactIntoMappingConverterImpl.java
@@ -70,11 +70,12 @@ public class ABoxFactIntoMappingConverterImpl implements FactIntoMappingConverte
                 projectedVariableGenerator.generateNewVariable());
         tripleAtomPredicate = (RDFAtomPredicate) tripleAtom.getPredicate();
 
-        quadAtom = atomFactory.getDistinctTripleAtom(
+        quadAtom = atomFactory.getDistinctQuadAtom(
+                projectedVariableGenerator.generateNewVariable(),
                 projectedVariableGenerator.generateNewVariable(),
                 projectedVariableGenerator.generateNewVariable(),
                 projectedVariableGenerator.generateNewVariable());
-        quadAtomPredicate = (RDFAtomPredicate) tripleAtom.getPredicate();
+        quadAtomPredicate = (RDFAtomPredicate) quadAtom.getPredicate();
 
     }
 

--- a/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/OntopMappingOntologyConfiguration.java
+++ b/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/OntopMappingOntologyConfiguration.java
@@ -21,6 +21,14 @@ public interface OntopMappingOntologyConfiguration extends OntopMappingConfigura
         B ontologyFile(@Nonnull File owlFile);
 
         B ontologyReader(@Nonnull Reader reader);
+
+        B factsFile(@Nonnull URL url);
+
+        B factsFile(@Nonnull File owlFile);
+
+        B factsReader(@Nonnull Reader reader);
+
+        B factsFile(@Nonnull String urlOrPath);
     }
 
     interface Builder<B extends Builder<B>> extends OntopMappingOntologyBuilderFragment<B>,

--- a/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/OntopMappingOntologyConfiguration.java
+++ b/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/OntopMappingOntologyConfiguration.java
@@ -32,7 +32,7 @@ public interface OntopMappingOntologyConfiguration extends OntopMappingConfigura
 
         B factFormat(@Nonnull String format);
 
-        B factsBaseURI(@Nonnull String factsBaseURI);
+        B factsBaseIRI(@Nonnull String factsBaseIRI);
     }
 
     interface Builder<B extends Builder<B>> extends OntopMappingOntologyBuilderFragment<B>,

--- a/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/OntopMappingOntologyConfiguration.java
+++ b/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/OntopMappingOntologyConfiguration.java
@@ -29,6 +29,10 @@ public interface OntopMappingOntologyConfiguration extends OntopMappingConfigura
         B factsReader(@Nonnull Reader reader);
 
         B factsFile(@Nonnull String urlOrPath);
+
+        B factFormat(@Nonnull String format);
+
+        B factsBaseURI(@Nonnull String factsBaseURI);
     }
 
     interface Builder<B extends Builder<B>> extends OntopMappingOntologyBuilderFragment<B>,

--- a/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyBuilders.java
+++ b/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyBuilders.java
@@ -26,6 +26,8 @@ public class OntopMappingOntologyBuilders {
 
         final OntopMappingOptions mappingOptions;
 
+        final Optional<String> factFormat;
+        final Optional<String> factsBaseURI;
         final Optional<File> factsFile;
         final Optional<URL> factsURL;
         final Optional<Reader> factsReader;
@@ -35,6 +37,8 @@ public class OntopMappingOntologyBuilders {
                                             Optional<Reader> ontologyReader,
                                             Optional<String> xmlCatalogFile,
                                             OntopMappingOptions mappingOptions,
+                                            Optional<String> factFormat,
+                                            Optional<String> factsBaseURI,
                                             Optional<File> factsFile,
                                             Optional<URL> factsURL,
                                             Optional<Reader> factsReader) {
@@ -46,6 +50,8 @@ public class OntopMappingOntologyBuilders {
             this.factsFile = factsFile;
             this.factsURL = factsURL;
             this.factsReader = factsReader;
+            this.factFormat = factFormat;
+            this.factsBaseURI = factsBaseURI;
         }
     }
 
@@ -57,6 +63,8 @@ public class OntopMappingOntologyBuilders {
         private Optional<URL> ontologyURL = Optional.empty();
         private Optional<Reader> ontologyReader = Optional.empty();
 
+        private Optional<String> factFormat = Optional.empty();
+        private Optional<String> factsBaseURI = Optional.empty();
         private Optional<File> factsFile = Optional.empty();
         private Optional<URL> factsURL = Optional.empty();
         private Optional<Reader> factsReader = Optional.empty();
@@ -114,6 +122,18 @@ public class OntopMappingOntologyBuilders {
         }
 
         @Override
+        public B factFormat(@Nonnull String factFormat) {
+            this.factFormat = Optional.of(factFormat);
+            return self();
+        }
+
+        @Override
+        public B factsBaseURI(@Nonnull String factsBaseURI) {
+            this.factsBaseURI = Optional.of(factsBaseURI);
+            return self();
+        }
+
+        @Override
         public B factsFile(@Nonnull String urlOrPath) {
             try {
                 URL url = new URL(urlOrPath);
@@ -152,7 +172,7 @@ public class OntopMappingOntologyBuilders {
         }
 
         protected OntopMappingOntologyOptions generateMappingOntologyOptions(OntopMappingOptions mappingOptions) {
-            return new OntopMappingOntologyOptions(ontologyFile, ontologyURL, ontologyReader, xmlCatalogFile, mappingOptions, factsFile, factsURL, factsReader);
+            return new OntopMappingOntologyOptions(ontologyFile, ontologyURL, ontologyReader, xmlCatalogFile, mappingOptions, factFormat, factsBaseURI, factsFile, factsURL, factsReader);
         }
     }
 }

--- a/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyBuilders.java
+++ b/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyBuilders.java
@@ -26,16 +26,26 @@ public class OntopMappingOntologyBuilders {
 
         final OntopMappingOptions mappingOptions;
 
+        final Optional<File> factsFile;
+        final Optional<URL> factsURL;
+        final Optional<Reader> factsReader;
+
         private OntopMappingOntologyOptions(Optional<File> ontologyFile,
                                             Optional<URL> ontologyURL,
                                             Optional<Reader> ontologyReader,
                                             Optional<String> xmlCatalogFile,
-                                            OntopMappingOptions mappingOptions) {
+                                            OntopMappingOptions mappingOptions,
+                                            Optional<File> factsFile,
+                                            Optional<URL> factsURL,
+                                            Optional<Reader> factsReader) {
             this.ontologyFile = ontologyFile;
             this.ontologyReader = ontologyReader;
             this.xmlCatalogFile = xmlCatalogFile;
             this.ontologyURL = ontologyURL;
             this.mappingOptions = mappingOptions;
+            this.factsFile = factsFile;
+            this.factsURL = factsURL;
+            this.factsReader = factsReader;
         }
     }
 
@@ -46,6 +56,10 @@ public class OntopMappingOntologyBuilders {
         private Optional<File> ontologyFile = Optional.empty();
         private Optional<URL> ontologyURL = Optional.empty();
         private Optional<Reader> ontologyReader = Optional.empty();
+
+        private Optional<File> factsFile = Optional.empty();
+        private Optional<URL> factsURL = Optional.empty();
+        private Optional<Reader> factsReader = Optional.empty();
         private Optional<String> xmlCatalogFile = Optional.empty();
 
         protected abstract B self();
@@ -99,8 +113,46 @@ public class OntopMappingOntologyBuilders {
             return self();
         }
 
+        @Override
+        public B factsFile(@Nonnull String urlOrPath) {
+            try {
+                URL url = new URL(urlOrPath);
+                /*
+                 * If no protocol, treats it as a path
+                 */
+                String protocol = url.getProtocol();
+                if (protocol == null) {
+                    return factsFile(new File(urlOrPath));
+                } else if (protocol.equals("file")) {
+                    return factsFile(new File(url.getPath()));
+                } else {
+                    return factsFile(url);
+                }
+            } catch (MalformedURLException e) {
+                return factsFile(new File(urlOrPath));
+            }
+        }
+
+        @Override
+        public B factsFile(@Nonnull URL url) {
+            this.factsURL = Optional.of(url);
+            return self();
+        }
+
+        @Override
+        public B factsFile(@Nonnull File owlFile) {
+            this.factsFile = Optional.of(owlFile);
+            return self();
+        }
+
+        @Override
+        public B factsReader(@Nonnull Reader reader) {
+            this.factsReader = Optional.of(reader);
+            return self();
+        }
+
         protected OntopMappingOntologyOptions generateMappingOntologyOptions(OntopMappingOptions mappingOptions) {
-            return new OntopMappingOntologyOptions(ontologyFile, ontologyURL, ontologyReader, xmlCatalogFile, mappingOptions);
+            return new OntopMappingOntologyOptions(ontologyFile, ontologyURL, ontologyReader, xmlCatalogFile, mappingOptions, factsFile, factsURL, factsReader);
         }
     }
 }

--- a/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyBuilders.java
+++ b/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyBuilders.java
@@ -27,7 +27,7 @@ public class OntopMappingOntologyBuilders {
         final OntopMappingOptions mappingOptions;
 
         final Optional<String> factFormat;
-        final Optional<String> factsBaseURI;
+        final Optional<String> factsBaseIRI;
         final Optional<File> factsFile;
         final Optional<URL> factsURL;
         final Optional<Reader> factsReader;
@@ -38,7 +38,7 @@ public class OntopMappingOntologyBuilders {
                                             Optional<String> xmlCatalogFile,
                                             OntopMappingOptions mappingOptions,
                                             Optional<String> factFormat,
-                                            Optional<String> factsBaseURI,
+                                            Optional<String> factsBaseIRI,
                                             Optional<File> factsFile,
                                             Optional<URL> factsURL,
                                             Optional<Reader> factsReader) {
@@ -51,7 +51,7 @@ public class OntopMappingOntologyBuilders {
             this.factsURL = factsURL;
             this.factsReader = factsReader;
             this.factFormat = factFormat;
-            this.factsBaseURI = factsBaseURI;
+            this.factsBaseIRI = factsBaseIRI;
         }
     }
 
@@ -64,7 +64,7 @@ public class OntopMappingOntologyBuilders {
         private Optional<Reader> ontologyReader = Optional.empty();
 
         private Optional<String> factFormat = Optional.empty();
-        private Optional<String> factsBaseURI = Optional.empty();
+        private Optional<String> factsBaseIRI = Optional.empty();
         private Optional<File> factsFile = Optional.empty();
         private Optional<URL> factsURL = Optional.empty();
         private Optional<Reader> factsReader = Optional.empty();
@@ -128,8 +128,8 @@ public class OntopMappingOntologyBuilders {
         }
 
         @Override
-        public B factsBaseURI(@Nonnull String factsBaseURI) {
-            this.factsBaseURI = Optional.of(factsBaseURI);
+        public B factsBaseIRI(@Nonnull String factsBaseIRI) {
+            this.factsBaseIRI = Optional.of(factsBaseIRI);
             return self();
         }
 
@@ -172,7 +172,7 @@ public class OntopMappingOntologyBuilders {
         }
 
         protected OntopMappingOntologyOptions generateMappingOntologyOptions(OntopMappingOptions mappingOptions) {
-            return new OntopMappingOntologyOptions(ontologyFile, ontologyURL, ontologyReader, xmlCatalogFile, mappingOptions, factFormat, factsBaseURI, factsFile, factsURL, factsReader);
+            return new OntopMappingOntologyOptions(ontologyFile, ontologyURL, ontologyReader, xmlCatalogFile, mappingOptions, factFormat, factsBaseIRI, factsFile, factsURL, factsReader);
         }
     }
 }

--- a/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyConfigurationImpl.java
+++ b/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyConfigurationImpl.java
@@ -159,7 +159,7 @@ public class OntopMappingOntologyConfigurationImpl extends OntopMappingConfigura
         Model model = new LinkedHashModel();
         parser.setRDFHandler(new StatementCollector(model));
         try {
-            parser.parse(reader, options.factsBaseIRI.orElse(UUID.randomUUID().toString()));
+            parser.parse(reader, options.factsBaseIRI.orElseGet(() -> String.format("http://%s.example.org/data/", UUID.randomUUID())));
         } catch (IOException e) {
             throw new FactsException(e);
         }

--- a/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyConfigurationImpl.java
+++ b/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyConfigurationImpl.java
@@ -127,6 +127,8 @@ public class OntopMappingOntologyConfigurationImpl extends OntopMappingConfigura
         Optional<RDFFormat> format = options.factFormat
                 .map(this::toRDFFormat)
                 .or(() -> options.factsFile.map(f -> Rio.getParserFormatForFileName(f.getName())).orElse(Optional.empty()));
+        if (options.factsFile.isEmpty() && options.factsURL.isEmpty() && options.factsReader.isEmpty())
+            return factsFile;
         if(format.isEmpty()) {
             throw new FactsException("No valid fact file format was provided, and a format could not be inferred from the file name.");
         }

--- a/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyConfigurationImpl.java
+++ b/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyConfigurationImpl.java
@@ -8,19 +8,15 @@ import it.unibz.inf.ontop.injection.OntopMappingOntologyConfiguration;
 import it.unibz.inf.ontop.injection.OntopMappingSettings;
 import it.unibz.inf.ontop.injection.OntopOntologyOWLAPIConfiguration;
 import it.unibz.inf.ontop.injection.impl.OntopMappingOntologyBuilders.OntopMappingOntologyOptions;
+import it.unibz.inf.ontop.spec.fact.impl.FactExtractorWithSaturatedTBox;
 import it.unibz.inf.ontop.spec.ontology.Ontology;
+import it.unibz.inf.ontop.spec.ontology.RDFFact;
 import it.unibz.inf.ontop.spec.ontology.owlapi.OWLAPITranslatorOWL2QL;
 import org.protege.xmlcatalog.owlapi.XMLCatalogIRIMapper;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyIRIMapper;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.*;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
@@ -30,11 +26,22 @@ public class OntopMappingOntologyConfigurationImpl extends OntopMappingConfigura
 
     private final OntopMappingOntologyOptions options;
     private Optional<OWLOntology> owlOntology;
+    private Optional<ImmutableSet<RDFFact>> factsFile;
 
     protected OntopMappingOntologyConfigurationImpl(OntopMappingSettings settings, OntopMappingOntologyOptions options) {
         super(settings, options.mappingOptions);
         this.options = options;
         this.owlOntology = Optional.empty();
+        this.factsFile = Optional.empty();
+    }
+
+    @Override
+    public Optional<ImmutableSet<RDFFact>> loadInputFacts() throws OWLOntologyCreationException {
+        if (factsFile.isPresent()){
+            return factsFile;
+        }
+
+        return loadFactsFromFile();
     }
 
     /**
@@ -99,6 +106,59 @@ public class OntopMappingOntologyConfigurationImpl extends OntopMappingConfigura
         }
 
         return owlOntology;
+    }
+
+    private ImmutableSet<RDFFact> axiomsToFacts(InputStream file, OWLOntologyManager manager) throws OWLOntologyCreationException {
+        var factOntology = manager.loadOntologyFromOntologyDocument(file);
+        OWLAPITranslatorOWL2QL translator = getInjector().getInstance(OWLAPITranslatorOWL2QL.class);
+        var translated = translator.translateAndClassify(factOntology);
+        var extractor = getInjector().getInstance(FactExtractorWithSaturatedTBox.class);
+        return extractor.extractAndSelect(Optional.of(translated), true);
+    }
+
+    private Optional<ImmutableSet<RDFFact>> loadFactsFromFile() throws OWLOntologyCreationException {
+        /*
+         * File
+         */
+        OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+        //var e = new FactExtractorWithSaturatedTBox(getTermFactory(), this);
+
+        if (options.factsFile.isPresent()) {
+            try {
+                factsFile = Optional.of(axiomsToFacts(new FileInputStream(options.factsFile.get()), manager));
+            } catch (IOException e) {
+                throw new OWLOntologyCreationException(e.getMessage());
+            }
+        }
+        else if (options.factsReader.isPresent()) {
+            try {
+                InputStream inputStream = new ByteArrayInputStream(
+                        CharStreams.toString(options.factsReader.get())
+                                .getBytes(Charsets.UTF_8));
+                factsFile = Optional.of(axiomsToFacts(inputStream, manager));
+            } catch (IOException e) {
+                throw new OWLOntologyCreationException(e.getMessage());
+            }
+
+        }
+
+        /*
+         * URL
+         */
+        Optional<URL> optionalURL = options.factsURL;
+        if (optionalURL.isPresent()) {
+            try (InputStream is = optionalURL.get().openStream()) {
+                factsFile = Optional.of(axiomsToFacts(is, manager));
+            }
+            catch (MalformedURLException e ) {
+                throw new OWLOntologyCreationException("Invalid URI: " + e.getMessage());
+            }
+            catch (IOException e) {
+                throw new OWLOntologyCreationException(e.getMessage());
+            }
+        }
+
+        return factsFile;
     }
 
     Optional<Ontology> loadOntology() throws OntologyException {

--- a/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyConfigurationImpl.java
+++ b/mapping/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingOntologyConfigurationImpl.java
@@ -29,6 +29,7 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
+import java.util.UUID;
 
 public class OntopMappingOntologyConfigurationImpl extends OntopMappingConfigurationImpl
         implements OntopMappingOntologyConfiguration, OntopOntologyOWLAPIConfiguration {
@@ -158,10 +159,7 @@ public class OntopMappingOntologyConfigurationImpl extends OntopMappingConfigura
         Model model = new LinkedHashModel();
         parser.setRDFHandler(new StatementCollector(model));
         try {
-            if(options.factsBaseURI.isPresent())
-                parser.parse(reader, options.factsBaseURI.get());
-            else
-                parser.parse(reader);
+            parser.parse(reader, options.factsBaseIRI.orElse(UUID.randomUUID().toString()));
         } catch (IOException e) {
             throw new FactsException(e);
         }

--- a/mapping/sql/all/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingSQLAllConfigurationImpl.java
+++ b/mapping/sql/all/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingSQLAllConfigurationImpl.java
@@ -38,13 +38,13 @@ public class OntopMappingSQLAllConfigurationImpl extends OntopMappingSQLConfigur
 
     @Override
     protected OBDASpecification loadOBDASpecification() throws OBDASpecificationException {
-        return loadSpecification(Optional::empty);
+        return loadSpecification(Optional::empty, Optional::empty);
     }
 
-    OBDASpecification loadSpecification(OntologySupplier ontologySupplier)
+    OBDASpecification loadSpecification(OntologySupplier ontologySupplier, FactsSupplier factsSupplier)
             throws OBDASpecificationException {
 
-        return loadSpecification(ontologySupplier,
+        return loadSpecification(ontologySupplier, factsSupplier,
                 () -> options.mappingFile,
                 () -> options.mappingReader,
                 () -> options.mappingGraph,

--- a/mapping/sql/core/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingSQLConfigurationImpl.java
+++ b/mapping/sql/core/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingSQLConfigurationImpl.java
@@ -68,11 +68,11 @@ public class OntopMappingSQLConfigurationImpl extends OntopMappingConfigurationI
      */
     @Override
     protected OBDASpecification loadOBDASpecification() throws OBDASpecificationException {
-        return loadSpecification(Optional::empty, Optional::empty, Optional::empty, Optional::empty, Optional::empty,
+        return loadSpecification(Optional::empty, Optional::empty, Optional::empty, Optional::empty, Optional::empty, Optional::empty,
                 Optional::empty, Optional::empty, Optional::empty, Optional::empty);
     }
 
-    OBDASpecification loadSpecification(OntologySupplier ontologySupplier,
+    OBDASpecification loadSpecification(OntologySupplier ontologySupplier, FactsSupplier factsSupplier,
                                         Supplier<Optional<File>> mappingFileSupplier,
                                         Supplier<Optional<Reader>> mappingReaderSupplier,
                                         Supplier<Optional<Graph>> mappingGraphSupplier,
@@ -84,6 +84,7 @@ public class OntopMappingSQLConfigurationImpl extends OntopMappingConfigurationI
             throws OBDASpecificationException {
         return loadSpecification(
                 ontologySupplier,
+                factsSupplier,
                 () -> options.ppMapping,
                 mappingFileSupplier,
                 mappingReaderSupplier,

--- a/mapping/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingSQLAllOWLAPIConfigurationImpl.java
+++ b/mapping/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingSQLAllOWLAPIConfigurationImpl.java
@@ -37,7 +37,7 @@ public class OntopMappingSQLAllOWLAPIConfigurationImpl extends OntopMappingSQLAl
     }
 
     @Override
-    public Optional<ImmutableSet<RDFFact>> loadInputFacts() throws OWLOntologyCreationException {
+    public Optional<ImmutableSet<RDFFact>> loadInputFacts() throws OBDASpecificationException {
         return mappingOWLConfiguration.loadInputFacts();
     }
 

--- a/mapping/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingSQLAllOWLAPIConfigurationImpl.java
+++ b/mapping/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingSQLAllOWLAPIConfigurationImpl.java
@@ -104,6 +104,16 @@ public class OntopMappingSQLAllOWLAPIConfigurationImpl extends OntopMappingSQLAl
         }
 
         @Override
+        public B factFormat(@Nonnull String factFormat) {
+            return ontologyBuilderFragment.factFormat(factFormat);
+        }
+
+        @Override
+        public B factsBaseURI(@Nonnull String factsBaseURI) {
+            return ontologyBuilderFragment.factsBaseURI(factsBaseURI);
+        }
+
+        @Override
         public B factsFile(@Nonnull URL url) {
             return ontologyBuilderFragment.factsFile(url);
         }

--- a/mapping/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingSQLAllOWLAPIConfigurationImpl.java
+++ b/mapping/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingSQLAllOWLAPIConfigurationImpl.java
@@ -1,10 +1,12 @@
 package it.unibz.inf.ontop.injection.impl;
 
+import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.exception.OBDASpecificationException;
 import it.unibz.inf.ontop.exception.InvalidOntopConfigurationException;
 import it.unibz.inf.ontop.injection.OntopMappingSQLAllOWLAPIConfiguration;
 import it.unibz.inf.ontop.injection.OntopMappingSQLAllSettings;
 import it.unibz.inf.ontop.spec.OBDASpecification;
+import it.unibz.inf.ontop.spec.ontology.RDFFact;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
@@ -27,11 +29,16 @@ public class OntopMappingSQLAllOWLAPIConfigurationImpl extends OntopMappingSQLAl
 
     @Override
     protected OBDASpecification loadOBDASpecification() throws OBDASpecificationException {
-        return loadSpecification(mappingOWLConfiguration::loadOntology);
+        return loadSpecification(mappingOWLConfiguration::loadOntology, mappingOWLConfiguration::loadInputFacts);
     }
     @Override
     public Optional<OWLOntology> loadInputOntology() throws OWLOntologyCreationException {
         return mappingOWLConfiguration.loadInputOntology();
+    }
+
+    @Override
+    public Optional<ImmutableSet<RDFFact>> loadInputFacts() throws OWLOntologyCreationException {
+        return mappingOWLConfiguration.loadInputFacts();
     }
 
     static class OntopMappingSQLAllOWLAPIOptions {
@@ -89,6 +96,26 @@ public class OntopMappingSQLAllOWLAPIConfigurationImpl extends OntopMappingSQLAl
         @Override
         public B xmlCatalogFile(@Nonnull String file) {
             return ontologyBuilderFragment.xmlCatalogFile(file);
+        }
+
+        @Override
+        public B factsFile(@Nonnull String urlOrPath) {
+            return ontologyBuilderFragment.factsFile(urlOrPath);
+        }
+
+        @Override
+        public B factsFile(@Nonnull URL url) {
+            return ontologyBuilderFragment.factsFile(url);
+        }
+
+        @Override
+        public B factsFile(@Nonnull File owlFile) {
+            return ontologyBuilderFragment.factsFile(owlFile);
+        }
+
+        @Override
+        public B factsReader(@Nonnull Reader reader) {
+            return ontologyBuilderFragment.factsReader(reader);
         }
 
         protected final void declareOntologyDefined() {

--- a/mapping/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingSQLAllOWLAPIConfigurationImpl.java
+++ b/mapping/sql/owlapi/src/main/java/it/unibz/inf/ontop/injection/impl/OntopMappingSQLAllOWLAPIConfigurationImpl.java
@@ -109,8 +109,8 @@ public class OntopMappingSQLAllOWLAPIConfigurationImpl extends OntopMappingSQLAl
         }
 
         @Override
-        public B factsBaseURI(@Nonnull String factsBaseURI) {
-            return ontologyBuilderFragment.factsBaseURI(factsBaseURI);
+        public B factsBaseIRI(@Nonnull String factsBaseIRI) {
+            return ontologyBuilderFragment.factsBaseIRI(factsBaseIRI);
         }
 
         @Override

--- a/ontology/owlapi/src/main/java/it/unibz/inf/ontop/injection/OntopOntologyOWLAPIConfiguration.java
+++ b/ontology/owlapi/src/main/java/it/unibz/inf/ontop/injection/OntopOntologyOWLAPIConfiguration.java
@@ -1,6 +1,7 @@
 package it.unibz.inf.ontop.injection;
 
 import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.exception.OBDASpecificationException;
 import it.unibz.inf.ontop.spec.ontology.RDFFact;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
@@ -11,7 +12,7 @@ public interface OntopOntologyOWLAPIConfiguration extends OntopModelConfiguratio
 
     Optional<OWLOntology> loadInputOntology() throws OWLOntologyCreationException;
 
-    Optional<ImmutableSet<RDFFact>> loadInputFacts() throws OWLOntologyCreationException;
+    Optional<ImmutableSet<RDFFact>> loadInputFacts() throws OBDASpecificationException;
 
     /**
      * Only call it if you are sure that an ontology has been provided

--- a/ontology/owlapi/src/main/java/it/unibz/inf/ontop/injection/OntopOntologyOWLAPIConfiguration.java
+++ b/ontology/owlapi/src/main/java/it/unibz/inf/ontop/injection/OntopOntologyOWLAPIConfiguration.java
@@ -1,5 +1,7 @@
 package it.unibz.inf.ontop.injection;
 
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.spec.ontology.RDFFact;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
@@ -8,6 +10,8 @@ import java.util.Optional;
 public interface OntopOntologyOWLAPIConfiguration extends OntopModelConfiguration {
 
     Optional<OWLOntology> loadInputOntology() throws OWLOntologyCreationException;
+
+    Optional<ImmutableSet<RDFFact>> loadInputFacts() throws OWLOntologyCreationException;
 
     /**
      * Only call it if you are sure that an ontology has been provided


### PR DESCRIPTION
Currently, additional facts have to be passed to Ontop through the ontology file - this is not a clean solution.

Added new parameters to all Ontop CLI commands to also provide a "facts" file in any RDF format.
The following parameters have been added 

-a <file>; --facts <file>: A file containing a collection of facts.
--fact-format <format>: The format to be used to parse the file. If not provided, we try to infer the format from the file extension. Supports the same formats as the `ontop materialize` command.
--facts-base-iri <baseIRI>: The base IRI used for the provided fact file. If none is given, a random IRI is generated instead.

Also added test cases for fact files in RDFXML format, TURTLE format, and in N-QUADS format with additional context graphs.