### PR TITLE
Decompose strict equalities with Values nodes

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/DestinationTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/DestinationTest.java
@@ -244,4 +244,66 @@ public class DestinationTest extends AbstractRDF4JTest {
         assertEquals(1, count);
     }
 
+    @Test
+    public void testValuesOnIRI1() {
+        String sparql = "PREFIX schema: <http://schema.org/>\n" +
+                "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\n" +
+                "PREFIX : <http://noi.example.org/ontology/odh#>\n" +
+                "PREFIX data: <http://destination.example.org/data/>\n" +
+                "\n" +
+                "SELECT (?h AS ?v)\n" +
+                "WHERE {\n" +
+                "  ?h a schema:LodgingBusiness .\n" +
+                "  OPTIONAL { \n" +
+                "    ?h schema:name ?en . \n" +
+                "    FILTER (lang(?en) = 'en')\n" +
+                "  }\n" +
+                "  OPTIONAL { \n" +
+                "    ?h schema:name ?it . \n" +
+                "    FILTER (lang(?it) = 'it')\n" +
+                "  }\n" +
+                "  VALUES ?h { \n" +
+                "   <http://destination.example.org/data/source1/hospitality/aaa> \n " +
+                "   <http://destination.example.org/data/source1/hospitality/bbb> \n" +
+                "  } \n" +
+                "}\n";
+
+        int count = runQueryAndCount(sparql);
+        assertEquals(1, count);
+
+        String sql = reformulateIntoNativeQuery(sparql);
+        assertEquals(0, StringUtils.countMatches(sql, "LEFT OUTER JOIN"));
+        assertEquals(0, StringUtils.countMatches(sql, "REPLACE"));
+    }
+
+    @Test
+    public void testValuesOnIRI2() {
+        String sparql = "PREFIX schema: <http://schema.org/>\n" +
+                "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\n" +
+                "PREFIX : <http://destination.example.org/ontology/dest#>\n" +
+                "\n" +
+                "SELECT (?h AS ?v)\n" +
+                "WHERE {\n" +
+                "  ?h a :Municipality .\n" +
+                "  OPTIONAL { \n" +
+                "    ?h schema:name ?en . \n" +
+                "    FILTER (lang(?en) = 'en')\n" +
+                "  }\n" +
+                "  OPTIONAL { \n" +
+                "    ?h schema:name ?it . \n" +
+                "    FILTER (lang(?it) = 'it')\n" +
+                "  }\n" +
+                "  VALUES ?h { \n" +
+                "   <http://destination.example.org/data/municipality/ESTSTE> \n " +
+                "   <http://destination.example.org/data/municipality/EEPST> \n" +
+                "  } \n" +
+                "}\n";
+
+        int count = runQueryAndCount(sparql);
+        assertEquals(1, count);
+
+        String sql = reformulateIntoNativeQuery(sparql);
+        assertEquals(0, StringUtils.countMatches(sql, "REPLACE"));
+    }
+
 }

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/MirrorViewPersonTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/MirrorViewPersonTest.java
@@ -34,6 +34,15 @@ public class MirrorViewPersonTest extends AbstractRDF4JTest {
     }
 
     @Test
+    public void testPerson2() {
+        int count = runQueryAndCount("SELECT * WHERE {\n" +
+                "\t?p a <http://person.example.org/Person> \n" +
+                " VALUES ?p { <http://person.example.org/person/1> <http://person.example.org/person/2> <http://person.example.org/person/%2B1> }\n" +
+                "}");
+        assertEquals(count, 1);
+    }
+
+    @Test
     public void testFullNameIn() {
         int count = runQueryAndCount("SELECT * WHERE {\n" +
                 "\t?p <http://person.example.org/fullName> ?n \n" +

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/DBTypeConversionFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/DBTypeConversionFunctionSymbol.java
@@ -2,6 +2,7 @@ package it.unibz.inf.ontop.model.term.functionsymbol.db;
 
 import it.unibz.inf.ontop.model.term.ImmutableFunctionalTerm;
 import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.TermFactory;
 import it.unibz.inf.ontop.model.term.functionsymbol.FunctionSymbol;
 import it.unibz.inf.ontop.model.type.DBTermType;
 
@@ -26,6 +27,14 @@ public interface DBTypeConversionFunctionSymbol extends DBFunctionSymbol {
      * Useful for simplifying nested casts ( A-to-B(B-to-A(x)) === x if both casts are simple)
      */
     boolean isSimple();
+
+    /**
+     * Returns no decomposer if it is not safe to decompose
+     *  (e.g. no respect of strict equalities, etc.)
+     */
+    default Optional<StringConstantDecomposer> getDecomposer(TermFactory termFactory) {
+        return Optional.empty();
+    }
 
     static boolean isTemporary(FunctionSymbol fs) {
         return (fs instanceof DBTypeConversionFunctionSymbol

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/ObjectStringTemplateFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/ObjectStringTemplateFunctionSymbol.java
@@ -1,7 +1,13 @@
 package it.unibz.inf.ontop.model.term.functionsymbol.db;
 
 import com.google.common.collect.ImmutableList;
+import it.unibz.inf.ontop.iq.node.VariableNullability;
 import it.unibz.inf.ontop.model.template.Template;
+import it.unibz.inf.ontop.model.term.DBConstant;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.TermFactory;
+
+import java.util.Optional;
 
 /**
  * Such a function symbol is specific to object identifier (IRI, bnode) template
@@ -13,4 +19,10 @@ public interface ObjectStringTemplateFunctionSymbol extends DBFunctionSymbol {
     String getTemplate();
 
     ImmutableList<Template.Component> getTemplateComponents();
+
+    /**
+     * Returns empty if the decomposition cannot be done (non-injective functional term or not matching the template)
+     */
+    Optional<ImmutableList<DBConstant>> decompose(ImmutableList<? extends ImmutableTerm> terms, DBConstant constant,
+                         TermFactory termFactory, VariableNullability variableNullability);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/ObjectStringTemplateFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/ObjectStringTemplateFunctionSymbol.java
@@ -8,6 +8,7 @@ import it.unibz.inf.ontop.model.term.ImmutableTerm;
 import it.unibz.inf.ontop.model.term.TermFactory;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Such a function symbol is specific to object identifier (IRI, bnode) template
@@ -21,8 +22,10 @@ public interface ObjectStringTemplateFunctionSymbol extends DBFunctionSymbol {
     ImmutableList<Template.Component> getTemplateComponents();
 
     /**
-     * Returns empty if the decomposition cannot be done (non-injective functional term or not matching the template)
+     * Returns no function if the functional term is not-injective
+     * The returned decomposition function returns empty if the template does not the constant.
      */
-    Optional<ImmutableList<DBConstant>> decompose(ImmutableList<? extends ImmutableTerm> terms, DBConstant constant,
-                         TermFactory termFactory, VariableNullability variableNullability);
+    Optional<Function<DBConstant, Optional<ImmutableList<DBConstant>>>> getDecomposer(ImmutableList<? extends ImmutableTerm> terms,
+                                                                                      TermFactory termFactory,
+                                                                                      VariableNullability variableNullability);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/ObjectStringTemplateFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/ObjectStringTemplateFunctionSymbol.java
@@ -3,12 +3,10 @@ package it.unibz.inf.ontop.model.term.functionsymbol.db;
 import com.google.common.collect.ImmutableList;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
 import it.unibz.inf.ontop.model.template.Template;
-import it.unibz.inf.ontop.model.term.DBConstant;
 import it.unibz.inf.ontop.model.term.ImmutableTerm;
 import it.unibz.inf.ontop.model.term.TermFactory;
 
 import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * Such a function symbol is specific to object identifier (IRI, bnode) template
@@ -22,10 +20,9 @@ public interface ObjectStringTemplateFunctionSymbol extends DBFunctionSymbol {
     ImmutableList<Template.Component> getTemplateComponents();
 
     /**
-     * Returns no function if the functional term is not-injective
-     * The returned decomposition function returns empty if the template does not the constant.
+     * Returns no decomposer if the functional term is not injective
      */
-    Optional<Function<DBConstant, Optional<ImmutableList<DBConstant>>>> getDecomposer(ImmutableList<? extends ImmutableTerm> terms,
+    Optional<StringConstantDecomposer> getDecomposer(ImmutableList<? extends ImmutableTerm> terms,
                                                                                       TermFactory termFactory,
                                                                                       VariableNullability variableNullability);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/StringConstantDecomposer.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/StringConstantDecomposer.java
@@ -1,0 +1,16 @@
+package it.unibz.inf.ontop.model.term.functionsymbol.db;
+
+import com.google.common.collect.ImmutableList;
+import it.unibz.inf.ontop.model.term.DBConstant;
+
+import java.util.Optional;
+
+@FunctionalInterface
+public interface StringConstantDecomposer {
+
+    /**
+     * Returns empty if the constant cannot be decomposed
+     *  (because it typically does not match the expected pattern)
+     */
+    Optional<ImmutableList<DBConstant>> decompose(DBConstant stringConstant);
+}

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultCastIntegerToStringFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultCastIntegerToStringFunctionSymbol.java
@@ -4,9 +4,11 @@ import com.google.common.collect.ImmutableList;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
 import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.model.term.functionsymbol.db.DBFunctionSymbolSerializer;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.StringConstantDecomposer;
 import it.unibz.inf.ontop.model.type.DBTermType;
 
 import javax.annotation.Nonnull;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 /**
@@ -28,6 +30,13 @@ public class DefaultCastIntegerToStringFunctionSymbol extends DefaultSimpleDBCas
     }
 
     @Override
+    protected boolean checkValueValidityForDecomposition(String value) {
+        // We eliminate the problematic pattern
+        return (!pattern.matcher(value).matches())
+                && super.checkValueValidityForDecomposition(value);
+    }
+
+    @Override
     protected IncrementalEvaluation evaluateStrictEqWithNonNullConstant(ImmutableList<? extends ImmutableTerm> terms,
                                                                         NonNullConstant otherTerm, TermFactory termFactory,
                                                                         VariableNullability variableNullability) {
@@ -41,4 +50,6 @@ public class DefaultCastIntegerToStringFunctionSymbol extends DefaultSimpleDBCas
 
         return perform2ndStepEvaluationStrictEqWithConstant(terms, otherValue, termFactory, variableNullability);
     }
+
+
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultSimpleDBCastFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultSimpleDBCastFunctionSymbol.java
@@ -86,9 +86,17 @@ public class DefaultSimpleDBCastFunctionSymbol extends AbstractDBTypeConversionF
         if (inputType == null || (!inputType.areEqualitiesStrict()))
             return Optional.empty();
 
-        return Optional.of(cst -> inputType.isValidLexicalValue(cst.getValue())
+        StringConstantDecomposer decomposer = cst -> checkValueValidityForDecomposition(cst.getValue())
+                ? Optional.of(ImmutableList.of(termFactory.getDBConstant(cst.getValue(), inputType)))
+                : Optional.empty();
+
+        return Optional.of(decomposer);
+    }
+
+    protected boolean checkValueValidityForDecomposition(String value) {
+        return (inputType != null) && inputType.isValidLexicalValue(value)
                 .filter(isValid -> isValid)
-                .map(b -> ImmutableList.of(termFactory.getDBConstant(cst.getValue(), inputType))));
+                .isPresent();
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultSimpleDBCastFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultSimpleDBCastFunctionSymbol.java
@@ -5,6 +5,7 @@ import it.unibz.inf.ontop.iq.node.VariableNullability;
 import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.model.term.functionsymbol.db.DBFunctionSymbolSerializer;
 import it.unibz.inf.ontop.model.term.functionsymbol.db.DBTypeConversionFunctionSymbol;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.StringConstantDecomposer;
 import it.unibz.inf.ontop.model.type.DBTermType;
 
 import javax.annotation.Nonnull;
@@ -78,6 +79,16 @@ public class DefaultSimpleDBCastFunctionSymbol extends AbstractDBTypeConversionF
     @Override
     public boolean isSimple() {
         return true;
+    }
+
+    @Override
+    public Optional<StringConstantDecomposer> getDecomposer(TermFactory termFactory) {
+        if (inputType == null || (!inputType.areEqualitiesStrict()))
+            return Optional.empty();
+
+        return Optional.of(cst -> inputType.isValidLexicalValue(cst.getValue())
+                .filter(isValid -> isValid)
+                .map(b -> ImmutableList.of(termFactory.getDBConstant(cst.getValue(), inputType))));
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/ObjectStringTemplateFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/ObjectStringTemplateFunctionSymbolImpl.java
@@ -18,6 +18,7 @@ import it.unibz.inf.ontop.model.type.TermType;
 import it.unibz.inf.ontop.model.type.TermTypeInference;
 import it.unibz.inf.ontop.model.type.TypeFactory;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import it.unibz.inf.ontop.utils.R2RMLIRISafeEncoder;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
@@ -465,7 +466,8 @@ public abstract class ObjectStringTemplateFunctionSymbolImpl extends FunctionSym
                 Matcher matcher = pattern.matcher(cst.getValue());
                 if (matcher.find()) {
                     return Optional.of(IntStream.range(0, getArity())
-                            .mapToObj(i -> termFactory.getDBStringConstant(matcher.group(i + 1)))
+                            .mapToObj(i -> termFactory.getDBStringConstant(
+                                    R2RMLIRISafeEncoder.decode(matcher.group(i + 1))))
                             .collect(ImmutableCollectors.toList()));
                 }
                 return Optional.empty();

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/ObjectStringTemplateFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/ObjectStringTemplateFunctionSymbolImpl.java
@@ -456,16 +456,20 @@ public abstract class ObjectStringTemplateFunctionSymbolImpl extends FunctionSym
     }
 
     @Override
-    public Optional<ImmutableList<DBConstant>> decompose(ImmutableList<? extends ImmutableTerm> terms, DBConstant constant,
-                                                         TermFactory termFactory, VariableNullability variableNullability) {
+    public Optional<Function<DBConstant, Optional<ImmutableList<DBConstant>>>> getDecomposer(ImmutableList<? extends ImmutableTerm> terms,
+                                                                                             TermFactory termFactory, VariableNullability variableNullability) {
 
         if (isInjective(terms, variableNullability, termFactory)) {
-            Matcher matcher = getPattern().matcher(constant.getValue());
-            if (matcher.find()) {
-                return Optional.of(IntStream.range(0, getArity())
-                                .mapToObj(i -> termFactory.getDBStringConstant(matcher.group(i + 1)))
-                                .collect(ImmutableCollectors.toList()));
-            }
+            Pattern pattern = getPattern();
+            return Optional.of( cst -> {
+                Matcher matcher = pattern.matcher(cst.getValue());
+                if (matcher.find()) {
+                    return Optional.of(IntStream.range(0, getArity())
+                            .mapToObj(i -> termFactory.getDBStringConstant(matcher.group(i + 1)))
+                            .collect(ImmutableCollectors.toList()));
+                }
+                return Optional.empty();
+            });
         }
         return Optional.empty();
     }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/ObjectStringTemplateFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/ObjectStringTemplateFunctionSymbolImpl.java
@@ -456,6 +456,21 @@ public abstract class ObjectStringTemplateFunctionSymbolImpl extends FunctionSym
     }
 
     @Override
+    public Optional<ImmutableList<DBConstant>> decompose(ImmutableList<? extends ImmutableTerm> terms, DBConstant constant,
+                                                         TermFactory termFactory, VariableNullability variableNullability) {
+
+        if (isInjective(terms, variableNullability, termFactory)) {
+            Matcher matcher = getPattern().matcher(constant.getValue());
+            if (matcher.find()) {
+                return Optional.of(IntStream.range(0, getArity())
+                                .mapToObj(i -> termFactory.getDBStringConstant(matcher.group(i + 1)))
+                                .collect(ImmutableCollectors.toList()));
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
     public boolean isPreferringToBePostProcessedOverBeingBlocked() {
         return true;
     }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/ObjectStringTemplateFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/ObjectStringTemplateFunctionSymbolImpl.java
@@ -11,6 +11,7 @@ import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.model.term.functionsymbol.FunctionSymbol;
 import it.unibz.inf.ontop.model.term.functionsymbol.db.DBTypeConversionFunctionSymbol;
 import it.unibz.inf.ontop.model.term.functionsymbol.db.ObjectStringTemplateFunctionSymbol;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.StringConstantDecomposer;
 import it.unibz.inf.ontop.model.term.functionsymbol.db.impl.AbstractEncodeURIorIRIFunctionSymbol.IRISafeEnDecoder;
 import it.unibz.inf.ontop.model.term.functionsymbol.impl.FunctionSymbolImpl;
 import it.unibz.inf.ontop.model.type.DBTermType;
@@ -457,8 +458,8 @@ public abstract class ObjectStringTemplateFunctionSymbolImpl extends FunctionSym
     }
 
     @Override
-    public Optional<Function<DBConstant, Optional<ImmutableList<DBConstant>>>> getDecomposer(ImmutableList<? extends ImmutableTerm> terms,
-                                                                                             TermFactory termFactory, VariableNullability variableNullability) {
+    public Optional<StringConstantDecomposer> getDecomposer(ImmutableList<? extends ImmutableTerm> terms,
+                                                            TermFactory termFactory, VariableNullability variableNullability) {
 
         if (isInjective(terms, variableNullability, termFactory)) {
             Pattern pattern = getPattern();

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/ValuesNodeTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/ValuesNodeTest.java
@@ -9,9 +9,7 @@ import it.unibz.inf.ontop.iq.node.ExtensionalDataNode;
 import it.unibz.inf.ontop.iq.node.FilterNode;
 import it.unibz.inf.ontop.iq.node.ValuesNode;
 import it.unibz.inf.ontop.model.template.Template;
-import it.unibz.inf.ontop.model.term.GroundFunctionalTerm;
-import it.unibz.inf.ontop.model.term.ImmutableTerm;
-import it.unibz.inf.ontop.model.term.VariableOrGroundTerm;
+import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.substitution.Substitution;
 import org.junit.Test;
 
@@ -19,6 +17,7 @@ import static it.unibz.inf.ontop.NoDependencyTestDBMetadata.TABLE1_AR1;
 import static it.unibz.inf.ontop.NoDependencyTestDBMetadata.TABLE1_AR2;
 import static it.unibz.inf.ontop.OptimizationTestingTools.*;
 import static it.unibz.inf.ontop.model.term.functionsymbol.InequalityLabel.LT;
+import static it.unibz.inf.ontop.model.term.functionsymbol.InequalityLabel.LTE;
 import static junit.framework.TestCase.assertTrue;
 
 public class ValuesNodeTest {
@@ -528,6 +527,75 @@ public class ValuesNodeTest {
                 constructionNode,
                 IQ_FACTORY.createNaryIQTree(
                         IQ_FACTORY.createInnerJoinNode(),
+                        ImmutableList.of(newValuesNode, dataNode)));
+
+        assertTrue(baseTestNormalization(initialTree, expectedTree));
+    }
+
+    @Test
+    public void testJoinIRITemplateString9() {
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1_AR2, ImmutableMap.of(0, A, 1, B));
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(X, Y),
+                SUBSTITUTION_FACTORY.getSubstitution(
+                        X, TERM_FACTORY.getIRIFunctionalTerm(
+                                Template.builder()
+                                        .addSeparator("http://localhost/thing/")
+                                        .addColumn()
+                                        .addSeparator("/")
+                                        .addColumn()
+                                        .build(),
+                                ImmutableList.of(A, B)
+                        ).getTerm(0),
+                Y, TERM_FACTORY.getIRIFunctionalTerm(
+                        Template.builder()
+                                .addSeparator("http://localhost/other/")
+                                .addColumn()
+                                .build(),
+                        ImmutableList.of(B)
+                        ).getTerm(0)));
+
+        DBConstant zero = TERM_FACTORY.getDBIntegerConstant(0);
+
+        ValuesNode valuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(X,Y,Z),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/1%2F/3"),
+                                TERM_FACTORY.getDBStringConstant("http://localhost/other/3"),
+                                zero),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/2/4"),
+                                TERM_FACTORY.getDBStringConstant("http://localhost/other/4"),
+                                ONE),
+                        ImmutableList.of(TERM_FACTORY.getNullConstant(),
+                                TERM_FACTORY.getDBStringConstant("http://localhost/other/4"),
+                                ONE),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/somethingelse"),
+                                TERM_FACTORY.getDBStringConstant("http://localhost/other/5"),
+                                ONE),
+                ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/1%2F/3"),
+                        TERM_FACTORY.getDBStringConstant("http://localhost/other/11"),
+                        ONE),
+                ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/1%2F/3"),
+                        TERM_FACTORY.getDBStringConstant("http://localhost/other/3"),
+                        TWO)));
+
+        ImmutableExpression condition = TERM_FACTORY.getDBNumericInequality(LTE, Z, ONE);
+
+        IQTree initialTree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createInnerJoinNode(condition),
+                ImmutableList.of(valuesNode, IQ_FACTORY.createUnaryIQTree(constructionNode, dataNode)));
+
+        ValuesNode newValuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(Z, A, B),
+                ImmutableList.of(
+                        ImmutableList.of(zero, TERM_FACTORY.getDBStringConstant("1/"), TERM_FACTORY.getDBStringConstant("3")),
+                        ImmutableList.of(ONE, TERM_FACTORY.getDBStringConstant("2"), TERM_FACTORY.getDBStringConstant("4"))));
+
+        IQTree expectedTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(initialTree.getVariables(), constructionNode.getSubstitution()),
+                IQ_FACTORY.createNaryIQTree(
+                        IQ_FACTORY.createInnerJoinNode(condition),
                         ImmutableList.of(newValuesNode, dataNode)));
 
         assertTrue(baseTestNormalization(initialTree, expectedTree));

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/ValuesNodeTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/ValuesNodeTest.java
@@ -10,11 +10,13 @@ import it.unibz.inf.ontop.iq.node.FilterNode;
 import it.unibz.inf.ontop.iq.node.ValuesNode;
 import it.unibz.inf.ontop.model.template.Template;
 import it.unibz.inf.ontop.model.term.GroundFunctionalTerm;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
 import it.unibz.inf.ontop.model.term.VariableOrGroundTerm;
 import it.unibz.inf.ontop.substitution.Substitution;
 import org.junit.Test;
 
 import static it.unibz.inf.ontop.NoDependencyTestDBMetadata.TABLE1_AR1;
+import static it.unibz.inf.ontop.NoDependencyTestDBMetadata.TABLE1_AR2;
 import static it.unibz.inf.ontop.OptimizationTestingTools.*;
 import static it.unibz.inf.ontop.model.term.functionsymbol.InequalityLabel.LT;
 import static junit.framework.TestCase.assertTrue;
@@ -197,7 +199,7 @@ public class ValuesNodeTest {
     }
 
     @Test
-    public void testJoinIRITemplateString() {
+    public void testJoinIRITemplateString1() {
 
         ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1_AR1, ImmutableMap.of(0, A));
 
@@ -226,6 +228,257 @@ public class ValuesNodeTest {
                 ImmutableList.of(
                         ImmutableList.of(TERM_FACTORY.getDBStringConstant("1")),
                         ImmutableList.of(TERM_FACTORY.getDBStringConstant("2"))));
+
+        IQTree expectedTree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createNaryIQTree(
+                        IQ_FACTORY.createInnerJoinNode(),
+                        ImmutableList.of(newValuesNode, dataNode)));
+
+        assertTrue(baseTestNormalization(initialTree, expectedTree));
+    }
+
+    @Test
+    public void testJoinIRITemplateString2() {
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1_AR1, ImmutableMap.of(0, A));
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(X),
+                SUBSTITUTION_FACTORY.getSubstitution(
+                        X, TERM_FACTORY.getIRIFunctionalTerm(
+                                Template.builder()
+                                        .addSeparator("http://localhost/thing/")
+                                        .addColumn()
+                                        .build(),
+                                ImmutableList.of(A)
+                        ).getTerm(0)));
+
+        ValuesNode valuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(X),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/1")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/2")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/somethingelse"))));
+
+        IQTree initialTree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createInnerJoinNode(),
+                ImmutableList.of(valuesNode, IQ_FACTORY.createUnaryIQTree(constructionNode, dataNode)));
+
+        ValuesNode newValuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(A),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("1")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("2"))));
+
+        IQTree expectedTree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createNaryIQTree(
+                        IQ_FACTORY.createInnerJoinNode(),
+                        ImmutableList.of(newValuesNode, dataNode)));
+
+        assertTrue(baseTestNormalization(initialTree, expectedTree));
+    }
+
+    @Test
+    public void testJoinIRITemplateString3() {
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1_AR1, ImmutableMap.of(0, A));
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(X),
+                SUBSTITUTION_FACTORY.getSubstitution(
+                        X, TERM_FACTORY.getIRIFunctionalTerm(
+                                Template.builder()
+                                        .addSeparator("http://localhost/thing/")
+                                        .addColumn()
+                                        .build(),
+                                ImmutableList.of(A)
+                        ).getTerm(0)));
+
+        ValuesNode valuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(X),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/somethingelse"))));
+
+        IQTree initialTree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createInnerJoinNode(),
+                ImmutableList.of(valuesNode, IQ_FACTORY.createUnaryIQTree(constructionNode, dataNode)));
+
+        IQTree expectedTree = IQ_FACTORY.createEmptyNode(initialTree.getVariables());
+
+        assertTrue(baseTestNormalization(initialTree, expectedTree));
+    }
+
+    @Test
+    public void testJoinIRITemplateString4() {
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1_AR2, ImmutableMap.of(0, A, 1, B));
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(X),
+                SUBSTITUTION_FACTORY.getSubstitution(
+                        X, TERM_FACTORY.getIRIFunctionalTerm(
+                                Template.builder()
+                                        .addSeparator("http://localhost/thing/")
+                                        .addColumn()
+                                        .addSeparator("/")
+                                        .addColumn()
+                                        .build(),
+                                ImmutableList.of(A, B)
+                        ).getTerm(0)));
+
+        ValuesNode valuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(X),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/1/3")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/2/4")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/somethingelse"))));
+
+        IQTree initialTree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createInnerJoinNode(),
+                ImmutableList.of(valuesNode, IQ_FACTORY.createUnaryIQTree(constructionNode, dataNode)));
+
+        ValuesNode newValuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(A, B),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("1"), TERM_FACTORY.getDBStringConstant("3")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("2"), TERM_FACTORY.getDBStringConstant("4"))));
+
+        IQTree expectedTree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createNaryIQTree(
+                        IQ_FACTORY.createInnerJoinNode(),
+                        ImmutableList.of(newValuesNode, dataNode)));
+
+        assertTrue(baseTestNormalization(initialTree, expectedTree));
+    }
+
+    /**
+     * Non-injective
+     */
+    @Test
+    public void testJoinIRITemplateString5() {
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1_AR2, ImmutableMap.of(0, A, 1, B));
+
+        ImmutableTerm functionalTerm = TERM_FACTORY.getIRIFunctionalTerm(
+                Template.builder()
+                        .addSeparator("http://localhost/thing/")
+                        .addColumn()
+                        // Non-injective!!
+                        .addColumn()
+                        .build(),
+                ImmutableList.of(A, B)).getTerm(0);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(X),
+                SUBSTITUTION_FACTORY.getSubstitution(X, functionalTerm));
+
+        ValuesNode valuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(X),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/13")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/24")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/somethingelse"))));
+
+        IQTree initialTree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createInnerJoinNode(),
+                ImmutableList.of(valuesNode, IQ_FACTORY.createUnaryIQTree(constructionNode, dataNode)));
+
+        ValuesNode newValuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(XF0),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/13")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/24"))));
+
+        IQTree expectedTree = IQ_FACTORY.createUnaryIQTree(constructionNode,
+                IQ_FACTORY.createNaryIQTree(
+                        IQ_FACTORY.createInnerJoinNode(TERM_FACTORY.getStrictEquality(functionalTerm, XF0)),
+                        ImmutableList.of(newValuesNode, dataNode)));
+
+        assertTrue(baseTestNormalization(initialTree, expectedTree));
+    }
+
+    @Test
+    public void testJoinIRITemplateString6() {
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1_AR2, ImmutableMap.of(0, A, 1, B));
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(X),
+                SUBSTITUTION_FACTORY.getSubstitution(
+                        X, TERM_FACTORY.getIRIFunctionalTerm(
+                                Template.builder()
+                                        .addSeparator("http://localhost/thing/")
+                                        .addColumn()
+                                        .addSeparator("/")
+                                        .addColumn()
+                                        .build(),
+                                ImmutableList.of(A, B)
+                        ).getTerm(0)));
+
+        ValuesNode valuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(X),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/1/3")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/2/4")),
+                        ImmutableList.of(TERM_FACTORY.getNullConstant()),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/somethingelse"))));
+
+        IQTree initialTree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createInnerJoinNode(),
+                ImmutableList.of(valuesNode, IQ_FACTORY.createUnaryIQTree(constructionNode, dataNode)));
+
+        ValuesNode newValuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(A, B),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("1"), TERM_FACTORY.getDBStringConstant("3")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("2"), TERM_FACTORY.getDBStringConstant("4"))));
+
+        IQTree expectedTree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createNaryIQTree(
+                        IQ_FACTORY.createInnerJoinNode(),
+                        ImmutableList.of(newValuesNode, dataNode)));
+
+        assertTrue(baseTestNormalization(initialTree, expectedTree));
+    }
+
+    @Test
+    public void testJoinIRITemplateString7() {
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1_AR2, ImmutableMap.of(0, A, 1, B));
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(X),
+                SUBSTITUTION_FACTORY.getSubstitution(
+                        X, TERM_FACTORY.getIRIFunctionalTerm(
+                                Template.builder()
+                                        .addSeparator("http://localhost/thing/")
+                                        .addColumn()
+                                        .addSeparator("/")
+                                        .addColumn()
+                                        .build(),
+                                ImmutableList.of(TERM_FACTORY.getDBCastFunctionalTerm(
+                                            TYPE_FACTORY.getDBTypeFactory().getDBLargeIntegerType(),
+                                            TYPE_FACTORY.getDBTypeFactory().getDBStringType(),
+                                            A),
+                                        B)
+                        ).getTerm(0)));
+
+        ValuesNode valuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(X),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/1/3")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/2/4")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/notANumber/5")),
+                        ImmutableList.of(TERM_FACTORY.getNullConstant()),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/somethingelse"))));
+
+        IQTree initialTree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createInnerJoinNode(),
+                ImmutableList.of(valuesNode, IQ_FACTORY.createUnaryIQTree(constructionNode, dataNode)));
+
+        ValuesNode newValuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(B, A),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("3"), TERM_FACTORY.getDBIntegerConstant(1)),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("4"), TERM_FACTORY.getDBIntegerConstant(2))));
 
         IQTree expectedTree = IQ_FACTORY.createUnaryIQTree(
                 constructionNode,

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/ValuesNodeTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/ValuesNodeTest.java
@@ -197,7 +197,7 @@ public class ValuesNodeTest {
     }
 
     @Test
-    public void testJoinIRITemplate() {
+    public void testJoinIRITemplateString() {
 
         ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1_AR1, ImmutableMap.of(0, A));
 
@@ -209,13 +209,13 @@ public class ValuesNodeTest {
                                         .addColumn()
                                         .build(),
                                 ImmutableList.of(A)
-                        )));
+                        ).getTerm(0)));
 
         ValuesNode valuesNode = IQ_FACTORY.createValuesNode(
                 ImmutableList.of(X),
                 ImmutableList.of(
-                        ImmutableList.of(TERM_FACTORY.getConstantIRI("http://localhost/thing/1")),
-                        ImmutableList.of(TERM_FACTORY.getConstantIRI("http://localhost/thing/2"))));
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/1")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/2"))));
 
         IQTree initialTree = IQ_FACTORY.createNaryIQTree(
                 IQ_FACTORY.createInnerJoinNode(),
@@ -224,9 +224,8 @@ public class ValuesNodeTest {
         ValuesNode newValuesNode = IQ_FACTORY.createValuesNode(
                 ImmutableList.of(A),
                 ImmutableList.of(
-                        ImmutableList.of(
-                                TERM_FACTORY.getDBStringConstant("1"),
-                                TERM_FACTORY.getDBStringConstant("2"))));
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("1")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("2"))));
 
         IQTree expectedTree = IQ_FACTORY.createUnaryIQTree(
                 constructionNode,

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/ValuesNodeTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/ValuesNodeTest.java
@@ -489,6 +489,50 @@ public class ValuesNodeTest {
         assertTrue(baseTestNormalization(initialTree, expectedTree));
     }
 
+    @Test
+    public void testJoinIRITemplateString8() {
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1_AR2, ImmutableMap.of(0, A, 1, B));
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(X),
+                SUBSTITUTION_FACTORY.getSubstitution(
+                        X, TERM_FACTORY.getIRIFunctionalTerm(
+                                Template.builder()
+                                        .addSeparator("http://localhost/thing/")
+                                        .addColumn()
+                                        .addSeparator("/")
+                                        .addColumn()
+                                        .build(),
+                                ImmutableList.of(A, B)
+                        ).getTerm(0)));
+
+        ValuesNode valuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(X),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/1%2F/3")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/2/4")),
+                        ImmutableList.of(TERM_FACTORY.getNullConstant()),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/somethingelse"))));
+
+        IQTree initialTree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createInnerJoinNode(),
+                ImmutableList.of(valuesNode, IQ_FACTORY.createUnaryIQTree(constructionNode, dataNode)));
+
+        ValuesNode newValuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(A, B),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("1/"), TERM_FACTORY.getDBStringConstant("3")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("2"), TERM_FACTORY.getDBStringConstant("4"))));
+
+        IQTree expectedTree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createNaryIQTree(
+                        IQ_FACTORY.createInnerJoinNode(),
+                        ImmutableList.of(newValuesNode, dataNode)));
+
+        assertTrue(baseTestNormalization(initialTree, expectedTree));
+    }
+
     private Boolean baseTestNormalization(IQTree initialTree, IQTree expectedTree) {
         System.out.println('\n' + "Tree before normalizing:");
         System.out.println(initialTree);

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/ValuesNodeTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/ValuesNodeTest.java
@@ -11,6 +11,7 @@ import it.unibz.inf.ontop.iq.node.ValuesNode;
 import it.unibz.inf.ontop.model.template.Template;
 import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.substitution.Substitution;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static it.unibz.inf.ontop.NoDependencyTestDBMetadata.TABLE1_AR1;
@@ -596,6 +597,57 @@ public class ValuesNodeTest {
                 IQ_FACTORY.createConstructionNode(initialTree.getVariables(), constructionNode.getSubstitution()),
                 IQ_FACTORY.createNaryIQTree(
                         IQ_FACTORY.createInnerJoinNode(condition),
+                        ImmutableList.of(newValuesNode, dataNode)));
+
+        assertTrue(baseTestNormalization(initialTree, expectedTree));
+    }
+
+    @Ignore("TODO: use type-specific casting function in the mockup factory")
+    @Test
+    public void testJoinIRITemplateString10() {
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1_AR2, ImmutableMap.of(0, A, 1, B));
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(X),
+                SUBSTITUTION_FACTORY.getSubstitution(
+                        X, TERM_FACTORY.getIRIFunctionalTerm(
+                                Template.builder()
+                                        .addSeparator("http://localhost/thing/")
+                                        .addColumn()
+                                        .addSeparator("/")
+                                        .addColumn()
+                                        .build(),
+                                ImmutableList.of(TERM_FACTORY.getDBCastFunctionalTerm(
+                                                TYPE_FACTORY.getDBTypeFactory().getDBLargeIntegerType(),
+                                                TYPE_FACTORY.getDBTypeFactory().getDBStringType(),
+                                                A),
+                                        B)
+                        ).getTerm(0)));
+
+        ValuesNode valuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(X),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/%2B1/3")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/2/4")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/5/6")),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/thing/notANumber/5")),
+                        ImmutableList.of(TERM_FACTORY.getNullConstant()),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("http://localhost/somethingelse"))));
+
+        IQTree initialTree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createInnerJoinNode(),
+                ImmutableList.of(valuesNode, IQ_FACTORY.createUnaryIQTree(constructionNode, dataNode)));
+
+        ValuesNode newValuesNode = IQ_FACTORY.createValuesNode(
+                ImmutableList.of(B, A),
+                ImmutableList.of(
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("4"), TERM_FACTORY.getDBIntegerConstant(2)),
+                        ImmutableList.of(TERM_FACTORY.getDBStringConstant("6"), TERM_FACTORY.getDBIntegerConstant(5))));
+
+        IQTree expectedTree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createNaryIQTree(
+                        IQ_FACTORY.createInnerJoinNode(),
                         ImmutableList.of(newValuesNode, dataNode)));
 
         assertTrue(baseTestNormalization(initialTree, expectedTree));


### PR DESCRIPTION
This PR introduces decomposition of strict equalities for values node.

For instance, values nodes often contain IRI strings and they are joining with mapping definitions that builds these IRIs from an IRI template. Values nodes can be simplified to contain the values used as parameters in the IRI template instead of the IRI strings.

Similarly they should use natural DB values (e.g. integer) instead of strings to make the joins more efficient (with no cast-to-string anymore).

Example:
```
JOIN
   VALUES [x] ("http://localhost/thing/1/3"^^STRING) ("http://localhost/thing/2/4"^^STRING) ("http://localhost/thing/notANumber/5"^^STRING) (NULL) ("http://localhost/somethingelse"^^STRING)
   CONSTRUCT [x] [x/http://localhost/thing/{}/{}(LARGE_INTToSTRING(a),b)]
      EXTENSIONAL STR_TABLE1AR2(0:a,1:b)
```
into

```
CONSTRUCT [x] [x/http://localhost/thing/{}/{}(LARGE_INTToSTRING(a),b)]
   JOIN
      VALUES [b, a] ("3"^^STRING,"1"^^LARGE_INT) ("4"^^STRING,"2"^^LARGE_INT)
      EXTENSIONAL STR_TABLE1AR2(0:a,1:b)
```