### PR TITLE
Supporting dependency between variables when removing non required variables

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/ConcreteIQTreeCache.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/ConcreteIQTreeCache.java
@@ -2,6 +2,7 @@ package it.unibz.inf.ontop.iq;
 
 import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.model.term.NonVariableTerm;
 import it.unibz.inf.ontop.model.term.Variable;
 import it.unibz.inf.ontop.substitution.Substitution;
@@ -21,7 +22,7 @@ public interface ConcreteIQTreeCache extends IQTreeCache {
     ImmutableSet<Variable> getVariables();
 
     @Nullable
-    ImmutableSet<Variable> getNotInternallyRequiredVariables();
+    VariableNonRequirement getVariableNonRequirement();
 
     @Nullable
     VariableNullability getVariableNullability();
@@ -43,7 +44,7 @@ public interface ConcreteIQTreeCache extends IQTreeCache {
     /**
      * Can only be set ONCE!
      */
-    void setNotInternallyRequiredVariables(@Nonnull ImmutableSet<Variable> notInternallyRequiredVariables);
+    void setVariableNonRequirement(@Nonnull VariableNonRequirement notInternallyRequiredVariables);
 
     /**
      * Can only be set ONCE!

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/IQTree.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/IQTree.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.node.QueryNode;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.visit.IQVisitor;
@@ -149,7 +150,8 @@ public interface IQTree {
     ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints();
 
     /**
-     * Variables that are the tree proposes for removal if the ancestor trees do not need them.
+     * Variables that the tree proposes for removal if the ancestor trees do not need them.
+     * Some variables can only be removed if some others are removed too.
      */
-    ImmutableSet<Variable> getNotInternallyRequiredVariables();
+    VariableNonRequirement getVariableNonRequirement();
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/AbstractCompositeIQTree.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/AbstractCompositeIQTree.java
@@ -6,6 +6,7 @@ import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.*;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.substitution.Substitution;
 import it.unibz.inf.ontop.substitution.InjectiveSubstitution;
@@ -263,18 +264,18 @@ public abstract class AbstractCompositeIQTree<N extends QueryNode> implements Co
     protected abstract ImmutableSet<ImmutableSet<Variable>> computeUniqueConstraints();
 
     @Override
-    public synchronized ImmutableSet<Variable> getNotInternallyRequiredVariables() {
+    public synchronized VariableNonRequirement getVariableNonRequirement() {
         // Non-final
-        ImmutableSet<Variable> notInternallyRequiredVariables = treeCache.getNotInternallyRequiredVariables();
+        VariableNonRequirement notInternallyRequiredVariables = treeCache.getVariableNonRequirement();
         if (notInternallyRequiredVariables != null)
             return notInternallyRequiredVariables;
 
-        notInternallyRequiredVariables = computeNotInternallyRequiredVariables();
-        treeCache.setNotInternallyRequiredVariables(notInternallyRequiredVariables);
+        notInternallyRequiredVariables = computeVariableNonRequirement();
+        treeCache.setVariableNonRequirement(notInternallyRequiredVariables);
         return notInternallyRequiredVariables;
     }
 
-    protected abstract ImmutableSet<Variable> computeNotInternallyRequiredVariables();
+    protected abstract VariableNonRequirement computeVariableNonRequirement();
 
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/BinaryNonCommutativeIQTreeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/BinaryNonCommutativeIQTreeImpl.java
@@ -1,6 +1,7 @@
 package it.unibz.inf.ontop.iq.impl;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
@@ -12,6 +13,7 @@ import it.unibz.inf.ontop.iq.IQTreeCache;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.node.BinaryNonCommutativeOperatorNode;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.visit.IQVisitor;
@@ -198,7 +200,7 @@ public class BinaryNonCommutativeIQTreeImpl extends AbstractCompositeIQTree<Bina
     }
 
     @Override
-    protected ImmutableSet<Variable> computeNotInternallyRequiredVariables() {
+    protected VariableNonRequirement computeVariableNonRequirement() {
         return getRootNode().computeNotInternallyRequiredVariables(leftChild, rightChild);
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/NaryIQTreeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/NaryIQTreeImpl.java
@@ -12,6 +12,7 @@ import it.unibz.inf.ontop.iq.NaryIQTree;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.node.NaryOperatorNode;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.visit.IQVisitor;
@@ -175,7 +176,7 @@ public class NaryIQTreeImpl extends AbstractCompositeIQTree<NaryOperatorNode> im
     }
 
     @Override
-    protected ImmutableSet<Variable> computeNotInternallyRequiredVariables() {
-        return getRootNode().computeNotInternallyRequiredVariables(getChildren());
+    protected VariableNonRequirement computeVariableNonRequirement() {
+        return getRootNode().computeVariableNonRequirement(getChildren());
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/UnaryIQTreeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/UnaryIQTreeImpl.java
@@ -12,6 +12,7 @@ import it.unibz.inf.ontop.iq.UnaryIQTree;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.node.UnaryOperatorNode;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.visit.IQVisitor;
@@ -128,8 +129,8 @@ public class UnaryIQTreeImpl extends AbstractCompositeIQTree<UnaryOperatorNode> 
     }
 
     @Override
-    protected ImmutableSet<Variable> computeNotInternallyRequiredVariables() {
-        return getRootNode().computeNotInternallyRequiredVariables(getChild());
+    protected VariableNonRequirement computeVariableNonRequirement() {
+        return getRootNode().computeVariableNonRequirement(getChild());
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/BinaryOrderedOperatorNode.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/BinaryOrderedOperatorNode.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.IQTreeCache;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.visit.IQVisitor;
@@ -69,5 +70,5 @@ public interface BinaryOrderedOperatorNode extends QueryNode {
 
     ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(IQTree leftChild, IQTree rightChild);
 
-    ImmutableSet<Variable> computeNotInternallyRequiredVariables(IQTree leftChild, IQTree rightChild);
+    VariableNonRequirement computeNotInternallyRequiredVariables(IQTree leftChild, IQTree rightChild);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/NaryOperatorNode.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/NaryOperatorNode.java
@@ -6,6 +6,7 @@ import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.IQTreeCache;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.transform.node.HomogeneousQueryNodeTransformer;
@@ -68,5 +69,5 @@ public interface NaryOperatorNode extends QueryNode {
 
     ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(ImmutableList<IQTree> children);
 
-    ImmutableSet<Variable> computeNotInternallyRequiredVariables(ImmutableList<IQTree> children);
+    VariableNonRequirement computeVariableNonRequirement(ImmutableList<IQTree> children);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/UnaryOperatorNode.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/UnaryOperatorNode.java
@@ -5,6 +5,7 @@ import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.IQTreeCache;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.transform.node.HomogeneousQueryNodeTransformer;
@@ -66,5 +67,5 @@ public interface UnaryOperatorNode extends QueryNode {
 
     ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(IQTree child);
 
-    ImmutableSet<Variable> computeNotInternallyRequiredVariables(IQTree child);
+    VariableNonRequirement computeVariableNonRequirement(IQTree child);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/AggregationNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/AggregationNodeImpl.java
@@ -12,6 +12,7 @@ import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.AggregationNormalizer;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.transform.node.HomogeneousQueryNodeTransformer;
@@ -329,8 +330,8 @@ public class AggregationNodeImpl extends ExtendedProjectionNodeImpl implements A
      * Out of the projected variables, only the grouping variables are required
      */
     @Override
-    public ImmutableSet<Variable> computeNotInternallyRequiredVariables(IQTree child) {
-        return substitution.getDomain();
+    public VariableNonRequirement computeVariableNonRequirement(IQTree child) {
+        return VariableNonRequirement.of(substitution.getDomain());
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ConstructionNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ConstructionNodeImpl.java
@@ -14,6 +14,7 @@ import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.ConstructionSubstitutionNormalizer;
 import it.unibz.inf.ontop.iq.node.normalization.NotRequiredVariableRemover;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.node.normalization.ConstructionSubstitutionNormalizer.ConstructionSubstitutionNormalization;
@@ -330,8 +331,8 @@ public class ConstructionNodeImpl extends ExtendedProjectionNodeImpl implements 
      * For a construction node, none of the projected variables is required.
      */
     @Override
-    public ImmutableSet<Variable> computeNotInternallyRequiredVariables(IQTree child) {
-        return getVariables();
+    public VariableNonRequirement computeVariableNonRequirement(IQTree child) {
+        return VariableNonRequirement.of(getVariables());
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/DistinctNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/DistinctNodeImpl.java
@@ -10,6 +10,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.DistinctNormalizer;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.transform.node.HomogeneousQueryNodeTransformer;
@@ -110,8 +111,8 @@ public class DistinctNodeImpl extends QueryModifierNodeImpl implements DistinctN
      * TODO: implement it more seriously, by consider functional dependencies between variables
      */
     @Override
-    public ImmutableSet<Variable> computeNotInternallyRequiredVariables(IQTree child) {
-        return ImmutableSet.of();
+    public VariableNonRequirement computeVariableNonRequirement(IQTree child) {
+        return VariableNonRequirement.empty();
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/EmptyNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/EmptyNodeImpl.java
@@ -8,6 +8,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.visit.IQVisitor;
@@ -128,8 +129,8 @@ public class EmptyNodeImpl extends LeafIQTreeImpl implements EmptyNode {
     }
 
     @Override
-    public ImmutableSet<Variable> getNotInternallyRequiredVariables() {
-        return getVariables();
+    public VariableNonRequirement getVariableNonRequirement() {
+        return VariableNonRequirement.of(getVariables());
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ExtensionalDataNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ExtensionalDataNodeImpl.java
@@ -10,6 +10,7 @@ import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.*;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.transform.node.HomogeneousQueryNodeTransformer;
@@ -47,7 +48,7 @@ public class ExtensionalDataNodeImpl extends LeafIQTreeImpl implements Extension
 
     // LAZY
     @Nullable
-    private ImmutableSet<Variable> notInternallyRequiredVariables;
+    private VariableNonRequirement variableNonRequirement;
 
     // LAZY
     @Nullable
@@ -233,19 +234,20 @@ public class ExtensionalDataNodeImpl extends LeafIQTreeImpl implements Extension
      * Only co-occuring variables are required.
      */
     @Override
-    public synchronized ImmutableSet<Variable> getNotInternallyRequiredVariables() {
-        if (notInternallyRequiredVariables == null) {
+    public synchronized VariableNonRequirement getVariableNonRequirement() {
+        if (variableNonRequirement == null) {
             ImmutableMultiset<Variable> multiset = argumentMap.values().stream()
                     .filter(t -> t instanceof Variable)
                     .map(t -> (Variable)t)
                     .collect(ImmutableCollectors.toMultiset());
 
-            notInternallyRequiredVariables = multiset.entrySet().stream()
-                    .filter(e -> e.getCount() == 1)
-                    .map(Multiset.Entry::getElement)
-                    .collect(ImmutableCollectors.toSet());
+            variableNonRequirement = VariableNonRequirement.of(
+                    multiset.entrySet().stream()
+                            .filter(e -> e.getCount() == 1)
+                            .map(Multiset.Entry::getElement)
+                            .collect(ImmutableCollectors.toSet()));
         }
-        return notInternallyRequiredVariables;
+        return variableNonRequirement;
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FilterNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FilterNodeImpl.java
@@ -10,6 +10,7 @@ import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.node.normalization.ConditionSimplifier.ExpressionAndSubstitution;
@@ -172,8 +173,8 @@ public class FilterNodeImpl extends JoinOrFilterNodeImpl implements FilterNode {
     }
 
     @Override
-    public ImmutableSet<Variable> computeNotInternallyRequiredVariables(IQTree child) {
-        return computeNotInternallyRequiredVariables(ImmutableList.of(child));
+    public VariableNonRequirement computeVariableNonRequirement(IQTree child) {
+        return applyFilterToVariableNonRequirement(child.getVariableNonRequirement());
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FlattenNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FlattenNodeImpl.java
@@ -12,6 +12,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.FlattenNormalizer;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.transform.node.HomogeneousQueryNodeTransformer;
@@ -208,10 +209,9 @@ public class FlattenNodeImpl extends CompositeQueryNodeImpl implements FlattenNo
      * Only the flattened variable is required
      */
     @Override
-    public ImmutableSet<Variable> computeNotInternallyRequiredVariables(IQTree child) {
-        return child.getNotInternallyRequiredVariables().stream()
-                .filter(v -> !v.equals(flattenedVariable))
-                .collect(ImmutableCollectors.toSet());
+    public VariableNonRequirement computeVariableNonRequirement(IQTree child) {
+        return child.getVariableNonRequirement()
+                .filter((v, conds) -> !v.equals(flattenedVariable));
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/InnerJoinNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/InnerJoinNodeImpl.java
@@ -12,6 +12,7 @@ import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.ConditionSimplifier.ExpressionAndSubstitution;
 import it.unibz.inf.ontop.iq.node.normalization.ConditionSimplifier;
 import it.unibz.inf.ontop.iq.node.normalization.InnerJoinNormalizer;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.visit.IQVisitor;
@@ -337,8 +338,8 @@ public class InnerJoinNodeImpl extends JoinLikeNodeImpl implements InnerJoinNode
     }
 
     @Override
-    public ImmutableSet<Variable> computeNotInternallyRequiredVariables(ImmutableList<IQTree> children) {
-        return super.computeNotInternallyRequiredVariables(children);
+    public VariableNonRequirement computeVariableNonRequirement(ImmutableList<IQTree> children) {
+        return super.computeVariableNonRequirement(children);
     }
 
     private Stream<Map.Entry<IQTree, IQTree>> extractFunctionalDependencies(

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/IntensionalDataNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/IntensionalDataNodeImpl.java
@@ -8,6 +8,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.visit.IQVisitor;
@@ -133,7 +134,7 @@ public class IntensionalDataNodeImpl extends DataNodeImpl<AtomPredicate> impleme
      * All the variables are required, because an intensional data node cannot be sparse.
      */
     @Override
-    public synchronized ImmutableSet<Variable> getNotInternallyRequiredVariables() {
-        return ImmutableSet.of();
+    public synchronized VariableNonRequirement getVariableNonRequirement() {
+        return VariableNonRequirement.empty();
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/JoinLikeNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/JoinLikeNodeImpl.java
@@ -83,7 +83,7 @@ public abstract class JoinLikeNodeImpl extends JoinOrFilterNodeImpl implements J
 
         // All variables are required
         if (candidates.isEmpty())
-            return new VariableNonRequirementImpl(ImmutableMap.of());
+            return VariableNonRequirement.empty();
 
         ImmutableMultiset<Variable> childVariableMultiset = children.stream()
                 .flatMap(c -> c.getVariables().stream())
@@ -95,13 +95,13 @@ public abstract class JoinLikeNodeImpl extends JoinOrFilterNodeImpl implements J
                 .map(Multiset.Entry::getElement)
                 .collect(ImmutableCollectors.toSet());
 
-        VariableNonRequirement nonRequirementBeforeFilter = new VariableNonRequirementImpl(
+        VariableNonRequirement nonRequirementBeforeFilter = VariableNonRequirement.of(
                 candidates.entrySet().stream()
                         .filter(e -> notSharedVariables.contains(e.getKey()))
                         .collect(ImmutableCollectors.toMap()));
 
         return getOptionalFilterCondition()
-                .map(f -> applyFilterToVariableNonRequirement(nonRequirementBeforeFilter))
+                .map(f -> applyFilterToVariableNonRequirement(nonRequirementBeforeFilter, children))
                 .orElse(nonRequirementBeforeFilter);
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/JoinLikeNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/JoinLikeNodeImpl.java
@@ -6,6 +6,8 @@ import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.node.normalization.ConditionSimplifier;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
+import it.unibz.inf.ontop.iq.request.impl.VariableNonRequirementImpl;
 import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.iq.node.JoinLikeNode;
 import it.unibz.inf.ontop.model.type.TypeFactory;
@@ -13,6 +15,7 @@ import it.unibz.inf.ontop.substitution.SubstitutionFactory;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -63,5 +66,42 @@ public abstract class JoinLikeNodeImpl extends JoinOrFilterNodeImpl implements J
             }
             allVariables.addAll(childNonProjectedVariables);
         }
+    }
+
+    protected VariableNonRequirement computeVariableNonRequirement(ImmutableList<IQTree> children) {
+        ImmutableMultimap<Variable, ImmutableSet<Variable>> childRequirementMultimap = children.stream()
+                .map(IQTree::getVariableNonRequirement)
+                .flatMap(r -> r.getNotRequiredVariables().stream()
+                        .map(v -> Maps.immutableEntry(v, r.getCondition(v))))
+                .collect(ImmutableCollectors.toMultimap());
+
+        ImmutableMap<Variable, ImmutableSet<Variable>> candidates = childRequirementMultimap.asMap().entrySet().stream()
+                .filter(e -> e.getValue().size() == 1)
+                .collect(ImmutableCollectors.toMap(
+                        Map.Entry::getKey,
+                        e -> e.getValue().iterator().next()));
+
+        // All variables are required
+        if (candidates.isEmpty())
+            return new VariableNonRequirementImpl(ImmutableMap.of());
+
+        ImmutableMultiset<Variable> childVariableMultiset = children.stream()
+                .flatMap(c -> c.getVariables().stream())
+                .collect(ImmutableCollectors.toMultiset());
+
+        ImmutableSet<Variable> notSharedVariables = childVariableMultiset.entrySet().stream()
+                // Only coming from one child
+                .filter(e -> e.getCount() == 1)
+                .map(Multiset.Entry::getElement)
+                .collect(ImmutableCollectors.toSet());
+
+        VariableNonRequirement nonRequirementBeforeFilter = new VariableNonRequirementImpl(
+                candidates.entrySet().stream()
+                        .filter(e -> notSharedVariables.contains(e.getKey()))
+                        .collect(ImmutableCollectors.toMap()));
+
+        return getOptionalFilterCondition()
+                .map(f -> applyFilterToVariableNonRequirement(nonRequirementBeforeFilter))
+                .orElse(nonRequirementBeforeFilter);
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/JoinOrFilterNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/JoinOrFilterNodeImpl.java
@@ -9,14 +9,12 @@ import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
 import it.unibz.inf.ontop.iq.node.normalization.ConditionSimplifier;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
-import it.unibz.inf.ontop.iq.request.impl.VariableNonRequirementImpl;
 import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.model.type.TypeFactory;
 import it.unibz.inf.ontop.iq.node.JoinOrFilterNode;
 import it.unibz.inf.ontop.substitution.SubstitutionFactory;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 
-import java.util.Map;
 import java.util.Optional;
 
 
@@ -91,6 +89,11 @@ public abstract class JoinOrFilterNodeImpl extends CompositeQueryNodeImpl implem
             throw new InvalidIntermediateQueryException("Expression " + expression + " of "
                     + expression + " uses unbound variables (" + unboundVariables +  ").\n" + this);
         }
+    }
+
+    protected VariableNonRequirement applyFilterToVariableNonRequirement(VariableNonRequirement nonRequirementBeforeFilter,
+                                                                         ImmutableList<IQTree> children) {
+        return applyFilterToVariableNonRequirement(nonRequirementBeforeFilter);
     }
 
     protected VariableNonRequirement applyFilterToVariableNonRequirement(VariableNonRequirement nonRequirementBeforeFilter) {

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/JoinOrFilterNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/JoinOrFilterNodeImpl.java
@@ -1,22 +1,22 @@
 package it.unibz.inf.ontop.iq.node.impl;
 
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMultiset;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multiset;
+import com.google.common.collect.*;
 import it.unibz.inf.ontop.evaluator.TermNullabilityEvaluator;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
 import it.unibz.inf.ontop.iq.node.normalization.ConditionSimplifier;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
+import it.unibz.inf.ontop.iq.request.impl.VariableNonRequirementImpl;
 import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.model.type.TypeFactory;
 import it.unibz.inf.ontop.iq.node.JoinOrFilterNode;
 import it.unibz.inf.ontop.substitution.SubstitutionFactory;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 
+import java.util.Map;
 import java.util.Optional;
 
 
@@ -93,28 +93,11 @@ public abstract class JoinOrFilterNodeImpl extends CompositeQueryNodeImpl implem
         }
     }
 
-    protected ImmutableSet<Variable> computeNotInternallyRequiredVariables(ImmutableList<IQTree> children) {
-        ImmutableSet<Variable> conditionVariables = getLocallyRequiredVariables();
+    protected VariableNonRequirement applyFilterToVariableNonRequirement(VariableNonRequirement nonRequirementBeforeFilter) {
+        ImmutableSet<Variable> filterVariables = getLocallyRequiredVariables();
 
-        ImmutableSet<Variable> notInternallyRequiredByAtLeastAChild = children.stream()
-                .flatMap(c -> c.getNotInternallyRequiredVariables().stream())
-                .collect(ImmutableCollectors.toSet());
-
-        // All variables are required
-        if (notInternallyRequiredByAtLeastAChild.isEmpty())
-            return notInternallyRequiredByAtLeastAChild;
-
-        ImmutableMultiset<Variable> childVariableMultiset = children.stream()
-                .flatMap(c -> c.getVariables().stream())
-                .collect(ImmutableCollectors.toMultiset());
-
-        return childVariableMultiset.entrySet().stream()
-                // Only coming from one child
-                .filter(e -> e.getCount() == 1)
-                .map(Multiset.Entry::getElement)
-                .filter(notInternallyRequiredByAtLeastAChild::contains)
-                .filter(v -> !conditionVariables.contains(v))
-                .collect(ImmutableCollectors.toSet());
+        return nonRequirementBeforeFilter
+                .filter((v, conds) -> !filterVariables.contains(v));
     }
 
     protected boolean isDistinct(IQTree tree, ImmutableList<IQTree> children) {

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
@@ -11,6 +11,7 @@ import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.LeftJoinNormalizer;
 import it.unibz.inf.ontop.iq.node.normalization.impl.ExpressionAndSubstitutionImpl;
 import it.unibz.inf.ontop.iq.node.normalization.ConditionSimplifier;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.visit.IQVisitor;
@@ -408,8 +409,8 @@ public class LeftJoinNodeImpl extends JoinLikeNodeImpl implements LeftJoinNode {
     }
 
     @Override
-    public ImmutableSet<Variable> computeNotInternallyRequiredVariables(IQTree leftChild, IQTree rightChild) {
-        return computeNotInternallyRequiredVariables(ImmutableList.of(leftChild, rightChild));
+    public VariableNonRequirement computeNotInternallyRequiredVariables(IQTree leftChild, IQTree rightChild) {
+        return computeVariableNonRequirement(ImmutableList.of(leftChild, rightChild));
     }
 
     /**
@@ -545,4 +546,11 @@ public class LeftJoinNodeImpl extends JoinLikeNodeImpl implements LeftJoinNode {
                 ImmutableList.of(leftChild, rightChild));
     }
 
+    /**
+     * TODO: implement it better
+     */
+    @Override
+    protected VariableNonRequirement applyFilterToVariableNonRequirement(VariableNonRequirement nonRequirementBeforeFilter) {
+        return super.applyFilterToVariableNonRequirement(nonRequirementBeforeFilter);
+    }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
@@ -546,11 +546,45 @@ public class LeftJoinNodeImpl extends JoinLikeNodeImpl implements LeftJoinNode {
                 ImmutableList.of(leftChild, rightChild));
     }
 
-    /**
-     * TODO: implement it better
-     */
     @Override
-    protected VariableNonRequirement applyFilterToVariableNonRequirement(VariableNonRequirement nonRequirementBeforeFilter) {
-        return super.applyFilterToVariableNonRequirement(nonRequirementBeforeFilter);
+    protected VariableNonRequirement applyFilterToVariableNonRequirement(VariableNonRequirement nonRequirementBeforeFilter,
+                                                                         ImmutableList<IQTree> children) {
+
+        if (nonRequirementBeforeFilter.isEmpty())
+            return nonRequirementBeforeFilter;
+
+        IQTree leftChild = children.get(0);
+        IQTree rightChild = children.get(1);
+
+        var rightSpecificVariables = Sets.difference(rightChild.getVariables(), leftChild.getVariables());
+
+        if (rightSpecificVariables.isEmpty())
+            return nonRequirementBeforeFilter;
+
+        var commonVariables = Sets.intersection(leftChild.getVariables(), rightChild.getVariables());
+
+        /*
+         * If the right child has no impact on cardinality (i.e. at most one match per row on the left),
+         *  it can potentially be eliminated if no right-specific variables is used above the LJ.
+         *
+         * Not required variables (before the LJ condition) that are involved in the LJ condition can be eliminated
+         *   if all the right-specific variables are removed too.
+         */
+        if ((!commonVariables.isEmpty())
+                && rightChild.inferUniqueConstraints().stream()
+                    .anyMatch(commonVariables::containsAll)) {
+
+            var rightSpecificNonRequiredVariables = Sets.intersection(
+                    rightSpecificVariables, nonRequirementBeforeFilter.getNotRequiredVariables());
+
+            ImmutableSet<Variable> filterVariables = getLocalVariables();
+
+            return nonRequirementBeforeFilter.transformConditions(
+                    (v, conditions) -> filterVariables.contains(v)
+                            ? Sets.union(conditions, rightSpecificNonRequiredVariables).immutableCopy()
+                            : conditions);
+        }
+        else
+            return super.applyFilterToVariableNonRequirement(nonRequirementBeforeFilter, children);
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/NativeNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/NativeNodeImpl.java
@@ -15,6 +15,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidQueryNodeException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.transform.node.HomogeneousQueryNodeTransformer;
@@ -182,8 +183,8 @@ public class NativeNodeImpl extends LeafIQTreeImpl implements NativeNode {
     }
 
     @Override
-    public ImmutableSet<Variable> getNotInternallyRequiredVariables() {
-        return getVariables();
+    public VariableNonRequirement getVariableNonRequirement() {
+        return VariableNonRequirement.of(getVariables());
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/OrderByNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/OrderByNodeImpl.java
@@ -11,6 +11,7 @@ import it.unibz.inf.ontop.iq.IQTreeCache;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.node.normalization.OrderByNormalizer;
@@ -152,12 +153,11 @@ public class OrderByNodeImpl extends QueryModifierNodeImpl implements OrderByNod
      * Subtracts from the variables proposed by the child the one used for ordering
      */
     @Override
-    public ImmutableSet<Variable> computeNotInternallyRequiredVariables(IQTree child) {
+    public VariableNonRequirement computeVariableNonRequirement(IQTree child) {
         ImmutableSet<Variable> localVariables = getLocalVariables();
 
-        return child.getNotInternallyRequiredVariables().stream()
-                .filter(v -> !localVariables.contains(v))
-                .collect(ImmutableCollectors.toSet());
+        return child.getVariableNonRequirement()
+                .filter((v, conds) -> !localVariables.contains(v));
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/SliceNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/SliceNodeImpl.java
@@ -10,6 +10,7 @@ import it.unibz.inf.ontop.iq.*;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.transform.node.HomogeneousQueryNodeTransformer;
@@ -390,8 +391,8 @@ public class SliceNodeImpl extends QueryModifierNodeImpl implements SliceNode {
     }
 
     @Override
-    public ImmutableSet<Variable> computeNotInternallyRequiredVariables(IQTree child) {
-        return child.getNotInternallyRequiredVariables();
+    public VariableNonRequirement computeVariableNonRequirement(IQTree child) {
+        return child.getVariableNonRequirement();
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/TrueNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/TrueNodeImpl.java
@@ -7,6 +7,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.visit.IQVisitor;
@@ -135,7 +136,7 @@ public class TrueNodeImpl extends LeafIQTreeImpl implements TrueNode {
     }
 
     @Override
-    public ImmutableSet<Variable> getNotInternallyRequiredVariables() {
-        return ImmutableSet.of();
+    public VariableNonRequirement getVariableNonRequirement() {
+        return VariableNonRequirement.empty();
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
@@ -12,6 +12,7 @@ import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.NotRequiredVariableRemover;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.visit.IQVisitor;
@@ -397,8 +398,8 @@ public class UnionNodeImpl extends CompositeQueryNodeImpl implements UnionNode {
      * All the variables of a union could be projected out
      */
     @Override
-    public ImmutableSet<Variable> computeNotInternallyRequiredVariables(ImmutableList<IQTree> children) {
-        return getVariables();
+    public VariableNonRequirement computeVariableNonRequirement(ImmutableList<IQTree> children) {
+        return VariableNonRequirement.of(getVariables());
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ValuesNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ValuesNodeImpl.java
@@ -13,6 +13,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.transform.node.HomogeneousQueryNodeTransformer;
@@ -440,8 +441,8 @@ public class ValuesNodeImpl extends LeafIQTreeImpl implements ValuesNode {
     }
 
     @Override
-    public ImmutableSet<Variable> getNotInternallyRequiredVariables() {
-        return projectedVariables;
+    public VariableNonRequirement getVariableNonRequirement() {
+        return VariableNonRequirement.of(projectedVariables);
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/normalization/impl/NotRequiredVariableRemoverImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/normalization/impl/NotRequiredVariableRemoverImpl.java
@@ -14,6 +14,7 @@ import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.ConstructionSubstitutionNormalizer;
 import it.unibz.inf.ontop.iq.node.normalization.NotRequiredVariableRemover;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.model.term.Constant;
@@ -43,17 +44,10 @@ public class NotRequiredVariableRemoverImpl implements NotRequiredVariableRemove
         if (variables.equals(requiredVariables))
             return tree;
 
-        ImmutableSet<Variable> notInternallyRequiredVariables = tree.getNotInternallyRequiredVariables();
-        if (notInternallyRequiredVariables.isEmpty())
-            return tree;
+        ImmutableSet<Variable> variablesToRemove = tree.getVariableNonRequirement()
+                .computeVariablesToRemove(variables, requiredVariables);
 
-        Sets.SetView<Variable> variablesToRemove = Sets.intersection(
-                Sets.difference(variables, requiredVariables), notInternallyRequiredVariables);
-
-        if (variablesToRemove.isEmpty())
-            return tree;
-
-        return removeNonRequiredVariables(tree, variablesToRemove.immutableCopy(), variableGenerator);
+        return removeNonRequiredVariables(tree, variablesToRemove, variableGenerator);
     }
 
     protected IQTree removeNonRequiredVariables(IQTree tree, ImmutableSet<Variable> variablesToRemove,

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/VariableNonRequirement.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/VariableNonRequirement.java
@@ -1,14 +1,14 @@
 package it.unibz.inf.ontop.iq.request;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.iq.request.impl.VariableNonRequirementImpl;
 import it.unibz.inf.ontop.model.term.Variable;
 import it.unibz.inf.ontop.substitution.InjectiveSubstitution;
 import it.unibz.inf.ontop.substitution.SubstitutionFactory;
 
-import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
-import java.util.stream.Stream;
 
 public interface VariableNonRequirement {
 
@@ -19,8 +19,6 @@ public interface VariableNonRequirement {
      */
     ImmutableSet<Variable> getCondition(Variable variable);
 
-    Stream<Map.Entry<Variable, ImmutableSet<Variable>>> entryStream();
-
     VariableNonRequirement filter(BiPredicate<Variable, ImmutableSet<Variable>> predicate);
 
     VariableNonRequirement rename(InjectiveSubstitution<Variable> renamingSubstitution, SubstitutionFactory substitutionFactory);
@@ -28,13 +26,19 @@ public interface VariableNonRequirement {
     ImmutableSet<Variable> computeVariablesToRemove(ImmutableSet<Variable> projectedVariables,
                                                     ImmutableSet<Variable> requiredVariables);
 
+    boolean isEmpty();
+
+    VariableNonRequirement transformConditions(BiFunction<Variable, ImmutableSet<Variable>, ImmutableSet<Variable>> fct);
+
     static VariableNonRequirement of(ImmutableSet<Variable> variables) {
         return new VariableNonRequirementImpl(variables);
+    }
+
+    static VariableNonRequirement of(ImmutableMap<Variable, ImmutableSet<Variable>> conditions) {
+        return new VariableNonRequirementImpl(conditions);
     }
 
     static VariableNonRequirement empty() {
         return new VariableNonRequirementImpl(ImmutableSet.of());
     }
-
-    boolean isEmpty();
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/VariableNonRequirement.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/VariableNonRequirement.java
@@ -1,0 +1,40 @@
+package it.unibz.inf.ontop.iq.request;
+
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.iq.request.impl.VariableNonRequirementImpl;
+import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.substitution.InjectiveSubstitution;
+import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+
+import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.stream.Stream;
+
+public interface VariableNonRequirement {
+
+    ImmutableSet<Variable> getNotRequiredVariables();
+
+    /**
+     * Variables that must be removed for being able to remove the variable passed as parameter
+     */
+    ImmutableSet<Variable> getCondition(Variable variable);
+
+    Stream<Map.Entry<Variable, ImmutableSet<Variable>>> entryStream();
+
+    VariableNonRequirement filter(BiPredicate<Variable, ImmutableSet<Variable>> predicate);
+
+    VariableNonRequirement rename(InjectiveSubstitution<Variable> renamingSubstitution, SubstitutionFactory substitutionFactory);
+
+    ImmutableSet<Variable> computeVariablesToRemove(ImmutableSet<Variable> projectedVariables,
+                                                    ImmutableSet<Variable> requiredVariables);
+
+    static VariableNonRequirement of(ImmutableSet<Variable> variables) {
+        return new VariableNonRequirementImpl(variables);
+    }
+
+    static VariableNonRequirement empty() {
+        return new VariableNonRequirementImpl(ImmutableSet.of());
+    }
+
+    boolean isEmpty();
+}

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/VariableNonRequirementImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/VariableNonRequirementImpl.java
@@ -12,8 +12,8 @@ import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
-import java.util.stream.Stream;
 
 public class VariableNonRequirementImpl implements VariableNonRequirement {
 
@@ -45,11 +45,6 @@ public class VariableNonRequirementImpl implements VariableNonRequirement {
     @Override
     public ImmutableSet<Variable> getCondition(Variable variable) {
         return conditions.getOrDefault(variable, ImmutableSet.of());
-    }
-
-    @Override
-    public Stream<Map.Entry<Variable, ImmutableSet<Variable>>> entryStream() {
-        return conditions.entrySet().stream();
     }
 
     @Override
@@ -86,13 +81,22 @@ public class VariableNonRequirementImpl implements VariableNonRequirement {
                 break;
             variablesToRemove.removeAll(variablesToKeep);
         }
-        
+
         return ImmutableSet.copyOf(variablesToRemove);
     }
 
     @Override
     public boolean isEmpty() {
         return conditions.isEmpty();
+    }
+
+    @Override
+    public VariableNonRequirement transformConditions(BiFunction<Variable, ImmutableSet<Variable>, ImmutableSet<Variable>> fct) {
+        return new VariableNonRequirementImpl(
+                conditions.entrySet().stream()
+                        .collect(ImmutableCollectors.toMap(
+                                Map.Entry::getKey,
+                                e -> fct.apply(e.getKey(), e.getValue()))));
     }
 
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/VariableNonRequirementImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/VariableNonRequirementImpl.java
@@ -1,0 +1,98 @@
+package it.unibz.inf.ontop.iq.request.impl;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
+import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.substitution.InjectiveSubstitution;
+import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.stream.Stream;
+
+public class VariableNonRequirementImpl implements VariableNonRequirement {
+
+    // LAZY
+    @Nullable
+    private ImmutableSet<Variable> nonRequiredVariables;
+    private final ImmutableMap<Variable, ImmutableSet<Variable>> conditions;
+
+
+    public VariableNonRequirementImpl(ImmutableMap<Variable, ImmutableSet<Variable>> conditions) {
+        this.conditions = conditions;
+    }
+
+    public VariableNonRequirementImpl(ImmutableSet<Variable> variables) {
+        this(variables.stream()
+                .collect(ImmutableCollectors.toMap(
+                        v -> v,
+                        v -> ImmutableSet.of())));
+    }
+
+    @Override
+    public synchronized ImmutableSet<Variable> getNotRequiredVariables() {
+        if (nonRequiredVariables == null) {
+            nonRequiredVariables = conditions.keySet();
+        }
+        return nonRequiredVariables;
+    }
+
+    @Override
+    public ImmutableSet<Variable> getCondition(Variable variable) {
+        return conditions.getOrDefault(variable, ImmutableSet.of());
+    }
+
+    @Override
+    public Stream<Map.Entry<Variable, ImmutableSet<Variable>>> entryStream() {
+        return conditions.entrySet().stream();
+    }
+
+    @Override
+    public VariableNonRequirement filter(BiPredicate<Variable, ImmutableSet<Variable>> predicate) {
+        return new VariableNonRequirementImpl(conditions.entrySet().stream()
+                .filter(e -> predicate.test(e.getKey(), e.getValue()))
+                .collect(ImmutableCollectors.toMap()));
+    }
+
+    @Override
+    public VariableNonRequirement rename(InjectiveSubstitution<Variable> renamingSubstitution, SubstitutionFactory substitutionFactory) {
+        return new VariableNonRequirementImpl(conditions.entrySet().stream()
+                .collect(ImmutableCollectors.toMap(
+                        e -> substitutionFactory.apply(renamingSubstitution, e.getKey()),
+                        e -> substitutionFactory.apply(renamingSubstitution, e.getValue()))));
+    }
+
+    @Override
+    public ImmutableSet<Variable> computeVariablesToRemove(ImmutableSet<Variable> projectedVariables,
+                                                           ImmutableSet<Variable> requiredVariables) {
+        if (isEmpty())
+            return ImmutableSet.of();
+
+        // Mutable
+        final Set<Variable> variablesToRemove = Sets.newHashSet(Sets.intersection(
+                Sets.difference(projectedVariables, requiredVariables),
+                getNotRequiredVariables()));
+
+        while(true) {
+            var variablesToKeep = variablesToRemove.stream()
+                    .filter(v -> !variablesToRemove.containsAll(getCondition(v)))
+                    .collect(ImmutableCollectors.toSet());
+            if (variablesToKeep.isEmpty())
+                break;
+            variablesToRemove.removeAll(variablesToKeep);
+        }
+        
+        return ImmutableSet.copyOf(variablesToRemove);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return conditions.isEmpty();
+    }
+
+}

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -3353,7 +3353,6 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
-    @Ignore("TODO: support it (see if it deserves making NotRequiredVariableRemover more complex)")
     @Test
     public void testProjectionAway3() {
 
@@ -3441,7 +3440,6 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
-    @Ignore("TODO: support it (see if it deserves making NotRequiredVariableRemover more complex)")
     @Test
     public void testProjectionAway7() {
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -3466,6 +3466,32 @@ public class LeftJoinOptimizationTest {
     }
 
     @Test
+    public void testProjectionAway8() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(1), ImmutableList.of(A));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, C, 2, D));
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getConjunction(
+                                TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, C, B),
+                                TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, D, ONE)
+                        )),
+                dataNode1, dataNode2);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, subLJTree));
+
+        ExtensionalDataNode newDataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A));
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newDataNode1);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
     public void testPartialProjectionAway1() {
 
         DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
@@ -3576,6 +3602,54 @@ public class LeftJoinOptimizationTest {
                 newSubLJTree);
 
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTopLJTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testNonProjectionAway2() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, C, 2, D));
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, C, B)),
+                dataNode1, dataNode2);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, subLJTree));
+
+        optimizeAndCompare(initialIQ, initialIQ);
+    }
+
+    @Test
+    public void testNonProjectionAway3() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A, 1, E,2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, C, 2, D));
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, C, B)),
+                dataNode1, dataNode2);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, subLJTree));
+
+        ExtensionalDataNode newDataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, A,2, B));
+
+        IQTree newSubLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, C, B)),
+                newDataNode1, dataNode2);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, newSubLJTree));
 
         optimizeAndCompare(initialIQ, expectedIQ);
     }


### PR DESCRIPTION
Important for eliminating right children of left-joins, even in the presence of a joining condition involving a right-specific variable.

Example:
```
CONSTRUCT [a] []
   LJ AND2(NUM_LT(c,b),NUM_LT(d,"1"^^LARGE_INT))
      EXTENSIONAL TABLE1A(0:a,2:b)
      EXTENSIONAL TABLE1(0:a,1:c,2:d)
```
can be reduced to
```
EXTENSIONAL TABLE1A(0:a)
```
as the first column of `TABLE1` is a primary key.

Here for removing `b`, one needs to make sure that `c` and `d` are removed. Also `c` can be removed if `d` is and vice-versa.

The PR introduces a mechanism for modelling these dependencies during the phase of removing the non-required variables.
