### PR TITLE
Join transfer made more robust to non-nullable unique constraints in complex right children

### DIFF
--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/AbstractJoinTransferLJTransformer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/AbstractJoinTransferLJTransformer.java
@@ -65,7 +65,7 @@ public abstract class AbstractJoinTransferLJTransformer extends DefaultNonRecurs
     public IQTree transformLeftJoin(IQTree tree, LeftJoinNode rootNode, IQTree leftChild, IQTree rightChild) {
         IQTree transformedLeftChild = transform(leftChild);
         // Cannot reuse
-        IQTree transformedRightChild = preTransformLJRightChild(rightChild);
+        IQTree transformedRightChild = preTransformLJRightChild(rightChild, rootNode.getOptionalFilterCondition());
 
         return furtherTransformLeftJoin(rootNode, transformedLeftChild, transformedRightChild)
                 .orElseGet(() -> transformedLeftChild.equals(leftChild)
@@ -460,9 +460,7 @@ public abstract class AbstractJoinTransferLJTransformer extends DefaultNonRecurs
     /**
      * Can be overridden
      */
-    protected IQTree preTransformLJRightChild(IQTree rightChild) {
-        return transformBySearchingFromScratch(rightChild);
-    }
+    abstract protected IQTree preTransformLJRightChild(IQTree rightChild, Optional<ImmutableExpression> ljCondition);
 
     protected static class SelectedNode {
 

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalityInsensitiveJoinTransferLJOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalityInsensitiveJoinTransferLJOptimizer.java
@@ -21,6 +21,7 @@ import it.unibz.inf.ontop.iq.optimizer.LeftJoinIQOptimizer;
 import it.unibz.inf.ontop.iq.optimizer.impl.LookForDistinctOrLimit1TransformerImpl;
 import it.unibz.inf.ontop.iq.transform.IQTreeTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
+import it.unibz.inf.ontop.model.term.ImmutableExpression;
 import it.unibz.inf.ontop.model.term.VariableOrGroundTerm;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import it.unibz.inf.ontop.utils.VariableGenerator;
@@ -127,7 +128,7 @@ public class CardinalityInsensitiveJoinTransferLJOptimizer implements LeftJoinIQ
         }
 
         @Override
-        protected IQTree preTransformLJRightChild(IQTree rightChild) {
+        protected IQTree preTransformLJRightChild(IQTree rightChild, Optional<ImmutableExpression> ljCondition) {
             return transformBySearchingFromScratchFromDistinctTree(rightChild);
         }
 

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalitySensitiveJoinTransferLJOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalitySensitiveJoinTransferLJOptimizer.java
@@ -11,8 +11,12 @@ import it.unibz.inf.ontop.iq.IQ;
 import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.node.ExtensionalDataNode;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.iq.node.impl.JoinOrFilterVariableNullabilityTools;
 import it.unibz.inf.ontop.iq.node.normalization.impl.RightProvenanceNormalizer;
 import it.unibz.inf.ontop.iq.optimizer.LeftJoinIQOptimizer;
+import it.unibz.inf.ontop.model.term.ImmutableExpression;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.term.Variable;
 import it.unibz.inf.ontop.model.term.VariableOrGroundTerm;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import it.unibz.inf.ontop.utils.VariableGenerator;
@@ -28,15 +32,18 @@ public class CardinalitySensitiveJoinTransferLJOptimizer implements LeftJoinIQOp
     private final RightProvenanceNormalizer rightProvenanceNormalizer;
     private final CoreSingletons coreSingletons;
     private final IntermediateQueryFactory iqFactory;
+    private final JoinOrFilterVariableNullabilityTools variableNullabilityTools;
 
     @Inject
     protected CardinalitySensitiveJoinTransferLJOptimizer(RequiredExtensionalDataNodeExtractor requiredDataNodeExtractor,
                                                           RightProvenanceNormalizer rightProvenanceNormalizer,
+                                                          JoinOrFilterVariableNullabilityTools variableNullabilityTools,
                                                           CoreSingletons coreSingletons) {
         this.requiredDataNodeExtractor = requiredDataNodeExtractor;
         this.rightProvenanceNormalizer = rightProvenanceNormalizer;
         this.coreSingletons = coreSingletons;
         this.iqFactory = coreSingletons.getIQFactory();
+        this.variableNullabilityTools = variableNullabilityTools;
     }
 
     @Override
@@ -47,7 +54,7 @@ public class CardinalitySensitiveJoinTransferLJOptimizer implements LeftJoinIQOp
                 query.getVariableGenerator(),
                 requiredDataNodeExtractor,
                 rightProvenanceNormalizer,
-                coreSingletons);
+                coreSingletons, variableNullabilityTools);
 
         IQTree newTree = initialTree.acceptTransformer(transformer);
 
@@ -58,11 +65,16 @@ public class CardinalitySensitiveJoinTransferLJOptimizer implements LeftJoinIQOp
 
     protected static class Transformer extends AbstractJoinTransferLJTransformer {
 
+        private final JoinOrFilterVariableNullabilityTools variableNullabilityTools;
+        private final TermFactory termFactory;
+
         protected Transformer(Supplier<VariableNullability> variableNullabilitySupplier,
                               VariableGenerator variableGenerator, RequiredExtensionalDataNodeExtractor requiredDataNodeExtractor,
                               RightProvenanceNormalizer rightProvenanceNormalizer,
-                              CoreSingletons coreSingletons) {
+                              CoreSingletons coreSingletons, JoinOrFilterVariableNullabilityTools variableNullabilityTools) {
             super(variableNullabilitySupplier, variableGenerator, requiredDataNodeExtractor, rightProvenanceNormalizer, coreSingletons);
+            this.variableNullabilityTools = variableNullabilityTools;
+            this.termFactory = coreSingletons.getTermFactory();
         }
 
 
@@ -105,8 +117,45 @@ public class CardinalitySensitiveJoinTransferLJOptimizer implements LeftJoinIQOp
         @Override
         protected IQTree transformBySearchingFromScratch(IQTree tree) {
             Transformer newTransformer = new Transformer(tree::getVariableNullability, variableGenerator, requiredDataNodeExtractor,
-                    rightProvenanceNormalizer, coreSingletons);
+                    rightProvenanceNormalizer, coreSingletons, variableNullabilityTools);
             return tree.acceptTransformer(newTransformer);
+        }
+
+        @Override
+        protected IQTree preTransformLJRightChild(IQTree rightChild, Optional<ImmutableExpression> ljCondition) {
+            Supplier<VariableNullability> variableNullabilitySupplier =
+                    () -> computeRightChildVariableNullability(rightChild, ljCondition);
+
+            Transformer newTransformer = new Transformer(variableNullabilitySupplier, variableGenerator, requiredDataNodeExtractor,
+                    rightProvenanceNormalizer, coreSingletons, variableNullabilityTools);
+            return rightChild.acceptTransformer(newTransformer);
+        }
+
+        @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+        private VariableNullability computeRightChildVariableNullability(IQTree rightChild, Optional<ImmutableExpression> ljCondition) {
+            VariableNullability bottomUpNullability = rightChild.getVariableNullability();
+
+            VariableNullability nullabilityWithLJCondition = ljCondition
+                    .map(c -> variableNullabilityTools.updateWithFilter(c, bottomUpNullability.getNullableGroups(),
+                                    rightChild.getVariables()))
+                    .orElse(bottomUpNullability);
+
+            ImmutableSet<Variable> nullableVariablesAfterLJCondition = nullabilityWithLJCondition.getNullableVariables();
+
+            if (nullableVariablesAfterLJCondition.isEmpty())
+                return nullabilityWithLJCondition;
+
+            VariableNullability inheritedNullability = getInheritedVariableNullability();
+
+            // Non-nullability information coming from the ancestors
+            Optional<ImmutableExpression> additionalFilter = termFactory.getConjunction(nullableVariablesAfterLJCondition.stream()
+                    .filter(v -> !inheritedNullability.isPossiblyNullable(v))
+                    .map(termFactory::getDBIsNotNull));
+
+            return additionalFilter
+                    .map(c -> variableNullabilityTools.updateWithFilter(c, nullabilityWithLJCondition.getNullableGroups(),
+                            rightChild.getVariables()))
+                    .orElse(nullabilityWithLJCondition);
         }
     }
 


### PR DESCRIPTION
Now optimizes examples like

```
LJ
   EXTENSIONAL TABLE1(0:a,1:d)
   LJ
      EXTENSIONAL TABLE7(0:a,1:c)
      EXTENSIONAL TABLE7(0:a,2:b)
```
into
```
LJ
   EXTENSIONAL TABLE1(0:a,1:d)
   EXTENSIONAL TABLE7(0:a,1:c,2:b)
```

and
```
LJ IS_NOT_NULL(a)
   EXTENSIONAL TABLE1(0:d)
   LJ
      EXTENSIONAL TABLE7(0:a,1:c)
      EXTENSIONAL TABLE7(0:a,2:b)
```
into
```
LJ IS_NOT_NULL(a)
   EXTENSIONAL TABLE1(0:d)
   EXTENSIONAL TABLE7(0:a,1:c,2:b)
```

where the first column of `TABLE7` has a nullable unique constraint.