### PR TITLE
Propagate Unique Constraints of lenses upwards

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/LensMetadataProviderImpl.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/LensMetadataProviderImpl.java
@@ -147,9 +147,9 @@ public class LensMetadataProviderImpl implements LensMetadataProvider {
                 Queue<NamedRelationDefinition> lensesForPropagation = new ArrayDeque<>();
                 lensesForPropagation.add(relation);
                 while(!lensesForPropagation.isEmpty()) {
-                    var currentPropagationLens = lensesForPropagation.poll();
-                    var currentPropagationJsonLens = jsonMap.get(currentPropagationLens.getID());
-                    var currentPropagationParents = dependencyCacheMetadataLookup.getBaseRelations(currentPropagationLens.getID());
+                    NamedRelationDefinition currentPropagationLens = lensesForPropagation.poll();
+                    JsonLens currentPropagationJsonLens = jsonMap.get(currentPropagationLens.getID());
+                    ImmutableList<NamedRelationDefinition> currentPropagationParents = dependencyCacheMetadataLookup.getBaseRelations(currentPropagationLens.getID());
                     if(currentPropagationJsonLens.propagateUniqueConstraintsUp((Lens)currentPropagationLens, currentPropagationParents, getQuotedIDFactory())) {
                         lensesForPropagation.addAll(currentPropagationParents.stream()
                                 .filter(l -> l instanceof Lens)

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/LensMetadataProviderImpl.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/LensMetadataProviderImpl.java
@@ -138,6 +138,19 @@ public class LensMetadataProviderImpl implements LensMetadataProvider {
 
                 jsonLens.insertIntegrityConstraints((Lens) relation, baseRelations, metadataLookupForFK,
                         getDBParameters());
+
+                JsonLens currentPropagateLens = jsonLens;
+                NamedRelationDefinition currentPropagateRelation = relation;
+                ImmutableList<NamedRelationDefinition> currentPropagateParents = baseRelations;
+                while(!currentPropagateParents.isEmpty() && currentPropagateLens != null && currentPropagateLens.propagateUniqueConstraintsUp((Lens)currentPropagateRelation, currentPropagateParents, getQuotedIDFactory())) {
+                    currentPropagateRelation = currentPropagateParents.get(0);
+                    currentPropagateLens = jsonMap.get(currentPropagateRelation.getID());
+                    try {
+                        currentPropagateParents = dependencyCacheMetadataLookup.getBaseRelations(currentPropagateRelation.getID());
+                    } catch (NullPointerException ex) {
+                        break;
+                    }
+                }
             }
         }
         else {

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonBasicLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonBasicLens.java
@@ -5,11 +5,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.*;
 import it.unibz.inf.ontop.dbschema.*;
+import it.unibz.inf.ontop.dbschema.impl.UniqueConstraintImpl;
 import it.unibz.inf.ontop.exception.MetadataExtractionException;
+import it.unibz.inf.ontop.injection.CoreSingletons;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @JsonDeserialize(as = JsonBasicLens.class)
 public class JsonBasicLens extends JsonBasicOrJoinLens {
@@ -53,4 +56,52 @@ public class JsonBasicLens extends JsonBasicOrJoinLens {
 
         return getDerivedFromParentAttributes(lens, parentAttributes);
     }
+
+    public boolean propagateUniqueConstraintsUp(Lens relation, ImmutableList<NamedRelationDefinition> parents, QuotedIDFactory idFactory) throws MetadataExtractionException {
+        //There is no guarantee a UC will hold in the parent if the lens performed a filter.
+        if(filterExpression != null)
+            return false;
+
+        var ucs = relation.getUniqueConstraints();
+        var propagableConstraints = ucs.stream().filter(this::noDeterminantOverridden).filter(u -> this.ucNotInParent(u, parents.get(0))).collect(Collectors.toList());
+        if(propagableConstraints.isEmpty())
+            return false;
+        for(var uc : propagableConstraints) {
+            var builder = UniqueConstraint.builder(parents.get(0), uc.getName());
+            JsonMetadata.deserializeAttributeList(idFactory, uc.getDeterminants().stream().map(d -> d.getID().getSQLRendering()).collect(Collectors.toList()), builder::addDeterminant);
+            builder.build();
+        }
+        return true;
+    }
+
+    private boolean noDeterminantOverridden(UniqueConstraint uc) {
+        return Sets.intersection(
+                uc.getDeterminants().stream().map(a -> a.getID().getName()).collect(Collectors.toSet()),
+                columns.added.stream().map(a -> a.name).collect(Collectors.toSet())
+        ).isEmpty();
+    }
+
+    private boolean ucNotInParent(UniqueConstraint uc, NamedRelationDefinition parent) {
+        return !parent.getUniqueConstraints().stream()
+                .anyMatch(u -> this.ucEquals(uc, u));
+    }
+
+    private boolean ucEquals(UniqueConstraint uc1, UniqueConstraint uc2) {
+        return uc1.getDeterminants().stream()
+                .map(a -> a.getID().getSQLRendering())
+                .collect(Collectors.toSet()).equals(
+                        uc2.getDeterminants().stream()
+                                .map(a -> a.getID().getSQLRendering())
+                                .collect(Collectors.toSet())
+                );
+    }
+
+    @Override
+    protected void insertUniqueConstraints(Lens relation, QuotedIDFactory idFactory,
+                                           List<AddUniqueConstraints> addUniqueConstraints,
+                                           ImmutableList<NamedRelationDefinition> baseRelations,
+                                           CoreSingletons coreSingletons) throws MetadataExtractionException {
+        super.insertUniqueConstraints(relation, idFactory, addUniqueConstraints, baseRelations, coreSingletons);
+    }
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
@@ -84,7 +84,7 @@ public abstract class JsonLens extends JsonOpenObject {
      * Propagates unique constraints of this lens to its parents, if possible. Returns true if at least one constraint was propagated.
      */
     public boolean propagateUniqueConstraintsUp(Lens relation, ImmutableList<NamedRelationDefinition> parents, QuotedIDFactory idFactory) throws MetadataExtractionException {
-        //Does nothing by default, but is implemented by JsonBasicLens.
+        //Does nothing by default, but is implemented by JsonBasicLens. May also be implemented by other lenses under certain conditions.
         return false;
     }
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
@@ -81,6 +81,14 @@ public abstract class JsonLens extends JsonOpenObject {
                                                     MetadataLookup metadataLookup, DBParameters dbParameters) throws MetadataExtractionException;
 
     /**
+     * Propagates unique constraints of this lens to its parents, if possible. Returns true if at least one constraint was propagated.
+     */
+    public boolean propagateUniqueConstraintsUp(Lens relation, ImmutableList<NamedRelationDefinition> parents, QuotedIDFactory idFactory) throws MetadataExtractionException {
+        //Does nothing by default, but is implemented by JsonBasicLens.
+        return false;
+    }
+
+    /**
      * May be incomplete, but must not produce any false positive.
      *
      * Returns the attributes for which it can be proved that the projection over them includes the results

--- a/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/BasicLensPropagateUCUpTest.java
+++ b/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/BasicLensPropagateUCUpTest.java
@@ -68,6 +68,36 @@ public class BasicLensPropagateUCUpTest {
         assertHasUCs(lensMap.get("lenses.x1"), ImmutableSet.of(ImmutableSet.of("id")));
     }
 
+    @Test
+    public void testNoPropagationFilter() {
+        assertHasUCs(tableMap.get("base_table_2"), ImmutableSet.of());
+    }
+
+    @Test
+    public void testNoPropagationOverride() {
+        assertHasUCs(tableMap.get("base_table_3"), ImmutableSet.of());
+    }
+
+    @Test
+    public void testNoPropagationCompositeOverride() {
+        assertHasUCs(tableMap.get("base_table_4"), ImmutableSet.of());
+    }
+
+    @Test
+    public void testPropagateCompositeConstraint() {
+        assertHasUCs(tableMap.get("base_table_5"), ImmutableSet.of(ImmutableSet.of("a", "b")));
+    }
+
+    @Test
+    public void testSomeVariablesOverridden() {
+        assertHasUCs(tableMap.get("base_table_6"), ImmutableSet.of(ImmutableSet.of("c")));
+    }
+
+    @Test
+    public void testPropagateMultipleConstraints() {
+        assertHasUCs(tableMap.get("base_table_7"), ImmutableSet.of(ImmutableSet.of("a"), ImmutableSet.of("b")));
+    }
+
     private void assertHasUCs(NamedRelationDefinition relation, ImmutableSet<ImmutableSet<String>> expected) {
         assertEquals(expected, relation.getUniqueConstraints().stream()
                 .map(uc -> uc.getDeterminants().stream()

--- a/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/BasicLensPropagateUCUpTest.java
+++ b/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/BasicLensPropagateUCUpTest.java
@@ -1,0 +1,83 @@
+package it.unibz.inf.ontop.dbschema;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class BasicLensPropagateUCUpTest {
+    private static final String LENS_FILE = "src/test/resources/propagate-uc-up/lenses.json";
+    private static final String DBMETADATA_FILE = "src/test/resources/propagate-uc-up/metadata.db-extract.json";
+
+    private final ImmutableSet<NamedRelationDefinition> relationDefinitions = LensParsingTest.loadLensesAndTablesH2(LENS_FILE, DBMETADATA_FILE);
+    private final ImmutableMap<String, Lens> lensMap;
+    private final ImmutableMap<String, NamedRelationDefinition> tableMap;
+
+    public BasicLensPropagateUCUpTest() throws Exception {
+        lensMap = relationDefinitions.stream()
+                .filter(l -> l instanceof Lens)
+                .map(l -> (Lens)l)
+                .collect(ImmutableCollectors.<Lens, String, Lens>toMap(
+                    l -> String.join(".", l.getID().getComponents().reverse().stream().map(c -> c.getName()).collect(Collectors.toList())),
+                    l -> l
+        ));
+        tableMap = relationDefinitions.stream()
+                .filter(t -> !(t instanceof Lens))
+                .collect(ImmutableCollectors.<NamedRelationDefinition, String, NamedRelationDefinition>toMap(
+                        t -> String.join(".", t.getID().getComponents().reverse().stream().map(c -> c.getName()).collect(Collectors.toList())),
+                        t -> t
+                ));
+    }
+
+    @Test
+    public void testLeafUC() {
+        assertHasUCs(lensMap.get("lenses.l4"), ImmutableSet.of(ImmutableSet.of("id")));
+    }
+
+    @Test
+    public void testDirectPropagation() {
+        assertHasUCs(lensMap.get("lenses.l3"), ImmutableSet.of(ImmutableSet.of("id")));
+    }
+
+    @Test
+    public void testTwoLevelPropagation() {
+        assertHasUCs(lensMap.get("lenses.l2"), ImmutableSet.of(ImmutableSet.of("id")));
+    }
+
+    @Test
+    public void testMultilevelPropagation() {
+        assertHasUCs(lensMap.get("lenses.l1"), ImmutableSet.of(ImmutableSet.of("id")));
+    }
+
+    @Test
+    public void testSourceTablePropagation() {
+        assertHasUCs(tableMap.get("base_table"), ImmutableSet.of(ImmutableSet.of("id")));
+    }
+
+    //The 'x' lenses are loaded in opposite order (starting with the one that define the UC first. Thi way, recursive propagation should happen more often.
+    @Test
+    public void testOppositeOrderPropagation() {
+        assertHasUCs(lensMap.get("lenses.x1"), ImmutableSet.of(ImmutableSet.of("id")));
+    }
+
+    @Test
+    public void testUpThenDownPropagation() {
+        assertHasUCs(lensMap.get("lenses.a"), ImmutableSet.of(ImmutableSet.of("id")));
+    }
+
+    private void assertHasUCs(NamedRelationDefinition relation, ImmutableSet<ImmutableSet<String>> expected) {
+        assertEquals(expected, relation.getUniqueConstraints().stream()
+                .map(uc -> uc.getDeterminants().stream().map(
+                        det -> det.getID().getName()
+                ).collect(Collectors.toSet()))
+                .collect(Collectors.toSet()));
+        assertEquals(expected.size(), relation.getUniqueConstraints().size());
+
+    }
+
+
+}

--- a/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/BasicLensPropagateUCUpTest.java
+++ b/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/BasicLensPropagateUCUpTest.java
@@ -22,13 +22,17 @@ public class BasicLensPropagateUCUpTest {
                 .filter(l -> l instanceof Lens)
                 .map(l -> (Lens)l)
                 .collect(ImmutableCollectors.<Lens, String, Lens>toMap(
-                    l -> String.join(".", l.getID().getComponents().reverse().stream().map(c -> c.getName()).collect(Collectors.toList())),
+                    l -> String.join(".", l.getID().getComponents().reverse().stream()
+                            .map(c -> c.getName())
+                            .collect(Collectors.toList())),
                     l -> l
         ));
         tableMap = relationDefinitions.stream()
                 .filter(t -> !(t instanceof Lens))
                 .collect(ImmutableCollectors.<NamedRelationDefinition, String, NamedRelationDefinition>toMap(
-                        t -> String.join(".", t.getID().getComponents().reverse().stream().map(c -> c.getName()).collect(Collectors.toList())),
+                        t -> String.join(".", t.getID().getComponents().reverse()
+                                .stream().map(c -> c.getName())
+                                .collect(Collectors.toList())),
                         t -> t
                 ));
     }
@@ -64,16 +68,11 @@ public class BasicLensPropagateUCUpTest {
         assertHasUCs(lensMap.get("lenses.x1"), ImmutableSet.of(ImmutableSet.of("id")));
     }
 
-    @Test
-    public void testUpThenDownPropagation() {
-        assertHasUCs(lensMap.get("lenses.a"), ImmutableSet.of(ImmutableSet.of("id")));
-    }
-
     private void assertHasUCs(NamedRelationDefinition relation, ImmutableSet<ImmutableSet<String>> expected) {
         assertEquals(expected, relation.getUniqueConstraints().stream()
-                .map(uc -> uc.getDeterminants().stream().map(
-                        det -> det.getID().getName()
-                ).collect(Collectors.toSet()))
+                .map(uc -> uc.getDeterminants().stream()
+                        .map(det -> det.getID().getName())
+                        .collect(Collectors.toSet()))
                 .collect(Collectors.toSet()));
         assertEquals(expected.size(), relation.getUniqueConstraints().size());
 

--- a/db/rdb/src/test/resources/propagate-uc-up/lenses.json
+++ b/db/rdb/src/test/resources/propagate-uc-up/lenses.json
@@ -93,6 +93,161 @@
         "hidden": []
       },
       "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"filter\""],
+      "baseRelation": ["\"base_table_2\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [
+              "\"name\""
+            ],
+            "isPrimaryKey": false
+          }
+        ]
+      },
+      "filterExpression": "\"id\" > 10",
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"override\""],
+      "baseRelation": ["\"base_table_3\""],
+      "columns": {
+        "added":  [
+          {
+            "name": "\"name\"",
+            "expression": "CONCAT(\"name\",'!')"
+          }
+        ],
+        "hidden": []
+      },
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [
+              "\"name\""
+            ],
+            "isPrimaryKey": false
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"composite_override\""],
+      "baseRelation": ["\"base_table_4\""],
+      "columns": {
+        "added":  [
+          {
+            "name": "\"a\"",
+            "expression": "\"a\" + \"b\""
+          }
+        ],
+        "hidden": []
+      },
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [
+              "\"a\"",
+              "\"b\""
+            ],
+            "isPrimaryKey": false
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"composite\""],
+      "baseRelation": ["\"base_table_5\""],
+      "columns": {
+        "added":  [],
+        "hidden": []
+      },
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [
+              "\"a\"",
+              "\"b\""
+            ],
+            "isPrimaryKey": false
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"override_unrelated\""],
+      "baseRelation": ["\"base_table_6\""],
+      "columns": {
+        "added":  [
+          {
+            "name": "\"b\"",
+            "expression": "2"
+          }
+        ],
+        "hidden": []
+      },
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [
+              "\"c\""
+            ],
+            "isPrimaryKey": false
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+
+    {
+      "name": ["\"lenses\"", "\"y1\""],
+      "baseRelation": ["\"base_table_7\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"y2\""],
+      "baseRelation": ["\"lenses\"", "\"y1\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc1",
+            "determinants": [
+              "\"a\""
+            ],
+            "isPrimaryKey": false
+          },
+          {
+            "name": "uc2",
+            "determinants": [
+              "\"b\""
+            ],
+            "isPrimaryKey": false
+          }
+        ]
+      },
+      "type": "BasicLens"
     }
   ]
 }

--- a/db/rdb/src/test/resources/propagate-uc-up/lenses.json
+++ b/db/rdb/src/test/resources/propagate-uc-up/lenses.json
@@ -1,0 +1,98 @@
+{
+  "relations": [
+    {
+      "name": ["\"lenses\"", "\"l1\""],
+      "baseRelation": ["\"base_table\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"l2\""],
+      "baseRelation": ["\"lenses\"", "\"l1\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"l3\""],
+      "baseRelation": ["\"lenses\"", "\"l2\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"l4\""],
+      "baseRelation": ["\"lenses\"", "\"l3\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [
+              "\"id\""
+            ],
+            "isPrimaryKey": false
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"x1\""],
+      "baseRelation": ["\"lenses\"", "\"x2\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [
+              "\"id\""
+            ],
+            "isPrimaryKey": false
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"x2\""],
+      "baseRelation": ["\"lenses\"", "\"x3\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"x3\""],
+      "baseRelation": ["\"base_table\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"a\""],
+      "baseRelation": ["\"base_table\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    }
+  ]
+}

--- a/db/rdb/src/test/resources/propagate-uc-up/metadata.db-extract.json
+++ b/db/rdb/src/test/resources/propagate-uc-up/metadata.db-extract.json
@@ -14,10 +14,236 @@
           "name": "\"name\"",
           "datatype": "VARCHAR",
           "isNullable": false
+        },
+        {
+          "name": "\"a\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"b\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"c\"",
+          "datatype": "INTEGER",
+          "isNullable": false
         }
       ],
       "name": [
         "\"base_table\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        },
+        {
+          "name": "\"a\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"b\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"c\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"base_table_2\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        },
+        {
+          "name": "\"a\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"b\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"c\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"base_table_3\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        },
+        {
+          "name": "\"a\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"b\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"c\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"base_table_4\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        },
+        {
+          "name": "\"a\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"b\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"c\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"base_table_5\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        },
+        {
+          "name": "\"a\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"b\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"c\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"base_table_6\""
+      ]
+    },
+
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        },
+        {
+          "name": "\"a\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"b\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"c\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"base_table_7\""
       ]
     }
   ],

--- a/db/rdb/src/test/resources/propagate-uc-up/metadata.db-extract.json
+++ b/db/rdb/src/test/resources/propagate-uc-up/metadata.db-extract.json
@@ -1,0 +1,32 @@
+{
+  "relations": [
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"name\"",
+          "datatype": "VARCHAR",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"base_table\""
+      ]
+    }
+  ],
+  "metadata": {
+    "dbmsProductName": "H2",
+    "dbmsVersion": "1.4.199 (2019-03-13)",
+    "driverName": "H2 JDBC Driver",
+    "driverVersion": "1.4.199 (2019-03-13)",
+    "quotationString": "\"",
+    "extractionTime": "2020-11-12T17:24:30"
+  }
+}


### PR DESCRIPTION
Basic implementation of the feature to push unique constraints of lenses upwards, implemented only for basic lenses for now.

If a basic lens has a UC added, it will try to add the same UC on the parent as well, if this is possible. This way, such UCs can be propagated all the way up to the base relation. 