### PR TITLE
Fixed issue that made SQLServer fail queries that involved a DISTINCT and a LIMIT

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/SQLServerSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/SQLServerSelectFromWhereSerializer.java
@@ -50,25 +50,25 @@ public class SQLServerSelectFromWhereSerializer extends IgnoreNullFirstSelectFro
             @Override
             protected String serializeLimitOffset(long limit, long offset, boolean noSortCondition) {
                 return noSortCondition
-                        ? String.format("ORDER BY (SELECT NULL)\nOFFSET %d ROWS\nFETCH NEXT %d ROWS ONLY", offset, limit)
+                        ? String.format("ORDER BY 1\nOFFSET %d ROWS\nFETCH NEXT %d ROWS ONLY", offset, limit)
                         : String.format("OFFSET %d ROWS\nFETCH NEXT %d ROWS ONLY", offset, limit);
             }
 
             /**
              * LIMIT without ORDER BY not supported in SQLServer
-             * ORDER BY (SELECT NULL) added as a default when no ORDER BY present
+             * ORDER BY 1 added as a default when no ORDER BY present
              */
             @Override
             protected String serializeLimit(long limit, boolean noSortCondition) {
                 return noSortCondition
-                        ? String.format("ORDER BY (SELECT NULL)\nOFFSET 0 ROWS\nFETCH NEXT %d ROWS ONLY", limit)
+                        ? String.format("ORDER BY 1\nOFFSET 0 ROWS\nFETCH NEXT %d ROWS ONLY", limit)
                         : String.format("OFFSET 0 ROWS\nFETCH NEXT %d ROWS ONLY", limit);
             }
 
             @Override
             protected String serializeOffset(long offset, boolean noSortCondition) {
                 return noSortCondition
-                        ? String.format("ORDER BY (SELECT NULL)\nOFFSET %d ROWS", offset)
+                        ? String.format("ORDER BY 1\nOFFSET %d ROWS", offset)
                         : String.format("OFFSET %d ROWS", offset);
             }
 


### PR DESCRIPTION
Limit only works in the presence of ORDER BY, so `ORDER BY (SELECT NULL)` as  added to circumvent this. However, this is not valid if the query uses `DISTINCT`, as it will fail with `com.microsoft.sqlserver.jdbc.SQLServerException: ORDER BY items must appear in the select list if SELECT DISTINCT is specified.`

Changed the SelectFromWhereSerializer of SQLServer to use `ORDER BY 1` instead, which is supported even with DISTINCT.