### PR TITLE
Implemented normalizer for SQLServer that adds an order by clause inside slices

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SQLServerExtraNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SQLServerExtraNormalizer.java
@@ -13,21 +13,26 @@ public class SQLServerExtraNormalizer implements DialectExtraNormalizer {
     private final DialectExtraNormalizer projectOrderByTermsNormalizer;
     private final DialectExtraNormalizer projectionWrapper;
     private final DialectExtraNormalizer limitOffsetOldVersionNormalizer;
+    private final DialectExtraNormalizer insertOrderByInSlizeNormalizer;
 
     @Inject
     protected SQLServerExtraNormalizer(AlwaysProjectOrderByTermsNormalizer projectOrderByTermsNormalizer,
                                        WrapProjectedOrOrderByExpressionNormalizer projectionWrapper,
-                                       SQLServerLimitOffsetOldVersionNormalizer limitOffsetOldVersionNormalizer) {
+                                       SQLServerLimitOffsetOldVersionNormalizer limitOffsetOldVersionNormalizer,
+                                       SQLServerInsertOrderByInSliceNormalizer insertOrderByInSlizeNormalizer) {
         this.projectOrderByTermsNormalizer = projectOrderByTermsNormalizer;
         this.projectionWrapper = projectionWrapper;
         this.limitOffsetOldVersionNormalizer = limitOffsetOldVersionNormalizer;
+        this.insertOrderByInSlizeNormalizer = insertOrderByInSlizeNormalizer;
     }
 
     @Override
     public IQTree transform(IQTree tree, VariableGenerator variableGenerator) {
-        return limitOffsetOldVersionNormalizer.transform(
-                projectOrderByTermsNormalizer.transform(
-                projectionWrapper.transform(tree, variableGenerator),
-                variableGenerator),variableGenerator);
+        return insertOrderByInSlizeNormalizer.transform(
+                limitOffsetOldVersionNormalizer.transform(
+                    projectOrderByTermsNormalizer.transform(
+                        projectionWrapper.transform(tree, variableGenerator),
+                    variableGenerator), variableGenerator),
+                variableGenerator);
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SQLServerInsertOrderByInSliceNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SQLServerInsertOrderByInSliceNormalizer.java
@@ -1,0 +1,80 @@
+package it.unibz.inf.ontop.generation.normalization.impl;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import it.unibz.inf.ontop.generation.normalization.DialectExtraNormalizer;
+import it.unibz.inf.ontop.injection.CoreSingletons;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeExtendedTransformer;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+public class SQLServerInsertOrderByInSliceNormalizer extends DefaultRecursiveIQTreeExtendedTransformer<VariableGenerator>
+        implements DialectExtraNormalizer {
+
+    private final IntermediateQueryFactory iqFactory;
+    private final SubstitutionFactory substitutionFactory;
+    private final TermFactory termFactory;
+
+    @Inject
+    protected SQLServerInsertOrderByInSliceNormalizer(IntermediateQueryFactory iqFactory, TermFactory termFactory,
+                                                      SubstitutionFactory substitutionFactory, CoreSingletons coreSingletons) {
+        super(coreSingletons);
+        this.iqFactory = iqFactory;
+        this.substitutionFactory = substitutionFactory;
+        this.termFactory = termFactory;
+    }
+
+    @Override
+    public IQTree transform(IQTree tree, VariableGenerator context) {
+        return super.transform(tree, context);
+    }
+
+    private boolean isOrderByPresent(IQTree child) {
+        if(child instanceof OrderByNode)
+            return true;
+        if(child instanceof DistinctNode) {
+            var grandchild = child.getChildren().get(0);
+            if(grandchild instanceof OrderByNode)
+                return true;
+        }
+        return false;
+    }
+
+    @Override
+    public IQTree transformSlice(IQTree tree, SliceNode sliceNode, IQTree child, VariableGenerator context) {
+        if(isOrderByPresent(child)) {
+            return iqFactory.createUnaryIQTree(
+                    sliceNode,
+                    transform(child, context)
+            );
+        }
+        var topConstruct = iqFactory.createConstructionNode(tree.getVariables(), substitutionFactory.getSubstitution());
+        var sortVariable = context.generateNewVariable("slice_sort_column");
+        var bottomConstruct = iqFactory.createConstructionNode(
+                Sets.union(tree.getVariables(), ImmutableSet.of(sortVariable)).immutableCopy(),
+                substitutionFactory.getSubstitution(
+                        sortVariable,
+                        termFactory.getDBConstant("", termFactory.getTypeFactory().getDBTypeFactory().getDBStringType())));
+        var orderByNode = iqFactory.createOrderByNode(ImmutableList.of(iqFactory.createOrderComparator(sortVariable, true)));
+
+        return iqFactory.createUnaryIQTree(
+                sliceNode,
+                iqFactory.createUnaryIQTree(
+                        topConstruct,
+                        iqFactory.createUnaryIQTree(
+                                orderByNode,
+                                iqFactory.createUnaryIQTree(
+                                        bottomConstruct,
+                                        transform(child, context)
+                                )
+                        )
+                )
+        );
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SQLServerInsertOrderByInSliceNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SQLServerInsertOrderByInSliceNormalizer.java
@@ -73,6 +73,9 @@ public class SQLServerInsertOrderByInSliceNormalizer extends DefaultRecursiveIQT
         );
     }
 
+    /**
+     * Search for an ORDER BY clause in the child IQTree. Keep searching until a node is found that will cause a new sub-query.
+     */
     static class OrderBySearcher implements IQVisitor<Boolean> {
 
         @Override
@@ -112,7 +115,7 @@ public class SQLServerInsertOrderByInSliceNormalizer extends DefaultRecursiveIQT
 
         @Override
         public Boolean visitConstruction(ConstructionNode rootNode, IQTree child) {
-            return child.acceptVisitor(this);
+            return false;
         }
 
         @Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DefaultSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DefaultSelectFromWhereSerializer.java
@@ -85,8 +85,7 @@ public class DefaultSelectFromWhereSerializer implements SelectFromWhereSerializ
             String groupByString = serializeGroupBy(selectFromWhere.getGroupByVariables(), columnIDs);
             String orderByString = serializeOrderBy(selectFromWhere.getSortConditions(),
                     columnIDs,
-                    selectFromWhere.getOffset().isPresent(),
-                    selectFromWhere.getLimit().isPresent());
+                    selectFromWhere.getOffset().isPresent() || selectFromWhere.getLimit().isPresent());
             String sliceString = serializeSlice(selectFromWhere.getLimit(), selectFromWhere.getOffset(),
                     selectFromWhere.getSortConditions().isEmpty());
 
@@ -172,11 +171,11 @@ public class DefaultSelectFromWhereSerializer implements SelectFromWhereSerializ
         }
 
         /**
-         * By default, calls serializeOrderBy without hasOffset and hasLimit. Can be used for specific dialects that
+         * By default, calls serializeOrderBy without hasOffsetOrLimit. Can be used for specific dialects that
          * have to handle ORDER BY differently if an offset or limit is provided (e.g. SQLServer)
          */
         protected String serializeOrderBy(ImmutableList<SQLOrderComparator> sortConditions,
-                                          ImmutableMap<Variable, QualifiedAttributeID> columnIDs, boolean hasOffset, boolean hasLimit) {
+                                          ImmutableMap<Variable, QualifiedAttributeID> columnIDs, boolean hasOffsetOrLimit) {
             return serializeOrderBy(sortConditions, columnIDs);
         }
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DefaultSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DefaultSelectFromWhereSerializer.java
@@ -83,7 +83,10 @@ public class DefaultSelectFromWhereSerializer implements SelectFromWhereSerializ
                     .orElse("");
 
             String groupByString = serializeGroupBy(selectFromWhere.getGroupByVariables(), columnIDs);
-            String orderByString = serializeOrderBy(selectFromWhere.getSortConditions(), columnIDs);
+            String orderByString = serializeOrderBy(selectFromWhere.getSortConditions(),
+                    columnIDs,
+                    selectFromWhere.getOffset().isPresent(),
+                    selectFromWhere.getLimit().isPresent());
             String sliceString = serializeSlice(selectFromWhere.getLimit(), selectFromWhere.getOffset(),
                     selectFromWhere.getSortConditions().isEmpty());
 
@@ -166,6 +169,11 @@ public class DefaultSelectFromWhereSerializer implements SelectFromWhereSerializ
                     .collect(Collectors.joining(", "));
 
             return String.format("ORDER BY %s\n", conditionString);
+        }
+
+        protected String serializeOrderBy(ImmutableList<SQLOrderComparator> sortConditions,
+                                          ImmutableMap<Variable, QualifiedAttributeID> columnIDs, boolean hasOffset, boolean hasLimit) {
+            return serializeOrderBy(sortConditions, columnIDs);
         }
 
         /**

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DefaultSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/DefaultSelectFromWhereSerializer.java
@@ -171,6 +171,10 @@ public class DefaultSelectFromWhereSerializer implements SelectFromWhereSerializ
             return String.format("ORDER BY %s\n", conditionString);
         }
 
+        /**
+         * By default, calls serializeOrderBy without hasOffset and hasLimit. Can be used for specific dialects that
+         * have to handle ORDER BY differently if an offset or limit is provided (e.g. SQLServer)
+         */
         protected String serializeOrderBy(ImmutableList<SQLOrderComparator> sortConditions,
                                           ImmutableMap<Variable, QualifiedAttributeID> columnIDs, boolean hasOffset, boolean hasLimit) {
             return serializeOrderBy(sortConditions, columnIDs);

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/SQLServerSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/SQLServerSelectFromWhereSerializer.java
@@ -49,33 +49,17 @@ public class SQLServerSelectFromWhereSerializer extends IgnoreNullFirstSelectFro
 
             @Override
             protected String serializeLimitOffset(long limit, long offset, boolean noSortCondition) {
-                return noSortCondition
-                        ? selectFromWhere.isDistinct()
-                            ? String.format("ORDER BY 1\nOFFSET %d ROWS\nFETCH NEXT %d ROWS ONLY", offset, limit)
-                            : String.format("ORDER BY (SELECT NULL)\nOFFSET %d ROWS\nFETCH NEXT %d ROWS ONLY", offset, limit)
-                        : String.format("OFFSET %d ROWS\nFETCH NEXT %d ROWS ONLY", offset, limit);
+                return String.format("OFFSET %d ROWS\nFETCH NEXT %d ROWS ONLY", offset, limit);
             }
 
-            /**
-             * LIMIT without ORDER BY not supported in SQLServer
-             * ORDER BY (SELECT NULL) or ORDER BY 1 are added as a default when no ORDER BY is present
-             */
             @Override
             protected String serializeLimit(long limit, boolean noSortCondition) {
-                return noSortCondition
-                        ? selectFromWhere.isDistinct()
-                            ? String.format("ORDER BY 1\nOFFSET 0 ROWS\nFETCH NEXT %d ROWS ONLY", limit)
-                            : String.format("ORDER BY (SELECT NULL)\nOFFSET 0 ROWS\nFETCH NEXT %d ROWS ONLY", limit)
-                        : String.format("OFFSET 0 ROWS\nFETCH NEXT %d ROWS ONLY", limit);
+                return String.format("OFFSET 0 ROWS\nFETCH NEXT %d ROWS ONLY", limit);
             }
 
             @Override
             protected String serializeOffset(long offset, boolean noSortCondition) {
-                return noSortCondition
-                        ? selectFromWhere.isDistinct()
-                            ? String.format("ORDER BY 1\nOFFSET %d ROWS", offset)
-                            : String.format("ORDER BY (SELECT NULL)\nOFFSET %d ROWS", offset)
-                        : String.format("OFFSET %d ROWS", offset);
+                return String.format("OFFSET %d ROWS", offset);
             }
 
             @Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/SQLServerSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/SQLServerSelectFromWhereSerializer.java
@@ -1,11 +1,13 @@
 package it.unibz.inf.ontop.generation.serializer.impl;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import it.unibz.inf.ontop.dbschema.QualifiedAttributeID;
 import it.unibz.inf.ontop.generation.algebra.SQLFlattenExpression;
 import it.unibz.inf.ontop.generation.algebra.SQLOneTupleDummyQueryExpression;
+import it.unibz.inf.ontop.generation.algebra.SQLOrderComparator;
 import it.unibz.inf.ontop.generation.algebra.SelectFromWhereWithModifiers;
 import it.unibz.inf.ontop.dbschema.DBParameters;
 import it.unibz.inf.ontop.generation.serializer.SQLSerializationException;
@@ -60,6 +62,13 @@ public class SQLServerSelectFromWhereSerializer extends IgnoreNullFirstSelectFro
             @Override
             protected String serializeOffset(long offset, boolean noSortCondition) {
                 return String.format("OFFSET %d ROWS", offset);
+            }
+
+            @Override
+            protected String serializeOrderBy(ImmutableList<SQLOrderComparator> sortConditions, ImmutableMap<Variable, QualifiedAttributeID> fromColumnMap, boolean hasOffset, boolean hasLimit) {
+                return String.format("%s%s",
+                        super.serializeOrderBy(sortConditions, fromColumnMap),
+                        hasOffset || hasLimit || sortConditions.isEmpty() ? "" : " OFFSET 0 ROWS\n");
             }
 
             @Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/SQLServerSelectFromWhereSerializer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/serializer/impl/SQLServerSelectFromWhereSerializer.java
@@ -65,10 +65,10 @@ public class SQLServerSelectFromWhereSerializer extends IgnoreNullFirstSelectFro
             }
 
             @Override
-            protected String serializeOrderBy(ImmutableList<SQLOrderComparator> sortConditions, ImmutableMap<Variable, QualifiedAttributeID> fromColumnMap, boolean hasOffset, boolean hasLimit) {
+            protected String serializeOrderBy(ImmutableList<SQLOrderComparator> sortConditions, ImmutableMap<Variable, QualifiedAttributeID> fromColumnMap, boolean hasOffsetOrLimit) {
                 return String.format("%s%s",
                         super.serializeOrderBy(sortConditions, fromColumnMap),
-                        hasOffset || hasLimit || sortConditions.isEmpty() ? "" : " OFFSET 0 ROWS\n");
+                        hasOffsetOrLimit || sortConditions.isEmpty() ? "" : " OFFSET 0 ROWS\n");
             }
 
             @Override


### PR DESCRIPTION
SQLServer does not support LIMIT and OFFSET on rows that have not first been ordered.

Added a new normalizer that inserts ORDER BY nodes inside slices if they do not already have one. The ORDER BY node sorts on a newly created variable to guarantee that it can always be sorted successfully.

This means we no longer require the old "ORDER BY (SELECT NULL)" used in the `SQLServerSelectFromWhereSerializer`, as it caused issues.