### PR TITLE
Fixed ORDER BY 1 issue for SQLServer

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/SQLServerSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/SQLServerSelectFromWhereSerializer.java
@@ -50,25 +50,31 @@ public class SQLServerSelectFromWhereSerializer extends IgnoreNullFirstSelectFro
             @Override
             protected String serializeLimitOffset(long limit, long offset, boolean noSortCondition) {
                 return noSortCondition
-                        ? String.format("ORDER BY 1\nOFFSET %d ROWS\nFETCH NEXT %d ROWS ONLY", offset, limit)
+                        ? selectFromWhere.isDistinct()
+                            ? String.format("ORDER BY 1\nOFFSET %d ROWS\nFETCH NEXT %d ROWS ONLY", offset, limit)
+                            : String.format("ORDER BY (SELECT NULL)\nOFFSET %d ROWS\nFETCH NEXT %d ROWS ONLY", offset, limit)
                         : String.format("OFFSET %d ROWS\nFETCH NEXT %d ROWS ONLY", offset, limit);
             }
 
             /**
              * LIMIT without ORDER BY not supported in SQLServer
-             * ORDER BY 1 added as a default when no ORDER BY present
+             * ORDER BY (SELECT NULL) or ORDER BY 1 are added as a default when no ORDER BY is present
              */
             @Override
             protected String serializeLimit(long limit, boolean noSortCondition) {
                 return noSortCondition
-                        ? String.format("ORDER BY 1\nOFFSET 0 ROWS\nFETCH NEXT %d ROWS ONLY", limit)
+                        ? selectFromWhere.isDistinct()
+                            ? String.format("ORDER BY 1\nOFFSET 0 ROWS\nFETCH NEXT %d ROWS ONLY", limit)
+                            : String.format("ORDER BY (SELECT NULL)\nOFFSET 0 ROWS\nFETCH NEXT %d ROWS ONLY", limit)
                         : String.format("OFFSET 0 ROWS\nFETCH NEXT %d ROWS ONLY", limit);
             }
 
             @Override
             protected String serializeOffset(long offset, boolean noSortCondition) {
                 return noSortCondition
-                        ? String.format("ORDER BY 1\nOFFSET %d ROWS", offset)
+                        ? selectFromWhere.isDistinct()
+                            ? String.format("ORDER BY 1\nOFFSET %d ROWS", offset)
+                            : String.format("ORDER BY (SELECT NULL)\nOFFSET %d ROWS", offset)
                         : String.format("OFFSET %d ROWS", offset);
             }
 

--- a/test/docker-tests/src/test/java/it/unibz/inf/ontop/docker/mssql/MsSQLLimitTest.java
+++ b/test/docker-tests/src/test/java/it/unibz/inf/ontop/docker/mssql/MsSQLLimitTest.java
@@ -88,7 +88,7 @@ public class MsSQLLimitTest extends AbstractVirtualModeTest {
                 "LIMIT 2 \n OFFSET 2";
         String val = runQueryAndReturnStringOfIndividualX(query);
         countResults(2, query);
-        assertEquals("<http://www.semanticweb.org/ontologies/2013/7/untitled-ontology-150#Country-992>", val);
+        assertEquals("<http://www.semanticweb.org/ontologies/2013/7/untitled-ontology-150#Country-993>", val);
     }
 
 }


### PR DESCRIPTION
Previously, we changed the `ORDER BY (SELECT NULL)` queries to `ORDER BY 1`, as the original approach would fail in the presence of `DISTINCT`.

However, we figured out that this solution will not always work. In particular, if column number 1 is of type XML, the query fails.

To reduce the likelihood of the error coming up, we added an additional condition: `ORDER BY 1` is only used if a `DISTINCT` appears. This way, queries on tables starting with XML columns will not always fail, but only if they also require DISTINCT, which should largely reduce the likelihood of this issue appearing.

In a future implementation we may fully fix this problem by generating a new column that will be of a simple data type and performing the `ORDER BY` on that column.