### PR TITLE
Functional Dependency Inference

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/ConcreteIQTreeCache.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/ConcreteIQTreeCache.java
@@ -2,6 +2,7 @@ package it.unibz.inf.ontop.iq;
 
 import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.model.term.NonVariableTerm;
 import it.unibz.inf.ontop.model.term.Variable;
@@ -34,6 +35,9 @@ public interface ConcreteIQTreeCache extends IQTreeCache {
     ImmutableSet<ImmutableSet<Variable>> getUniqueConstraints();
 
     @Nullable
+    FunctionalDependencies getFunctionalDependencies();
+
+    @Nullable
     Boolean isDistinct();
 
     /**
@@ -60,6 +64,11 @@ public interface ConcreteIQTreeCache extends IQTreeCache {
      * Can only be set ONCE!
      */
     void setUniqueConstraints(@Nonnull ImmutableSet<ImmutableSet<Variable>> uniqueConstraints);
+
+    /**
+     * Can only be set ONCE!
+     */
+    void setFunctionalDependencies(@Nonnull FunctionalDependencies functionalDependencies);
 
     /**
      * Can only be set ONCE!

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/IQTree.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/IQTree.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.node.QueryNode;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -148,6 +149,11 @@ public interface IQTree {
      * Warning: some determinants may be nullable!
      */
     ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints();
+
+    /**
+     * NOT guaranteed to return all the functional dependencies (MAY BE INCOMPLETE)
+     */
+    FunctionalDependencies inferFunctionalDependencies();
 
     /**
      * Variables that the tree proposes for removal if the ancestor trees do not need them.

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/AbstractCompositeIQTree.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/AbstractCompositeIQTree.java
@@ -2,8 +2,6 @@ package it.unibz.inf.ontop.iq.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.*;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
@@ -278,9 +276,7 @@ public abstract class AbstractCompositeIQTree<N extends QueryNode> implements Co
         return dependencies;
     }
 
-    protected FunctionalDependencies computeFunctionalDependencies() {
-        return getRootNode().inferFunctionalDependencies(getChildren(), inferUniqueConstraints(), getVariables());
-    }
+    protected abstract FunctionalDependencies computeFunctionalDependencies();
 
     @Override
     public synchronized VariableNonRequirement getVariableNonRequirement() {

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/AbstractCompositeIQTree.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/AbstractCompositeIQTree.java
@@ -2,6 +2,7 @@ package it.unibz.inf.ontop.iq.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.*;
@@ -271,21 +272,14 @@ public abstract class AbstractCompositeIQTree<N extends QueryNode> implements Co
         // Non-final
         FunctionalDependencies dependencies = treeCache.getFunctionalDependencies();
         if (dependencies == null) {
-            dependencies = computeAllFunctionalDependencies();
+            dependencies = computeFunctionalDependencies();
             treeCache.setFunctionalDependencies(dependencies);
         }
         return dependencies;
     }
 
-    protected abstract FunctionalDependencies computeFunctionalDependencies();
-
-    protected FunctionalDependencies computeAllFunctionalDependencies() {
-        FunctionalDependencies inferredDependencies = computeFunctionalDependencies();
-        FunctionalDependencies fromUCs = inferUniqueConstraints().stream()
-                .map(uc -> Map.entry(uc, Sets.difference(getVariables(), uc).immutableCopy()))
-                .filter(fd -> !fd.getValue().isEmpty())
-                .collect(FunctionalDependencies.toFunctionalDependencies());
-        return inferredDependencies.concat(fromUCs);
+    protected FunctionalDependencies computeFunctionalDependencies() {
+        return getRootNode().inferFunctionalDependencies(getChildren(), inferUniqueConstraints(), getVariables());
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/AbstractCompositeIQTree.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/AbstractCompositeIQTree.java
@@ -2,6 +2,7 @@ package it.unibz.inf.ontop.iq.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.*;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
@@ -281,7 +282,8 @@ public abstract class AbstractCompositeIQTree<N extends QueryNode> implements Co
     protected FunctionalDependencies computeAllFunctionalDependencies() {
         FunctionalDependencies inferredDependencies = computeFunctionalDependencies();
         FunctionalDependencies fromUCs = inferUniqueConstraints().stream()
-                .map(uc -> Map.entry(uc, getVariables()))
+                .map(uc -> Map.entry(uc, Sets.difference(getVariables(), uc).immutableCopy()))
+                .filter(fd -> !fd.getValue().isEmpty())
                 .collect(FunctionalDependencies.toFunctionalDependencies());
         return inferredDependencies.concat(fromUCs);
     }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/BinaryNonCommutativeIQTreeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/BinaryNonCommutativeIQTreeImpl.java
@@ -13,6 +13,7 @@ import it.unibz.inf.ontop.iq.IQTreeCache;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.node.BinaryNonCommutativeOperatorNode;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -197,6 +198,11 @@ public class BinaryNonCommutativeIQTreeImpl extends AbstractCompositeIQTree<Bina
     @Override
     protected ImmutableSet<ImmutableSet<Variable>> computeUniqueConstraints() {
         return getRootNode().inferUniqueConstraints(leftChild, rightChild);
+    }
+
+    @Override
+    protected FunctionalDependencies computeFunctionalDependencies() {
+        return getRootNode().inferFunctionalDependencies(leftChild, rightChild);
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/BinaryNonCommutativeIQTreeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/BinaryNonCommutativeIQTreeImpl.java
@@ -1,7 +1,6 @@
 package it.unibz.inf.ontop.iq.impl;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
@@ -203,5 +202,10 @@ public class BinaryNonCommutativeIQTreeImpl extends AbstractCompositeIQTree<Bina
     @Override
     protected VariableNonRequirement computeVariableNonRequirement() {
         return getRootNode().computeNotInternallyRequiredVariables(leftChild, rightChild);
+    }
+
+    @Override
+    protected FunctionalDependencies computeFunctionalDependencies() {
+        return getRootNode().inferFunctionalDependencies(leftChild, rightChild, inferUniqueConstraints(), getVariables());
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/BinaryNonCommutativeIQTreeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/BinaryNonCommutativeIQTreeImpl.java
@@ -201,11 +201,6 @@ public class BinaryNonCommutativeIQTreeImpl extends AbstractCompositeIQTree<Bina
     }
 
     @Override
-    protected FunctionalDependencies computeFunctionalDependencies() {
-        return getRootNode().inferFunctionalDependencies(leftChild, rightChild);
-    }
-
-    @Override
     protected VariableNonRequirement computeVariableNonRequirement() {
         return getRootNode().computeNotInternallyRequiredVariables(leftChild, rightChild);
     }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/NaryIQTreeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/NaryIQTreeImpl.java
@@ -177,11 +177,6 @@ public class NaryIQTreeImpl extends AbstractCompositeIQTree<NaryOperatorNode> im
     }
 
     @Override
-    protected FunctionalDependencies computeFunctionalDependencies() {
-        return getRootNode().inferFunctionalDependencies(getChildren());
-    }
-
-    @Override
     protected VariableNonRequirement computeVariableNonRequirement() {
         return getRootNode().computeVariableNonRequirement(getChildren());
     }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/NaryIQTreeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/NaryIQTreeImpl.java
@@ -180,4 +180,9 @@ public class NaryIQTreeImpl extends AbstractCompositeIQTree<NaryOperatorNode> im
     protected VariableNonRequirement computeVariableNonRequirement() {
         return getRootNode().computeVariableNonRequirement(getChildren());
     }
+
+    @Override
+    protected FunctionalDependencies computeFunctionalDependencies() {
+        return getRootNode().inferFunctionalDependencies(getChildren(), inferUniqueConstraints(), getVariables());
+    }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/NaryIQTreeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/NaryIQTreeImpl.java
@@ -12,6 +12,7 @@ import it.unibz.inf.ontop.iq.NaryIQTree;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.node.NaryOperatorNode;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -173,6 +174,11 @@ public class NaryIQTreeImpl extends AbstractCompositeIQTree<NaryOperatorNode> im
     @Override
     protected ImmutableSet<ImmutableSet<Variable>> computeUniqueConstraints() {
         return getRootNode().inferUniqueConstraints(getChildren());
+    }
+
+    @Override
+    protected FunctionalDependencies computeFunctionalDependencies() {
+        return getRootNode().inferFunctionalDependencies(getChildren());
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/UnaryIQTreeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/UnaryIQTreeImpl.java
@@ -135,12 +135,6 @@ public class UnaryIQTreeImpl extends AbstractCompositeIQTree<UnaryOperatorNode> 
     }
 
     @Override
-    protected FunctionalDependencies computeFunctionalDependencies() {
-        return getRootNode().inferFunctionalDependencies(getChild());
-    }
-
-
-    @Override
     public IQTree removeDistincts() {
         IQTreeCache treeCache = getTreeCache();
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/UnaryIQTreeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/UnaryIQTreeImpl.java
@@ -12,6 +12,7 @@ import it.unibz.inf.ontop.iq.UnaryIQTree;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.node.UnaryOperatorNode;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -132,6 +133,12 @@ public class UnaryIQTreeImpl extends AbstractCompositeIQTree<UnaryOperatorNode> 
     protected VariableNonRequirement computeVariableNonRequirement() {
         return getRootNode().computeVariableNonRequirement(getChild());
     }
+
+    @Override
+    protected FunctionalDependencies computeFunctionalDependencies() {
+        return getRootNode().inferFunctionalDependencies(getChild());
+    }
+
 
     @Override
     public IQTree removeDistincts() {

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/UnaryIQTreeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/impl/UnaryIQTreeImpl.java
@@ -172,4 +172,9 @@ public class UnaryIQTreeImpl extends AbstractCompositeIQTree<UnaryOperatorNode> 
     public IQTree getChild() {
         return getChildren().get(0);
     }
+
+    @Override
+    protected FunctionalDependencies computeFunctionalDependencies() {
+        return getRootNode().inferFunctionalDependencies(getChild(), inferUniqueConstraints(), getVariables());
+    }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/BinaryOrderedOperatorNode.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/BinaryOrderedOperatorNode.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.IQTreeCache;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -69,6 +70,7 @@ public interface BinaryOrderedOperatorNode extends QueryNode {
     IQTree removeDistincts(IQTree leftChild, IQTree rightChild, IQTreeCache treeCache);
 
     ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(IQTree leftChild, IQTree rightChild);
+    FunctionalDependencies inferFunctionalDependencies(IQTree leftChild, IQTree rightChild);
 
     VariableNonRequirement computeNotInternallyRequiredVariables(IQTree leftChild, IQTree rightChild);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/BinaryOrderedOperatorNode.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/BinaryOrderedOperatorNode.java
@@ -70,7 +70,7 @@ public interface BinaryOrderedOperatorNode extends QueryNode {
     IQTree removeDistincts(IQTree leftChild, IQTree rightChild, IQTreeCache treeCache);
 
     ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(IQTree leftChild, IQTree rightChild);
-    FunctionalDependencies inferFunctionalDependencies(IQTree leftChild, IQTree rightChild);
+    FunctionalDependencies inferFunctionalDependencies(IQTree leftChild, IQTree rightChild, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables);
 
     VariableNonRequirement computeNotInternallyRequiredVariables(IQTree leftChild, IQTree rightChild);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/NaryOperatorNode.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/NaryOperatorNode.java
@@ -6,6 +6,7 @@ import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.IQTreeCache;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -68,6 +69,7 @@ public interface NaryOperatorNode extends QueryNode {
     IQTree removeDistincts(ImmutableList<IQTree> children, IQTreeCache treeCache);
 
     ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(ImmutableList<IQTree> children);
+    FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children);
 
     VariableNonRequirement computeVariableNonRequirement(ImmutableList<IQTree> children);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/NaryOperatorNode.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/NaryOperatorNode.java
@@ -69,7 +69,7 @@ public interface NaryOperatorNode extends QueryNode {
     IQTree removeDistincts(ImmutableList<IQTree> children, IQTreeCache treeCache);
 
     ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(ImmutableList<IQTree> children);
-    FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children);
+    FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables);
 
     VariableNonRequirement computeVariableNonRequirement(ImmutableList<IQTree> children);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/QueryNode.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/QueryNode.java
@@ -1,10 +1,7 @@
 package it.unibz.inf.ontop.iq.node;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
-import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.model.term.Variable;
 import it.unibz.inf.ontop.iq.transform.node.HomogeneousQueryNodeTransformer;
 
@@ -66,6 +63,4 @@ public interface QueryNode {
      *
      */
     boolean wouldKeepDescendingGroundTermInFilterAbove(Variable variable, boolean isConstant);
-
-    FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/QueryNode.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/QueryNode.java
@@ -1,7 +1,10 @@
 package it.unibz.inf.ontop.iq.node;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.model.term.Variable;
 import it.unibz.inf.ontop.iq.transform.node.HomogeneousQueryNodeTransformer;
 
@@ -63,4 +66,6 @@ public interface QueryNode {
      *
      */
     boolean wouldKeepDescendingGroundTermInFilterAbove(Variable variable, boolean isConstant);
+
+    FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/UnaryOperatorNode.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/UnaryOperatorNode.java
@@ -68,7 +68,7 @@ public interface UnaryOperatorNode extends QueryNode {
 
     ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(IQTree child);
 
-    FunctionalDependencies inferFunctionalDependencies(IQTree child);
+    FunctionalDependencies inferFunctionalDependencies(IQTree child, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables);
 
     VariableNonRequirement computeVariableNonRequirement(IQTree child);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/UnaryOperatorNode.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/UnaryOperatorNode.java
@@ -5,6 +5,7 @@ import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.IQTreeCache;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -66,6 +67,8 @@ public interface UnaryOperatorNode extends QueryNode {
     IQTree removeDistincts(IQTree child, IQTreeCache treeCache);
 
     ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(IQTree child);
+
+    FunctionalDependencies inferFunctionalDependencies(IQTree child);
 
     VariableNonRequirement computeVariableNonRequirement(IQTree child);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/AggregationNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/AggregationNodeImpl.java
@@ -336,7 +336,7 @@ public class AggregationNodeImpl extends ExtendedProjectionNodeImpl implements A
                 .filter(e -> groupingVariables.containsAll(e.getKey()))
                 .filter(e -> e.getValue().stream()
                         .anyMatch(groupingVariables::contains))
-                .map(e -> Map.entry(e.getKey(), e.getValue().stream()
+                .map(e -> Maps.immutableEntry(e.getKey(), e.getValue().stream()
                         .filter(groupingVariables::contains)
                         .collect(ImmutableCollectors.toSet())))
                 .collect(FunctionalDependencies.toFunctionalDependencies());

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/AggregationNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/AggregationNodeImpl.java
@@ -328,7 +328,7 @@ public class AggregationNodeImpl extends ExtendedProjectionNodeImpl implements A
     }
 
     @Override
-    public FunctionalDependencies inferFunctionalDependencies(IQTree child) {
+    public FunctionalDependencies inferFunctionalDependencies(IQTree child, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
         var childFDs = child.inferFunctionalDependencies();
 
         //Return all of the child's functional dependencies that are included entirely inside the grouping variables.
@@ -339,7 +339,8 @@ public class AggregationNodeImpl extends ExtendedProjectionNodeImpl implements A
                 .map(e -> Maps.immutableEntry(e.getKey(), e.getValue().stream()
                         .filter(groupingVariables::contains)
                         .collect(ImmutableCollectors.toSet())))
-                .collect(FunctionalDependencies.toFunctionalDependencies());
+                .collect(FunctionalDependencies.toFunctionalDependencies())
+                .concat(FunctionalDependencies.fromUniqueConstraints(uniqueConstraints, variables));
     }
 
     /**

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ConstructionNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ConstructionNodeImpl.java
@@ -341,7 +341,7 @@ public class ConstructionNodeImpl extends ExtendedProjectionNodeImpl implements 
     private Stream<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>> newDependenciesFromSubstitution(VariableNullability nullability) {
         var variableToSubstitution = substitution.stream()
                 .filter(e -> isDeterministic(e.getValue()))
-                .map(e -> Map.entry(
+                .map(e -> Maps.immutableEntry(
                         e.getValue().getVariableStream().collect(ImmutableCollectors.toSet()),
                         ImmutableSet.of(e.getKey())
                 ))
@@ -349,7 +349,7 @@ public class ConstructionNodeImpl extends ExtendedProjectionNodeImpl implements 
         var substitutionToVariable = substitution.stream()
                 .filter(e -> e.getValue() instanceof ImmutableFunctionalTerm)
                 .filter(e -> isAtomicConstraint((ImmutableFunctionalTerm) e.getValue(), ((ImmutableFunctionalTerm) e.getValue()).getVariables(), nullability))
-                .map(e -> Map.entry(
+                .map(e -> Maps.immutableEntry(
                         ImmutableSet.of(e.getKey()),
                         e.getValue().getVariableStream().collect(ImmutableCollectors.toSet())
                 ))
@@ -358,7 +358,7 @@ public class ConstructionNodeImpl extends ExtendedProjectionNodeImpl implements 
                 .restrictRangeTo(Variable.class)
                 .build()
                 .stream()
-                .map(entry -> Map.entry(ImmutableSet.of(entry.getKey()), ImmutableSet.of(entry.getValue())));
+                .map(entry -> Maps.immutableEntry(ImmutableSet.of(entry.getKey()), ImmutableSet.of(entry.getValue())));
         return Streams.concat(variableToSubstitution, substitutionToVariable, renamingDependencies);
     }
 
@@ -381,7 +381,7 @@ public class ConstructionNodeImpl extends ExtendedProjectionNodeImpl implements 
         var allDeterminants = Streams.concat(preservedDeterminants, newDeterminants);
 
         return allDeterminants
-                .map(determinant -> Map.entry(determinant, Sets.difference(allDependents, determinant).immutableCopy()))
+                .map(determinant -> Maps.immutableEntry(determinant, Sets.difference(allDependents, determinant).immutableCopy()))
                 .filter(e -> !e.getValue().isEmpty());
     }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ConstructionNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ConstructionNodeImpl.java
@@ -326,12 +326,13 @@ public class ConstructionNodeImpl extends ExtendedProjectionNodeImpl implements 
     }
 
     @Override
-    public FunctionalDependencies inferFunctionalDependencies(IQTree child) {
+    public FunctionalDependencies inferFunctionalDependencies(IQTree child, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
         var childFDs = child.inferFunctionalDependencies();
         var nullability = getVariableNullability(child);
         return Stream.concat(childFDs.stream(), newDependenciesFromSubstitution(nullability))
                 .flatMap(e -> translateFunctionalDependency(e.getKey(), e.getValue(), child))
-                .collect(FunctionalDependencies.toFunctionalDependencies());
+                .collect(FunctionalDependencies.toFunctionalDependencies())
+                .concat(FunctionalDependencies.fromUniqueConstraints(uniqueConstraints, variables));
     }
 
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/DistinctNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/DistinctNodeImpl.java
@@ -10,6 +10,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.DistinctNormalizer;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -105,6 +106,11 @@ public class DistinctNodeImpl extends QueryModifierNodeImpl implements DistinctN
         return Sets.union(
                 child.inferUniqueConstraints(),
                 ImmutableSet.of(child.getVariables())).immutableCopy();
+    }
+
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies(IQTree child) {
+        return child.inferFunctionalDependencies();
     }
 
     /**

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/DistinctNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/DistinctNodeImpl.java
@@ -109,7 +109,7 @@ public class DistinctNodeImpl extends QueryModifierNodeImpl implements DistinctN
     }
 
     @Override
-    public FunctionalDependencies inferFunctionalDependencies(IQTree child) {
+    public FunctionalDependencies inferFunctionalDependencies(IQTree child, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
         return child.inferFunctionalDependencies();
     }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/EmptyNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/EmptyNodeImpl.java
@@ -8,6 +8,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -126,6 +127,11 @@ public class EmptyNodeImpl extends LeafIQTreeImpl implements EmptyNode {
     @Override
     public ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints() {
         return ImmutableSet.of();
+    }
+
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies() {
+        return FunctionalDependencies.empty();
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ExtensionalDataNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ExtensionalDataNodeImpl.java
@@ -252,7 +252,7 @@ public class ExtensionalDataNodeImpl extends LeafIQTreeImpl implements Extension
         if (!determinants.stream().allMatch(Optional::isPresent) || !dependents.stream().anyMatch(Optional::isPresent))
             return Optional.empty();
 
-        return Optional.of(Map.entry(
+        return Optional.of(Maps.immutableEntry(
                     determinants.stream()
                             .map(Optional::get)
                             .filter(t -> t instanceof Variable)

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ExtensionalDataNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ExtensionalDataNodeImpl.java
@@ -10,6 +10,7 @@ import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.*;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -228,6 +229,42 @@ public class ExtensionalDataNodeImpl extends LeafIQTreeImpl implements Extension
                 .filter(t -> t instanceof Variable)
                 .map(v -> (Variable)v)
                 .collect(ImmutableCollectors.toSet()));
+    }
+
+    @Override
+    public synchronized FunctionalDependencies inferFunctionalDependencies() {
+        return relationDefinition.getOtherFunctionalDependencies().stream()
+                .map(this::convertFunctionalDependency)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(FunctionalDependencies.toFunctionalDependencies());
+    }
+
+    private Optional<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>> convertFunctionalDependency(FunctionalDependency functionalDependency) {
+        ImmutableList<Optional<? extends VariableOrGroundTerm>> determinants = functionalDependency.getDeterminants().stream()
+                .map(a -> Optional.ofNullable(argumentMap.get(a.getIndex() - 1)))
+                .collect(ImmutableCollectors.toList());
+
+        ImmutableList<Optional<? extends VariableOrGroundTerm>> dependents = functionalDependency.getDependents().stream()
+                .map(a -> Optional.ofNullable(argumentMap.get(a.getIndex() - 1)))
+                .collect(ImmutableCollectors.toList());
+
+        if (!determinants.stream().allMatch(Optional::isPresent) || !dependents.stream().anyMatch(Optional::isPresent))
+            return Optional.empty();
+
+        return Optional.of(Map.entry(
+                    determinants.stream()
+                            .map(Optional::get)
+                            .filter(t -> t instanceof Variable)
+                            .map(v -> (Variable)v)
+                            .collect(ImmutableCollectors.toSet()),
+                    dependents.stream()
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .filter(t -> t instanceof Variable)
+                            .map(v -> (Variable)v)
+                            .collect(ImmutableCollectors.toSet())
+                ));
     }
 
     /**

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ExtensionalDataNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ExtensionalDataNodeImpl.java
@@ -237,7 +237,8 @@ public class ExtensionalDataNodeImpl extends LeafIQTreeImpl implements Extension
                 .map(this::convertFunctionalDependency)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .collect(FunctionalDependencies.toFunctionalDependencies());
+                .collect(FunctionalDependencies.toFunctionalDependencies())
+                .concat(FunctionalDependencies.fromUniqueConstraints(inferUniqueConstraints(), variables));
     }
 
     private Optional<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>> convertFunctionalDependency(FunctionalDependency functionalDependency) {

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FilterNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FilterNodeImpl.java
@@ -10,6 +10,7 @@ import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -170,6 +171,11 @@ public class FilterNodeImpl extends JoinOrFilterNodeImpl implements FilterNode {
     @Override
     public ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(IQTree child) {
         return child.inferUniqueConstraints();
+    }
+
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies(IQTree child) {
+        return child.inferFunctionalDependencies();
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FilterNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FilterNodeImpl.java
@@ -174,7 +174,7 @@ public class FilterNodeImpl extends JoinOrFilterNodeImpl implements FilterNode {
     }
 
     @Override
-    public FunctionalDependencies inferFunctionalDependencies(IQTree child) {
+    public FunctionalDependencies inferFunctionalDependencies(IQTree child, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
         return child.inferFunctionalDependencies();
     }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FlattenNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FlattenNodeImpl.java
@@ -2,6 +2,7 @@ package it.unibz.inf.ontop.iq.node.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
@@ -217,7 +218,7 @@ public class FlattenNodeImpl extends CompositeQueryNodeImpl implements FlattenNo
         //if FD A -> B exists, and B contains the flattened field, then there is a FD (A, index) -> output.
         return childFDs.stream()
                 .filter(fd -> fd.getValue().contains(flattenedVariable))
-                .map(fd -> Map.entry(Sets.union(fd.getKey(), ImmutableSet.of(index)).immutableCopy(), ImmutableSet.of(outputVariable)))
+                .map(fd -> Maps.immutableEntry(Sets.union(fd.getKey(), ImmutableSet.of(index)).immutableCopy(), ImmutableSet.of(outputVariable)))
                 .collect(FunctionalDependencies.toFunctionalDependencies())
                 .concat(childFDs);
     }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FlattenNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/FlattenNodeImpl.java
@@ -28,7 +28,6 @@ import it.unibz.inf.ontop.substitution.*;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import it.unibz.inf.ontop.utils.VariableGenerator;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -210,7 +209,7 @@ public class FlattenNodeImpl extends CompositeQueryNodeImpl implements FlattenNo
     }
 
     @Override
-    public FunctionalDependencies inferFunctionalDependencies(IQTree child) {
+    public FunctionalDependencies inferFunctionalDependencies(IQTree child, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
         var childFDs = child.inferFunctionalDependencies();
         if(indexVariable.isEmpty())
             return childFDs;
@@ -220,7 +219,8 @@ public class FlattenNodeImpl extends CompositeQueryNodeImpl implements FlattenNo
                 .filter(fd -> fd.getValue().contains(flattenedVariable))
                 .map(fd -> Maps.immutableEntry(Sets.union(fd.getKey(), ImmutableSet.of(index)).immutableCopy(), ImmutableSet.of(outputVariable)))
                 .collect(FunctionalDependencies.toFunctionalDependencies())
-                .concat(childFDs);
+                .concat(childFDs)
+                .concat(FunctionalDependencies.fromUniqueConstraints(uniqueConstraints, variables));
     }
 
     /**

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/InnerJoinNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/InnerJoinNodeImpl.java
@@ -342,7 +342,7 @@ public class InnerJoinNodeImpl extends JoinLikeNodeImpl implements InnerJoinNode
     We can simply collect all FDs from the children.
      */
     @Override
-    public FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children) {
+    public FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
         return children.stream()
                 .flatMap(child -> child.inferFunctionalDependencies().stream())
                 .collect(FunctionalDependencies.toFunctionalDependencies());

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/InnerJoinNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/InnerJoinNodeImpl.java
@@ -12,6 +12,7 @@ import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.ConditionSimplifier.ExpressionAndSubstitution;
 import it.unibz.inf.ontop.iq.node.normalization.ConditionSimplifier;
 import it.unibz.inf.ontop.iq.node.normalization.InnerJoinNormalizer;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -336,6 +337,17 @@ public class InnerJoinNodeImpl extends JoinLikeNodeImpl implements InnerJoinNode
                 .flatMap(child -> constraintMap.get(child).stream())
                 .collect(ImmutableCollectors.toSet());
     }
+
+    /*
+    We can simply collect all FDs from the children.
+     */
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children) {
+        return children.stream()
+                .flatMap(child -> child.inferFunctionalDependencies().stream())
+                .collect(FunctionalDependencies.toFunctionalDependencies());
+    }
+
 
     @Override
     public VariableNonRequirement computeVariableNonRequirement(ImmutableList<IQTree> children) {

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/IntensionalDataNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/IntensionalDataNodeImpl.java
@@ -8,6 +8,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -93,6 +94,11 @@ public class IntensionalDataNodeImpl extends DataNodeImpl<AtomPredicate> impleme
     @Override
     public ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints() {
         return ImmutableSet.of(getVariables());
+    }
+
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies() {
+        return FunctionalDependencies.empty();
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
@@ -410,7 +410,7 @@ public class LeftJoinNodeImpl extends JoinLikeNodeImpl implements LeftJoinNode {
     }
 
     @Override
-    public FunctionalDependencies inferFunctionalDependencies(IQTree leftChild, IQTree rightChild) {
+    public FunctionalDependencies inferFunctionalDependencies(IQTree leftChild, IQTree rightChild, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
         //TODO: Infer functional dependencies for the right child (we have to filter those from the right to not impact the left child)
         return leftChild.inferFunctionalDependencies();
     }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
@@ -411,7 +411,8 @@ public class LeftJoinNodeImpl extends JoinLikeNodeImpl implements LeftJoinNode {
 
     @Override
     public FunctionalDependencies inferFunctionalDependencies(IQTree leftChild, IQTree rightChild) {
-        return leftChild.inferFunctionalDependencies().concat(rightChild.inferFunctionalDependencies());
+        //TODO: Infer functional dependencies for the right child (we have to filter those from the right to not impact the left child)
+        return leftChild.inferFunctionalDependencies();
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
@@ -11,6 +11,7 @@ import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.LeftJoinNormalizer;
 import it.unibz.inf.ontop.iq.node.normalization.impl.ExpressionAndSubstitutionImpl;
 import it.unibz.inf.ontop.iq.node.normalization.ConditionSimplifier;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -406,6 +407,11 @@ public class LeftJoinNodeImpl extends JoinLikeNodeImpl implements LeftJoinNode {
             return ImmutableSet.of();
 
         return leftChildConstraints;
+    }
+
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies(IQTree leftChild, IQTree rightChild) {
+        return leftChild.inferFunctionalDependencies().concat(rightChild.inferFunctionalDependencies());
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/NativeNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/NativeNodeImpl.java
@@ -15,6 +15,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidQueryNodeException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -180,6 +181,14 @@ public class NativeNodeImpl extends LeafIQTreeImpl implements NativeNode {
     @Override
     public ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints() {
         return ImmutableSet.of();
+    }
+
+    /**
+     * Dummy implementation (considered too late for inferring it)
+     */
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies() {
+        return FunctionalDependencies.empty();
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/OrderByNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/OrderByNodeImpl.java
@@ -151,7 +151,7 @@ public class OrderByNodeImpl extends QueryModifierNodeImpl implements OrderByNod
     }
 
     @Override
-    public FunctionalDependencies inferFunctionalDependencies(IQTree child) {
+    public FunctionalDependencies inferFunctionalDependencies(IQTree child, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
         return child.inferFunctionalDependencies();
     }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/OrderByNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/OrderByNodeImpl.java
@@ -11,6 +11,7 @@ import it.unibz.inf.ontop.iq.IQTreeCache;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -147,6 +148,11 @@ public class OrderByNodeImpl extends QueryModifierNodeImpl implements OrderByNod
     @Override
     public ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(IQTree child) {
         return child.inferUniqueConstraints();
+    }
+
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies(IQTree child) {
+        return child.inferFunctionalDependencies();
     }
 
     /**

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/QueryNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/QueryNodeImpl.java
@@ -1,11 +1,7 @@
 package it.unibz.inf.ontop.iq.node.impl;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
-import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.node.*;
-import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.model.term.Variable;
 
 public abstract class QueryNodeImpl implements QueryNode {
@@ -28,18 +24,5 @@ public abstract class QueryNodeImpl implements QueryNode {
     @Override
     public boolean wouldKeepDescendingGroundTermInFilterAbove(Variable variable, boolean isConstant) {
         return false;
-    }
-
-    @Override
-    public FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
-        var fromUcs = FunctionalDependencies.fromUniqueConstraints(uniqueConstraints, variables);
-        if(this instanceof UnaryOperatorNode) {
-            return fromUcs.concat(((UnaryOperatorNode)this).inferFunctionalDependencies(children.get(0)));
-        } else if(this instanceof BinaryOrderedOperatorNode) {
-            return fromUcs.concat(((BinaryOrderedOperatorNode)this).inferFunctionalDependencies(children.get(0), children.get(1)));
-        } else if(this instanceof NaryOperatorNode) {
-            return fromUcs.concat(((NaryOperatorNode)this).inferFunctionalDependencies(children));
-        }
-        return fromUcs;
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/QueryNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/QueryNodeImpl.java
@@ -1,7 +1,11 @@
 package it.unibz.inf.ontop.iq.node.impl;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
-import it.unibz.inf.ontop.iq.node.QueryNode;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.model.term.Variable;
 
 public abstract class QueryNodeImpl implements QueryNode {
@@ -24,5 +28,18 @@ public abstract class QueryNodeImpl implements QueryNode {
     @Override
     public boolean wouldKeepDescendingGroundTermInFilterAbove(Variable variable, boolean isConstant) {
         return false;
+    }
+
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
+        var fromUcs = FunctionalDependencies.fromUniqueConstraints(uniqueConstraints, variables);
+        if(this instanceof UnaryOperatorNode) {
+            return fromUcs.concat(((UnaryOperatorNode)this).inferFunctionalDependencies(children.get(0)));
+        } else if(this instanceof BinaryOrderedOperatorNode) {
+            return fromUcs.concat(((BinaryOrderedOperatorNode)this).inferFunctionalDependencies(children.get(0), children.get(1)));
+        } else if(this instanceof NaryOperatorNode) {
+            return fromUcs.concat(((NaryOperatorNode)this).inferFunctionalDependencies(children));
+        }
+        return fromUcs;
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/SliceNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/SliceNodeImpl.java
@@ -10,6 +10,7 @@ import it.unibz.inf.ontop.iq.*;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -388,6 +389,11 @@ public class SliceNodeImpl extends QueryModifierNodeImpl implements SliceNode {
     @Override
     public ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints(IQTree child) {
         return child.inferUniqueConstraints();
+    }
+
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies(IQTree child) {
+        return child.inferFunctionalDependencies();
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/SliceNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/SliceNodeImpl.java
@@ -392,7 +392,7 @@ public class SliceNodeImpl extends QueryModifierNodeImpl implements SliceNode {
     }
 
     @Override
-    public FunctionalDependencies inferFunctionalDependencies(IQTree child) {
+    public FunctionalDependencies inferFunctionalDependencies(IQTree child, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
         return child.inferFunctionalDependencies();
     }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/TrueNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/TrueNodeImpl.java
@@ -7,6 +7,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -133,6 +134,11 @@ public class TrueNodeImpl extends LeafIQTreeImpl implements TrueNode {
     @Override
     public ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints() {
         return ImmutableSet.of();
+    }
+
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies() {
+        return FunctionalDependencies.empty();
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
@@ -421,7 +421,7 @@ public class UnionNodeImpl extends CompositeQueryNodeImpl implements UnionNode {
                     fd.getKey().stream(),
                     Stream.of(v)).collect(ImmutableCollectors.toSet()
                 ),
-                fd.getValue()
+                Sets.difference(fd.getValue(), ImmutableSet.of(v)).immutableCopy()
         );
     }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
@@ -3,7 +3,6 @@ package it.unibz.inf.ontop.iq.node.impl;
 import com.google.common.collect.*;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
-import it.unibz.inf.ontop.dbschema.UniqueConstraint;
 import it.unibz.inf.ontop.exception.MinorOntopInternalBugException;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
@@ -27,7 +26,6 @@ import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import it.unibz.inf.ontop.utils.VariableGenerator;
 
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -383,7 +381,7 @@ public class UnionNodeImpl extends CompositeQueryNodeImpl implements UnionNode {
     }
 
     @Override
-    public FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children) {
+    public FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
         int childrenCount = children.size();
         if (childrenCount < 2)
             throw new InvalidIntermediateQueryException("At least 2 children are expected for a union");

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
@@ -12,6 +12,7 @@ import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.NotRequiredVariableRemover;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -379,6 +380,49 @@ public class UnionNodeImpl extends CompositeQueryNodeImpl implements UnionNode {
                         .flatMap(uc -> disjointVariables.stream()
                                         .map(v -> appendVariable(uc, v)))
                 ).collect(ImmutableCollectors.toSet());
+    }
+
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies(ImmutableList<IQTree> children) {
+        int childrenCount = children.size();
+        if (childrenCount < 2)
+            throw new InvalidIntermediateQueryException("At least 2 children are expected for a union");
+
+        IQTree firstChild = children.get(0);
+        // Partitions the fds based on if they are fully disjoint or not. Guaranteed to have two entries: true and false (but they may be empty)
+        ImmutableMap<Boolean, ImmutableList<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>>> fdsPartitionedByDisjointness = firstChild.inferFunctionalDependencies().stream()
+                .filter(fd -> children.stream()
+                        .skip(1)
+                        .allMatch(c -> c.inferFunctionalDependencies().contains(fd.getKey(), fd.getValue())))
+                .collect(ImmutableCollectors.partitioningBy(uc -> areDisjoint(children, uc.getKey())));
+
+        if(fdsPartitionedByDisjointness.get(false).isEmpty())
+            return fdsPartitionedByDisjointness.get(true)
+                    .stream()
+                    .collect(FunctionalDependencies.toFunctionalDependencies());
+
+        // By definition not parts of the non-disjoint UCs
+        var disjointVariables = firstChild.getVariables().stream()
+                .filter(v -> areDisjoint(children, ImmutableSet.of(v)))
+                .filter(v -> fdsPartitionedByDisjointness.get(true).stream().noneMatch(entry -> entry.getKey().size() == 1 && entry.getKey().stream().findFirst().get().equals(v)))
+                .collect(ImmutableCollectors.toSet());
+
+        return Stream.concat(
+                fdsPartitionedByDisjointness.get(true).stream(),
+                fdsPartitionedByDisjointness.get(false).stream()
+                        .flatMap(fd -> disjointVariables.stream()
+                                .map(v -> appendDeterminant(fd, v)))
+        ).collect(FunctionalDependencies.toFunctionalDependencies());
+    }
+
+    private Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>> appendDeterminant(Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>> fd, Variable v) {
+        return Map.entry(
+                Stream.concat(
+                    fd.getKey().stream(),
+                    Stream.of(v)).collect(ImmutableCollectors.toSet()
+                ),
+                fd.getValue()
+        );
     }
 
     private ImmutableSet<Variable> appendVariable(ImmutableSet<Variable> uc, Variable v) {

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/UnionNodeImpl.java
@@ -416,7 +416,7 @@ public class UnionNodeImpl extends CompositeQueryNodeImpl implements UnionNode {
     }
 
     private Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>> appendDeterminant(Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>> fd, Variable v) {
-        return Map.entry(
+        return Maps.immutableEntry(
                 Stream.concat(
                     fd.getKey().stream(),
                     Stream.of(v)).collect(ImmutableCollectors.toSet()

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ValuesNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ValuesNodeImpl.java
@@ -13,6 +13,7 @@ import it.unibz.inf.ontop.iq.exception.InvalidIntermediateQueryException;
 import it.unibz.inf.ontop.iq.exception.QueryNodeTransformationException;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.request.VariableNonRequirement;
 import it.unibz.inf.ontop.iq.transform.IQTreeExtendedTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
@@ -438,6 +439,12 @@ public class ValuesNodeImpl extends LeafIQTreeImpl implements ValuesNode {
     public ImmutableSet<ImmutableSet<Variable>> inferUniqueConstraints() {
         // TODO: Worth implementing?
         return ImmutableSet.of();
+    }
+
+    @Override
+    public FunctionalDependencies inferFunctionalDependencies() {
+        // TODO: Worth implementing?
+        return FunctionalDependencies.empty();
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/FunctionalDependencies.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/FunctionalDependencies.java
@@ -1,13 +1,16 @@
 package it.unibz.inf.ontop.iq.request;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 import it.unibz.inf.ontop.iq.request.impl.FunctionalDependenciesImpl;
 import it.unibz.inf.ontop.model.term.Variable;
 import it.unibz.inf.ontop.substitution.InjectiveSubstitution;
 import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
 
 import java.util.Map;
 import java.util.stream.Collector;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public interface FunctionalDependencies {
@@ -21,8 +24,18 @@ public interface FunctionalDependencies {
 
     boolean contains(ImmutableSet<Variable> determinants, ImmutableSet<Variable> dependents);
 
-    static FunctionalDependencies of(ImmutableSet<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>> dependencies) {
-        return new FunctionalDependenciesImpl(dependencies);
+    static FunctionalDependencies of(ImmutableSet<Variable>... dependencies) {
+        if(dependencies.length % 2 != 0)
+            throw new IllegalArgumentException("FunctionalDependency must be built of 2n ImmutableSets.");
+        var determinants = IntStream.range(0, dependencies.length)
+                .filter(i -> i % 2 == 0)
+                .mapToObj(i -> dependencies[i]);
+        var dependents = IntStream.range(0, dependencies.length)
+                .filter(i -> i % 2 == 1)
+                .mapToObj(i -> dependencies[i]);
+        return new FunctionalDependenciesImpl(Streams.zip(determinants, dependents, (a, b) -> Map.entry(a, b))
+                .collect(ImmutableCollectors.toSet())
+            );
     }
 
     static FunctionalDependencies empty() {

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/FunctionalDependencies.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/FunctionalDependencies.java
@@ -1,6 +1,8 @@
 package it.unibz.inf.ontop.iq.request;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import it.unibz.inf.ontop.iq.request.impl.FunctionalDependenciesImpl;
 import it.unibz.inf.ontop.model.term.Variable;
@@ -33,7 +35,7 @@ public interface FunctionalDependencies {
         var dependents = IntStream.range(0, dependencies.length)
                 .filter(i -> i % 2 == 1)
                 .mapToObj(i -> dependencies[i]);
-        return new FunctionalDependenciesImpl(Streams.zip(determinants, dependents, (a, b) -> Map.entry(a, b))
+        return new FunctionalDependenciesImpl(Streams.zip(determinants, dependents, (a, b) -> Maps.immutableEntry(a, b))
                 .collect(ImmutableCollectors.toSet())
             );
     }
@@ -44,6 +46,13 @@ public interface FunctionalDependencies {
 
     static Collector<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>, ?, FunctionalDependencies> toFunctionalDependencies() {
         return FunctionalDependenciesImpl.getCollector();
+    }
+
+    static FunctionalDependencies fromUniqueConstraints(ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> allVariables) {
+        return uniqueConstraints.stream()
+                .map(uc -> Maps.immutableEntry(uc, Sets.difference(allVariables, uc).immutableCopy()))
+                .filter(fd -> !fd.getValue().isEmpty())
+                .collect(FunctionalDependencies.toFunctionalDependencies());
     }
 
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/FunctionalDependencies.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/FunctionalDependencies.java
@@ -1,0 +1,36 @@
+package it.unibz.inf.ontop.iq.request;
+
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.iq.request.impl.FunctionalDependenciesImpl;
+import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.substitution.InjectiveSubstitution;
+import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+
+import java.util.Map;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+
+public interface FunctionalDependencies {
+
+    boolean isEmpty();
+
+    Stream<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>> stream();
+
+    FunctionalDependencies rename(InjectiveSubstitution<Variable> renamingSubstitution, SubstitutionFactory substitutionFactory);
+    FunctionalDependencies concat(FunctionalDependencies other);
+
+    boolean contains(ImmutableSet<Variable> determinants, ImmutableSet<Variable> dependents);
+
+    static FunctionalDependencies of(ImmutableSet<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>> dependencies) {
+        return new FunctionalDependenciesImpl(dependencies);
+    }
+
+    static FunctionalDependencies empty() {
+        return new FunctionalDependenciesImpl(ImmutableSet.of());
+    }
+
+    static Collector<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>, ?, FunctionalDependencies> toFunctionalDependencies() {
+        return FunctionalDependenciesImpl.getCollector();
+    }
+
+}

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/FunctionalDependenciesImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/FunctionalDependenciesImpl.java
@@ -1,0 +1,138 @@
+package it.unibz.inf.ontop.iq.request.impl;
+
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
+import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.substitution.InjectiveSubstitution;
+import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.*;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+
+public class FunctionalDependenciesImpl implements FunctionalDependencies {
+
+    private final ImmutableSet<FunctionalDependency>  dependencies;
+
+
+    public FunctionalDependenciesImpl(ImmutableSet<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>> dependencies) {
+        this.dependencies = dependencies.stream()
+                .map(e -> new FunctionalDependency(e.getKey(), e.getValue()))
+                .collect(ImmutableCollectors.toSet());
+    }
+
+    @Override
+    public Stream<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>> stream() {
+        return dependencies.stream()
+                .map(fd -> Map.entry(fd.determinants, fd.dependents));
+    }
+
+    @Override
+    public FunctionalDependencies rename(InjectiveSubstitution<Variable> renamingSubstitution, SubstitutionFactory substitutionFactory) {
+        return new FunctionalDependenciesImpl(dependencies.stream()
+                .map(fd -> fd.rename(renamingSubstitution, substitutionFactory))
+                .map(fd -> Map.entry(fd.determinants, fd.dependents))
+                .collect(ImmutableCollectors.toSet())
+        );
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return dependencies.isEmpty();
+    }
+
+    @Override
+    public FunctionalDependencies concat(FunctionalDependencies other) {
+        return new FunctionalDependenciesImpl(
+                Stream.concat(stream(), other.stream())
+                        .collect(ImmutableCollectors.toSet())
+        );
+    }
+
+    @Override
+    public boolean contains(ImmutableSet<Variable> determinants, ImmutableSet<Variable> dependents) {
+        return dependencies.stream()
+                .anyMatch(dp -> determinants.containsAll(dp.determinants) && dp.dependents.containsAll(dependents));
+    }
+
+    public static Collector<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>, ?, FunctionalDependencies> getCollector() {
+        return new FunctionalDependenciesCollector();
+    }
+
+    private static class FunctionalDependency {
+        private final ImmutableSet<Variable> determinants;
+        private final ImmutableSet<Variable> dependents;
+
+        public FunctionalDependency(ImmutableSet<Variable> determinants, ImmutableSet<Variable> dependents) {
+            this.determinants = determinants;
+            this.dependents = dependents;
+        }
+
+        public ImmutableSet<Variable> getDeterminants() {
+            return determinants;
+        }
+
+        public ImmutableSet<Variable> getDependents() {
+            return dependents;
+        }
+
+        @Override
+        public int hashCode() {
+            return determinants.hashCode() ^ dependents.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if(!(obj instanceof FunctionalDependency))
+                return false;
+            FunctionalDependency other = (FunctionalDependency) obj;
+            return dependents.equals(other.dependents) && determinants.equals(other.determinants);
+        }
+
+        private FunctionalDependency rename(InjectiveSubstitution<Variable> renamingSubstitution, SubstitutionFactory substitutionFactory) {
+            return new FunctionalDependency(
+                    determinants.stream()
+                            .map(vars -> substitutionFactory.apply(renamingSubstitution, vars))
+                            .collect(ImmutableCollectors.toSet()),
+                    dependents.stream()
+                            .map(vars -> substitutionFactory.apply(renamingSubstitution, vars))
+                            .collect(ImmutableCollectors.toSet())
+            );
+        }
+    }
+
+    protected static class FunctionalDependenciesCollector implements Collector<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>, ImmutableSet.Builder<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>>, FunctionalDependencies> {
+
+
+        @Override
+        public Supplier<ImmutableSet.Builder<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>>> supplier() {
+            return ImmutableSet::builder;
+        }
+
+        @Override
+        public BiConsumer<ImmutableSet.Builder<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>>, Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>> accumulator() {
+            return (builder, fd) -> builder.add(fd);
+        }
+
+        @Override
+        public BinaryOperator<ImmutableSet.Builder<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>>> combiner() {
+            return (builder1, builder2) -> {
+                builder1.addAll(builder2.build());
+                return builder1;
+            };
+        }
+
+        @Override
+        public Function<ImmutableSet.Builder<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>>, FunctionalDependencies> finisher() {
+            return builder -> new FunctionalDependenciesImpl(builder.build());
+        }
+
+        @Override
+        public Set<Characteristics> characteristics() {
+            return Set.of(Characteristics.UNORDERED);
+        }
+    }
+}

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/FunctionalDependenciesImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/FunctionalDependenciesImpl.java
@@ -1,6 +1,7 @@
 package it.unibz.inf.ontop.iq.request.impl;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
@@ -30,21 +31,21 @@ public class FunctionalDependenciesImpl implements FunctionalDependencies {
         return dependencies.stream()
                 .flatMap(entry -> dependencies.stream()
                         .filter(entry2 -> Sets.union(entry2.getValue(), entry2.getKey()).containsAll(entry.getKey()))
-                        .map(entry2 -> Map.entry(entry2.getKey(), Sets.difference(entry.getValue(), entry2.getKey()).immutableCopy()))
+                        .map(entry2 -> Maps.immutableEntry(entry2.getKey(), Sets.difference(entry.getValue(), entry2.getKey()).immutableCopy()))
                 );
     }
 
     @Override
     public Stream<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>> stream() {
         return dependencies.stream()
-                .map(fd -> Map.entry(fd.determinants, fd.dependents));
+                .map(fd -> Maps.immutableEntry(fd.determinants, fd.dependents));
     }
 
     @Override
     public FunctionalDependencies rename(InjectiveSubstitution<Variable> renamingSubstitution, SubstitutionFactory substitutionFactory) {
         return new FunctionalDependenciesImpl(dependencies.stream()
                 .map(fd -> fd.rename(renamingSubstitution, substitutionFactory))
-                .map(fd -> Map.entry(fd.determinants, fd.dependents))
+                .map(fd -> Maps.immutableEntry(fd.determinants, fd.dependents))
                 .collect(ImmutableCollectors.toSet())
         ).complete();
     }
@@ -115,7 +116,7 @@ public class FunctionalDependenciesImpl implements FunctionalDependencies {
                 .filter(fd -> !fd.dependents.isEmpty())
                 .collect(ImmutableCollectors.toSet());
         return new FunctionalDependenciesImpl(packedDependencies.stream()
-                .map(fd -> Map.entry(fd.determinants, fd.dependents))
+                .map(fd -> Maps.immutableEntry(fd.determinants, fd.dependents))
                 .collect(ImmutableCollectors.toSet()));
     }
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/DependencyTestDBMetadata.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/DependencyTestDBMetadata.java
@@ -28,6 +28,9 @@ public class DependencyTestDBMetadata {
 
     public static final RelationDefinition PK_TABLE7_AR4;
 
+    public static final RelationDefinition FD_TABLE1_AR2;
+    public static final RelationDefinition FD_TABLE2_AR2;
+
     static {
         OptimizationTestingTools.OfflineMetadataProviderBuilder3 builder = createMetadataProviderBuilder();
         PK_TABLE1_AR1 = builder.createRelationWithPK(1, 1);
@@ -51,5 +54,8 @@ public class DependencyTestDBMetadata {
         PK_TABLE6_AR3 = builder.createRelationWithPK(6, 3);
 
         PK_TABLE7_AR4 = builder.createRelationWithPK(7, 4);
+
+        FD_TABLE1_AR2 = builder.createRelationWithFD(1, 2, false);
+        FD_TABLE2_AR2 = builder.createRelationWithFD(2, 2, false);
     }
 }

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/OptimizationTestingTools.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/OptimizationTestingTools.java
@@ -2,6 +2,8 @@ package it.unibz.inf.ontop;
 
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
 import it.unibz.inf.ontop.dbschema.*;
 import it.unibz.inf.ontop.dbschema.impl.DatabaseTableDefinition;
@@ -24,6 +26,7 @@ import it.unibz.inf.ontop.utils.VariableGenerator;
 import it.unibz.inf.ontop.utils.impl.LegacyVariableGenerator;
 import org.apache.commons.rdf.api.RDF;
 
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.IntStream;
 
@@ -230,6 +233,16 @@ public class OptimizationTestingTools {
             UniqueConstraint.builder(tableDef, "uc_" + tableNumber)
                     .addDeterminant(1)
                     .build();
+            return tableDef;
+        }
+
+        public NamedRelationDefinition createRelationWithFD(int tableNumber, int arity, boolean canNull) {
+            DBTermType stringDBType = getDBTypeFactory().getDBStringType();
+            NamedRelationDefinition tableDef = createRelation(tableNumber, arity, stringDBType, "FD_", canNull);
+            FunctionalDependency.defaultBuilder(tableDef)
+                            .addDeterminant(1)
+                            .addDependent(2)
+                            .build();
             return tableDef;
         }
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/FunctionalDependencyInferenceTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/FunctionalDependencyInferenceTest.java
@@ -1,0 +1,333 @@
+package it.unibz.inf.ontop.iq.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.dbschema.NamedRelationDefinition;
+import it.unibz.inf.ontop.dbschema.UniqueConstraint;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.node.ExtensionalDataNode;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
+import it.unibz.inf.ontop.model.template.Template;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import static it.unibz.inf.ontop.DependencyTestDBMetadata.*;
+import static it.unibz.inf.ontop.OptimizationTestingTools.*;
+import static junit.framework.TestCase.assertEquals;
+
+public class FunctionalDependencyInferenceTest {
+
+    private final ImmutableList<Template.Component> URI_TEMPLATE_INJECTIVE_2 = Template.of("http://example.org/ds1/", 0, "/", 1);
+
+    private final ImmutableList<Template.Component> URI_TEMPLATE_INJECTIVE_2_1 = Template.of("http://example.org/ds3/", 0, "/", 1);
+
+    private final ExtensionalDataNode DATA_NODE_1 = createExtensionalDataNode(PK_TABLE1_AR2, ImmutableList.of(A, B));
+    private final ExtensionalDataNode DATA_NODE_1_WITH_ADDED_FD = createExtensionalDataNode(FD_TABLE1_AR2 , ImmutableList.of(A, B));
+    private final ExtensionalDataNode DATA_NODE_2_WITH_ADDED_FD = createExtensionalDataNode(FD_TABLE2_AR2 , ImmutableList.of(C, D));
+    private final ExtensionalDataNode DATA_NODE_2 = createExtensionalDataNode(PK_TABLE1_AR3, ImmutableList.of(A, B, C));
+
+    private static final NamedRelationDefinition COMPOSITE_PK_REL;
+
+    static {
+        OfflineMetadataProviderBuilder3 builder = createMetadataProviderBuilder();
+        COMPOSITE_PK_REL = builder.createRelation("table", 2, TYPE_FACTORY.getDBTypeFactory().getDBStringType(), false);
+        UniqueConstraint.primaryKeyOf(COMPOSITE_PK_REL.getAttribute(1), COMPOSITE_PK_REL.getAttribute(2));
+    }
+
+
+
+
+    @Test
+    public void testConstructionOneVariable() {
+
+        IQTree tree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(X, B),
+                        SUBSTITUTION_FACTORY.getSubstitution(X, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(A, B)))),
+                DATA_NODE_1);
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(X), ImmutableSet.of(B)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testConstructionMultipleUCs() {
+
+        IQTree tree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(X, A, B),
+                        SUBSTITUTION_FACTORY.getSubstitution(X, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(A, B)))),
+                DATA_NODE_1);
+        assertEquals(FunctionalDependencies.of(
+                ImmutableSet.of(X), ImmutableSet.of(A, B),
+                ImmutableSet.of(A), ImmutableSet.of(X, B)
+        ), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testConstructionInferFromUCs() {
+
+        IQTree tree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(X),
+                        SUBSTITUTION_FACTORY.getSubstitution(X, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(A, B)))),
+                DATA_NODE_1);
+        assertEquals(FunctionalDependencies.of(), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testConstructionInferFromDirectSubstitution() {
+        IQTree tree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(X, B),
+                        SUBSTITUTION_FACTORY.getSubstitution(X, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(A, B)))),
+                DATA_NODE_1_WITH_ADDED_FD);
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(X), ImmutableSet.of(B)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testConstructionInferFromSubstitutionOnDeterminantAndDependent() {
+        IQTree tree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(X, Y),
+                        SUBSTITUTION_FACTORY.getSubstitution(
+                                X, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(A, B)),
+                                Y, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(B, B))
+                        )),
+                DATA_NODE_1_WITH_ADDED_FD);
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(X), ImmutableSet.of(Y)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testConstructionInferFromSubstitutionWithNonDeterministicDependent() {
+        IQTree tree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(X, Y),
+                        SUBSTITUTION_FACTORY.getSubstitution(
+                                X, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(A, B)),
+                                Y, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(B, TERM_FACTORY.getDBRand(UUID.randomUUID())))
+                        )),
+                DATA_NODE_1_WITH_ADDED_FD);
+        assertEquals(FunctionalDependencies.empty(), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testConstructionInferFromDirectSubstitutionWithMultipleDependents() {
+        IQTree tree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(X, Y, Z),
+                        SUBSTITUTION_FACTORY.getSubstitution(
+                                X, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(A, B)),
+                                Y, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(B, B)),
+                                Z, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(B, B))
+                        )),
+                DATA_NODE_1_WITH_ADDED_FD);
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(X), ImmutableSet.of(Y, Z), ImmutableSet.of(Z), ImmutableSet.of(Y), ImmutableSet.of(Y), ImmutableSet.of(Z)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testConstructionInferFromDirectSubstitutionWithMultipleDeterminants() {
+        IQTree tree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(X, Y, Z),
+                        SUBSTITUTION_FACTORY.getSubstitution(
+                                X, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(A, B)),
+                                Y, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(A, B)),
+                                Z, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(B, B))
+                        )),
+                DATA_NODE_1_WITH_ADDED_FD);
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(X), ImmutableSet.of(Z, Y), ImmutableSet.of(Y), ImmutableSet.of(Z, X)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testConstructionInferNewFromDirectSubstitution() {
+        IQTree tree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(X, Y, A, B),
+                        SUBSTITUTION_FACTORY.getSubstitution(
+                                X, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(B, B)),
+                                Y, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(A, B))
+                        )),
+                DATA_NODE_1_WITH_ADDED_FD);
+        assertEquals(FunctionalDependencies.of(
+                ImmutableSet.of(A), ImmutableSet.of(B, X, Y),
+                ImmutableSet.of(B), ImmutableSet.of(X),
+                ImmutableSet.of(Y), ImmutableSet.of(B, X, A),
+                ImmutableSet.of(X), ImmutableSet.of(B)
+        ), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testConstructionInferNewFromDirectSubstitutionWithHiddenVariable() {
+        IQTree tree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(X, Y, B),
+                        SUBSTITUTION_FACTORY.getSubstitution(
+                                X, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(B, B)),
+                                Y, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(A, B))
+                        )),
+                DATA_NODE_1_WITH_ADDED_FD);
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(B), ImmutableSet.of(X), ImmutableSet.of(Y), ImmutableSet.of(X, B), ImmutableSet.of(X), ImmutableSet.of(B)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testConstructionInferFromDirectSubstitutionNonInjective() {
+        IQTree tree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(X, B),
+                        SUBSTITUTION_FACTORY.getSubstitution(X, TERM_FACTORY.getDBLower(A))),
+                DATA_NODE_1_WITH_ADDED_FD);
+        assertEquals(FunctionalDependencies.empty(), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testConstructionInferFromDirectSubstitutionTransitive() {
+        IQTree tree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(X, A),
+                        SUBSTITUTION_FACTORY.getSubstitution(X, TERM_FACTORY.getIRIFunctionalTerm(URI_TEMPLATE_INJECTIVE_2, ImmutableList.of(B, B)))),
+                DATA_NODE_1_WITH_ADDED_FD);
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(X)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testUnionNoProvenance() {
+        IQTree tree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createUnionNode(ImmutableSet.of(A, B)),
+                ImmutableList.of(DATA_NODE_1_WITH_ADDED_FD, DATA_NODE_1_WITH_ADDED_FD));
+        assertEquals(FunctionalDependencies.empty(), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testUnionWithProvenance() {
+        ImmutableList<IQTree> children = IntStream.range(0, 5)
+                .mapToObj(i -> IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(
+                                ImmutableSet.of(A, B, X),
+                                SUBSTITUTION_FACTORY.getSubstitution(X, TERM_FACTORY.getDBConstant(i + "", TYPE_FACTORY.getDBTypeFactory().getDBStringType()))),
+                        DATA_NODE_1_WITH_ADDED_FD))
+                .collect(ImmutableCollectors.toList());
+        IQTree tree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createUnionNode(ImmutableSet.of(A, B, X)),
+                children);
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A, X), ImmutableSet.of(B)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testUnionWithMultipleProvenances() {
+        ImmutableList<IQTree> children = IntStream.range(0, 2)
+                .mapToObj(i -> IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(
+                                ImmutableSet.of(A, B, X, Y),
+                                SUBSTITUTION_FACTORY.getSubstitution(
+                                        X, TERM_FACTORY.getDBConstant(i + "", TYPE_FACTORY.getDBTypeFactory().getDBStringType()),
+                                        Y, TERM_FACTORY.getDBConstant(i + "!", TYPE_FACTORY.getDBTypeFactory().getDBStringType())
+                                )),
+                        DATA_NODE_1_WITH_ADDED_FD))
+                .collect(ImmutableCollectors.toList());
+        IQTree tree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createUnionNode(ImmutableSet.of(A, B, X, Y)),
+                children);
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A, X), ImmutableSet.of(B, Y), ImmutableSet.of(A, Y), ImmutableSet.of(B, X)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testUnionWithDisjointDeterminants() {
+        ImmutableList<IQTree> children = IntStream.range(0, 2)
+                .mapToObj(i -> IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(
+                                ImmutableSet.of(A, B, X),
+                                SUBSTITUTION_FACTORY.getSubstitution(
+                                        X, TERM_FACTORY.getIRIFunctionalTerm(i == 0 ? URI_TEMPLATE_INJECTIVE_2 : URI_TEMPLATE_INJECTIVE_2_1, ImmutableList.of(A, A))
+                                )),
+                        DATA_NODE_1_WITH_ADDED_FD))
+                .collect(ImmutableCollectors.toList());
+        IQTree tree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createUnionNode(ImmutableSet.of(A, B, X)),
+                children);
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(X), ImmutableSet.of(B, A)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testLeftJoinFromChildren() {
+        ImmutableList<IQTree> children = ImmutableList.of(
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(
+                                ImmutableSet.of(A, B),
+                                SUBSTITUTION_FACTORY.getSubstitution()),
+                        DATA_NODE_1_WITH_ADDED_FD),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(
+                                ImmutableSet.of(C, D),
+                                SUBSTITUTION_FACTORY.getSubstitution()),
+                        DATA_NODE_2_WITH_ADDED_FD));
+        IQTree tree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                children.get(0),
+                children.get(1)
+        );
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(B), ImmutableSet.of(C), ImmutableSet.of(D)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testLeftJoinCrossInfer() {
+        ImmutableList<IQTree> children = ImmutableList.of(
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(
+                                ImmutableSet.of(A, B),
+                                SUBSTITUTION_FACTORY.getSubstitution()),
+                        DATA_NODE_1_WITH_ADDED_FD),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(
+                                ImmutableSet.of(C, D),
+                                SUBSTITUTION_FACTORY.getSubstitution()),
+                        DATA_NODE_2_WITH_ADDED_FD));
+        IQTree tree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getStrictEquality(A, C)),
+                children.get(0),
+                children.get(1)
+        );
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(B, D, C)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testInnerJoinFromChildren() {
+        ImmutableList<IQTree> children = ImmutableList.of(
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(
+                                ImmutableSet.of(A, B),
+                                SUBSTITUTION_FACTORY.getSubstitution()),
+                        DATA_NODE_1_WITH_ADDED_FD),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(
+                                ImmutableSet.of(C, D),
+                                SUBSTITUTION_FACTORY.getSubstitution()),
+                        DATA_NODE_2_WITH_ADDED_FD));
+        IQTree tree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createInnerJoinNode(),
+                ImmutableList.of(children.get(0), children.get(1))
+        );
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(B), ImmutableSet.of(C), ImmutableSet.of(D)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testInnerJoinCrossInfer() {
+        ImmutableList<IQTree> children = ImmutableList.of(
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(
+                                ImmutableSet.of(A, B),
+                                SUBSTITUTION_FACTORY.getSubstitution()),
+                        DATA_NODE_1_WITH_ADDED_FD),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(
+                                ImmutableSet.of(C, D),
+                                SUBSTITUTION_FACTORY.getSubstitution()),
+                        DATA_NODE_2_WITH_ADDED_FD));
+        IQTree tree = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createInnerJoinNode(TERM_FACTORY.getStrictEquality(A, C)),
+                ImmutableList.of(children.get(0), children.get(1))
+        );
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(B, D, C), ImmutableSet.of(C), ImmutableSet.of(B, D, A)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+}

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/FunctionalDependencyInferenceTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/FunctionalDependencyInferenceTest.java
@@ -267,7 +267,7 @@ public class FunctionalDependencyInferenceTest {
                 children.get(0),
                 children.get(1)
         );
-        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(B), ImmutableSet.of(C), ImmutableSet.of(D)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(B)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
     }
 
     @Test
@@ -288,7 +288,7 @@ public class FunctionalDependencyInferenceTest {
                 children.get(0),
                 children.get(1)
         );
-        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(B, D, C)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(B), ImmutableSet.of(D, A), ImmutableSet.of(C)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
     }
 
     @Test


### PR DESCRIPTION
Implemented a basic structure for the inference of functional dependencies on the IQTree.

The IQTree now provides the method `inferFunctionalDependencies()` to get a list of possible functional dependencies. It is not guaranteed to find all of them, but all dependencies found are guaranteed to be correct.

Some improvements can still be made, in particular in the context of the LeftJoin node, which currently only infers FDs from the left child.

At this point, the `inferFunctionalDependencies()` method is not called from anywhere. This may change in the future when we require its functionality.