### PR TITLE
Push terms used in substitution below DISTINCT node, if they do not support distinct.

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/FunctionalDependencies.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/FunctionalDependencies.java
@@ -26,6 +26,8 @@ public interface FunctionalDependencies {
 
     boolean contains(ImmutableSet<Variable> determinants, ImmutableSet<Variable> dependents);
 
+    ImmutableSet<ImmutableSet<Variable>> getDeterminantsOf(Variable variable);
+
     static FunctionalDependencies of(ImmutableSet<Variable>... dependencies) {
         if(dependencies.length % 2 != 0)
             throw new IllegalArgumentException("FunctionalDependency must be built of 2n ImmutableSets.");

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/FunctionalDependenciesImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/FunctionalDependenciesImpl.java
@@ -76,6 +76,14 @@ public class FunctionalDependenciesImpl implements FunctionalDependencies {
                 .collect(ImmutableCollectors.toList())));
     }
 
+    @Override
+    public ImmutableSet<ImmutableSet<Variable>> getDeterminantsOf(Variable variable) {
+        return dependencies.stream()
+                .filter(d -> d.dependents.contains(variable))
+                .map(FunctionalDependency::getDeterminants)
+                .collect(ImmutableCollectors.toSet());
+    }
+
     /**
      * Completes the list of functional dependencies by applying the following actions:
      *     - Infer transitive dependencies

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/type/DBTermType.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/type/DBTermType.java
@@ -47,7 +47,7 @@ public interface DBTermType extends TermType {
     Optional<Boolean> isValidLexicalValue(String lexicalValue);
 
     /**
-     * Indicates if enforcing DISTINCT over columns of this type is recommended. If not, Ontop will try to push expressions
+     * Indicates if preventing to enforce DISTINCT over columns of this type is recommended. If so, Ontop will try to push expressions
      * of this type below the DISTINCT.
      */
     boolean isPreventDistinctRecommended();

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/type/DBTermType.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/type/DBTermType.java
@@ -46,6 +46,12 @@ public interface DBTermType extends TermType {
 
     Optional<Boolean> isValidLexicalValue(String lexicalValue);
 
+    /**
+     * Indicates if enforcing DISTINCT over columns of this type is recommended. If not, Ontop will try to push expressions
+     * of this type below the DISTINCT.
+     */
+    boolean isPreventDistinctRecommended();
+
 
     enum Category {
         STRING,

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/type/DBTypeFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/type/DBTypeFactory.java
@@ -41,6 +41,7 @@ public interface DBTypeFactory {
     DBTermType getDBHexBinaryType();
 
     DBTermType getDBArrayType();
+    DBTermType getDBArrayType(DBTermType baseType);
 
     /**
      * Default JSON datatype.

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/type/GenericDBTermType.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/type/GenericDBTermType.java
@@ -20,4 +20,6 @@ public interface GenericDBTermType extends DBTermType {
      * Creates a new concrete type that uses the correct generic types deduced from the type string.
      */
     Optional<GenericDBTermType> createFromSignature(String signature);//int[] ARRAY<int>
+
+    GenericDBTermType createFromGenericTypes(ImmutableList<DBTermType> types);
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/type/impl/ArrayDBTermType.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/type/impl/ArrayDBTermType.java
@@ -56,6 +56,11 @@ public class ArrayDBTermType extends DBTermTypeImpl implements GenericDBTermType
     }
 
     @Override
+    public GenericDBTermType createFromGenericTypes(ImmutableList<DBTermType> types) {
+        return new ArrayDBTermType(String.format("ARRAY[%s]", types.get(0).getCastName()), getAncestry(), Optional.of(types.get(0)), parsingFunction);
+    }
+
+    @Override
     public ImmutableList<DBTermType> getGenericArguments() {
         return ImmutableList.of(this.itemType.get());
     }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/type/impl/DBTermTypeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/type/impl/DBTermTypeImpl.java
@@ -43,4 +43,9 @@ public abstract class DBTermTypeImpl extends TermTypeImpl implements DBTermType 
     public Optional<Boolean> isValidLexicalValue(String lexicalValue) {
         return lexicalSpace.includes(lexicalValue);
     }
+
+    @Override
+    public boolean isPreventDistinctRecommended() {
+        return false;
+    }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/type/impl/MockupDBTypeFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/type/impl/MockupDBTypeFactory.java
@@ -107,6 +107,11 @@ public class MockupDBTypeFactory implements DBTypeFactory {
     }
 
     @Override
+    public DBTermType getDBArrayType(DBTermType baseType) {
+        return getDBArrayType();
+    }
+
+    @Override
     public DBTermType getDBJsonType() {
         throw new UnsupportedOperationException("No JSON datatype supported");
     }

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/injection/impl/OntopOptimizationModule.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/injection/impl/OntopOptimizationModule.java
@@ -55,6 +55,7 @@ public class OntopOptimizationModule extends OntopAbstractModule {
         bindFromSettings(FlattenLifter.class);
         bindFromSettings(FilterLifter.class);
         bindFromSettings(BooleanExpressionPushDownOptimizer.class);
+        bindFromSettings(PreventDistinctOptimizer.class);
 
         bind(OptimizationSingletons.class).to(OptimizationSingletonsImpl.class);
 

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/injection/impl/OntopOptimizationModule.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/injection/impl/OntopOptimizationModule.java
@@ -9,6 +9,7 @@ import it.unibz.inf.ontop.injection.OntopOptimizationSettings;
 import it.unibz.inf.ontop.injection.OptimizationSingletons;
 import it.unibz.inf.ontop.injection.OptimizerFactory;
 import it.unibz.inf.ontop.iq.optimizer.*;
+import it.unibz.inf.ontop.iq.optimizer.splitter.PreventDistinctProjectionSplitter;
 import it.unibz.inf.ontop.iq.planner.QueryPlanner;
 import it.unibz.inf.ontop.iq.tools.UnionBasedQueryMerger;
 import it.unibz.inf.ontop.iq.transformer.*;
@@ -56,6 +57,7 @@ public class OntopOptimizationModule extends OntopAbstractModule {
         bindFromSettings(FilterLifter.class);
         bindFromSettings(BooleanExpressionPushDownOptimizer.class);
         bindFromSettings(PreventDistinctOptimizer.class);
+        bindFromSettings(PreventDistinctProjectionSplitter.class);
 
         bind(OptimizationSingletons.class).to(OptimizationSingletonsImpl.class);
 

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/PreventDistinctOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/PreventDistinctOptimizer.java
@@ -1,0 +1,6 @@
+package it.unibz.inf.ontop.iq.optimizer;
+
+
+public interface PreventDistinctOptimizer extends IQOptimizer {
+
+}

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/GeneralStructuralAndSemanticIQOptimizerImpl.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/GeneralStructuralAndSemanticIQOptimizerImpl.java
@@ -21,6 +21,7 @@ public class GeneralStructuralAndSemanticIQOptimizerImpl implements GeneralStruc
     private final LensUnfolder lensUnfolder;
     private final AggregationSplitter aggregationSplitter;
     private final FlattenLifter flattenLifter;
+    private final PreventDistinctOptimizer preventDistinctOptimizer;
 
     @Inject
     private GeneralStructuralAndSemanticIQOptimizerImpl(UnionAndBindingLiftOptimizer bindingLiftOptimizer,
@@ -29,7 +30,8 @@ public class GeneralStructuralAndSemanticIQOptimizerImpl implements GeneralStruc
                                                         AggregationSimplifier aggregationSimplifier,
                                                         LensUnfolder lensUnfolder,
                                                         AggregationSplitter aggregationSplitter,
-                                                        FlattenLifter flattenLifter) {
+                                                        FlattenLifter flattenLifter,
+                                                        PreventDistinctOptimizer preventDistinctOptimizer) {
         this.bindingLiftOptimizer = bindingLiftOptimizer;
         this.joinLikeOptimizer = joinLikeOptimizer;
         this.orderBySimplifier = orderBySimplifier;
@@ -37,6 +39,7 @@ public class GeneralStructuralAndSemanticIQOptimizerImpl implements GeneralStruc
         this.lensUnfolder = lensUnfolder;
         this.aggregationSplitter = aggregationSplitter;
         this.flattenLifter = flattenLifter;
+        this.preventDistinctOptimizer = preventDistinctOptimizer;
     }
 
     @Override
@@ -46,7 +49,11 @@ public class GeneralStructuralAndSemanticIQOptimizerImpl implements GeneralStruc
 
         LOGGER.debug("New lifted query:\n{}\n", liftedQuery);
 
-        IQ current = liftedQuery;
+        // Push expressions into a distinct below where possible if they have a data type that is not supported for distinct.
+        IQ pushedIntoDistinct = preventDistinctOptimizer.optimize(liftedQuery);
+        LOGGER.debug("Query tree after preventing DISTINCT for non-supported data types:\n{}\n", pushedIntoDistinct);
+
+        IQ current = pushedIntoDistinct;
         do {
 
             long beginningJoinLike = System.currentTimeMillis();
@@ -80,6 +87,10 @@ public class GeneralStructuralAndSemanticIQOptimizerImpl implements GeneralStruc
         IQ optimizedQuery = orderBySimplifier.optimize(queryAfterAggregationSplitting);
         LOGGER.debug("New query after simplifying the order by node:\n{}\n", optimizedQuery);
 
-        return optimizedQuery;
+        // Called a second time in case the order of nodes was changed during previous optimization steps.
+        IQ resultingQuery = preventDistinctOptimizer.optimize(liftedQuery);
+        LOGGER.debug("Query tree after preventing DISTINCT for non-supported data types, second pass:\n{}\n", resultingQuery);
+
+        return resultingQuery;
     }
 }

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/GeneralStructuralAndSemanticIQOptimizerImpl.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/GeneralStructuralAndSemanticIQOptimizerImpl.java
@@ -88,7 +88,7 @@ public class GeneralStructuralAndSemanticIQOptimizerImpl implements GeneralStruc
         LOGGER.debug("New query after simplifying the order by node:\n{}\n", optimizedQuery);
 
         // Called a second time in case the order of nodes was changed during previous optimization steps.
-        IQ resultingQuery = preventDistinctOptimizer.optimize(liftedQuery);
+        IQ resultingQuery = preventDistinctOptimizer.optimize(optimizedQuery);
         LOGGER.debug("Query tree after preventing DISTINCT for non-supported data types, second pass:\n{}\n", resultingQuery);
 
         return resultingQuery;

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/PreventDistinctOptimizerImpl.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/PreventDistinctOptimizerImpl.java
@@ -1,0 +1,218 @@
+package it.unibz.inf.ontop.iq.optimizer.impl;
+
+import com.google.common.collect.*;
+import it.unibz.inf.ontop.exception.MinorOntopInternalBugException;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.injection.OptimizationSingletons;
+import it.unibz.inf.ontop.iq.IQ;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.UnaryIQTree;
+import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.optimizer.PreventDistinctOptimizer;
+import it.unibz.inf.ontop.iq.transform.IQTreeTransformer;
+import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeVisitingTransformer;
+import it.unibz.inf.ontop.model.term.*;
+import it.unibz.inf.ontop.model.type.DBTermType;
+import it.unibz.inf.ontop.model.type.TermTypeInference;
+import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+import javax.inject.Inject;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class PreventDistinctOptimizerImpl implements PreventDistinctOptimizer {
+
+    private final IntermediateQueryFactory iqFactory;
+    private final OptimizationSingletons optimizationSingletons;
+
+    @Inject
+    private PreventDistinctOptimizerImpl(IntermediateQueryFactory iqFactory, OptimizationSingletons optimizationSingletons) {
+        this.iqFactory = iqFactory;
+        this.optimizationSingletons = optimizationSingletons;
+    }
+
+    @Override
+    public IQ optimize(IQ query) {
+        VariableGenerator variableGenerator = query.getVariableGenerator();
+        IQTreeTransformer transformer = createTransformer(variableGenerator);
+        IQTree newTree = transformer.transform(query.getTree());
+        return iqFactory.createIQ(query.getProjectionAtom(), newTree);
+    }
+
+    protected IQTreeTransformer createTransformer(VariableGenerator variableGenerator) {
+        return new PreventDistinctTransformer(variableGenerator, optimizationSingletons);
+    }
+
+    private static class PreventDistinctTransformer extends DefaultRecursiveIQTreeVisitingTransformer {
+
+        private final TermFactory termFactory;
+        private final SubstitutionFactory substitutionFactory;
+        private final VariableGenerator variableGenerator;
+
+        public PreventDistinctTransformer(VariableGenerator variableGenerator, OptimizationSingletons optimizationSingletons) {
+            super(optimizationSingletons.getCoreSingletons());
+            this.variableGenerator = variableGenerator;
+            this.termFactory = optimizationSingletons.getCoreSingletons().getTermFactory();
+            this.substitutionFactory = optimizationSingletons.getCoreSingletons().getSubstitutionFactory();
+        }
+
+        @Override
+        public IQTree transformConstruction(IQTree tree, ConstructionNode rootNode, IQTree child) {
+            var decomposition = Decomposition.decomposeTree(child);
+            if(decomposition.distinctNode.isPresent()) {
+                return performTransformation(rootNode, tree, decomposition);
+            }
+            return super.transformConstruction(tree, rootNode, child);
+        }
+
+        private IQTree performTransformation(ConstructionNode constructionNode, IQTree originalTree, Decomposition decomposition) {
+            var subtree = decomposition.descendantTree;
+
+
+            //Find terms that need to be pushed below the distinct.
+            ImmutableMap.Builder<Variable, ImmutableTerm> substitutionBuilder = ImmutableMap.builder();
+            var updatedTerms = constructionNode.getSubstitution().stream()
+                    .map(entry -> Maps.immutableEntry(entry.getKey(), splitByPreventDistinctType(entry.getValue(), substitutionBuilder)))
+                    .collect(ImmutableCollectors.toSet());
+            if(substitutionBuilder.build().isEmpty())
+                return originalTree;
+            var substitution = substitutionBuilder.build();
+
+
+            //Check if all variables used by these terms have a functional dependency pointing to them.
+            var pushedVariables = substitution.entrySet().stream()
+                    .flatMap(entry -> entry.getValue().getVariableStream())
+                    .collect(ImmutableCollectors.toSet());
+            var functionalDependencies = subtree.inferFunctionalDependencies();
+            if(pushedVariables.stream()
+                    .anyMatch(v -> functionalDependencies.getDeterminantsOf(v).stream()
+                            .noneMatch(determinants -> Sets.intersection(determinants, pushedVariables).isEmpty())))
+                throw new IllegalArgumentException(String.format("No Functional Dependency could be used to push the variables %s down.", pushedVariables));
+
+
+            //Construct the updated IQTree.
+            var topConstruction = iqFactory.createConstructionNode(
+                    constructionNode.getVariables(),
+                    updatedTerms.stream()
+                            .filter(entry -> !(entry.getValue() instanceof Variable))
+                            .collect(substitutionFactory.toSubstitution())
+            );
+            var bottomSubstitution = substitution.entrySet().stream()
+                    .map(entry -> Maps.immutableEntry(
+                            updatedTerms.stream().filter(e -> e.getValue().equals(entry.getKey())).findFirst().map(e -> e.getKey()).orElse(entry.getKey()),
+                            entry.getValue()))
+                    .collect(substitutionFactory.toSubstitution());
+            var bottomConstruction = iqFactory.createConstructionNode(
+                    Sets.difference(
+                            Sets.union(constructionNode.getChildVariables(), bottomSubstitution.getDomain()),
+                            pushedVariables
+                    ).immutableCopy(),
+                    bottomSubstitution
+            );
+
+            var newSubtree = decomposition.rebuildWithNewDescendantTree(iqFactory.createUnaryIQTree(bottomConstruction, subtree.acceptTransformer(this)), iqFactory);
+            return iqFactory.createUnaryIQTree(topConstruction, newSubtree);
+        }
+
+        private boolean shouldPreventDistinct(ImmutableTerm term) {
+            var type = term.inferType();
+            return type.flatMap(TermTypeInference::getTermType)
+                    .filter(t -> t instanceof DBTermType)
+                    .map(t -> (DBTermType) t)
+                    .map(DBTermType::isPreventDistinctRecommended)
+                    .orElse(false);
+        }
+
+        private ImmutableTerm splitByPreventDistinctType(ImmutableTerm term, ImmutableMap.Builder<Variable, ImmutableTerm> substitutionBuilder) {
+            if(shouldPreventDistinct(term)) {
+                throw new IllegalArgumentException(String.format("The term %s does not allow DISTINCT and could not be separated and pushed down", term));
+            }
+
+            if(!(term instanceof ImmutableFunctionalTerm)) {
+                return term;
+            }
+
+            var f = (ImmutableFunctionalTerm) term;
+
+            if(f.getTerms().stream().anyMatch(this::shouldPreventDistinct)
+                    || IntStream.range(0, f.getArity())
+                            .mapToObj(i -> f.getFunctionSymbol().getExpectedBaseType(i))
+                            .filter(t -> t instanceof DBTermType)
+                            .anyMatch(t -> ((DBTermType) t).isPreventDistinctRecommended())) {
+                if(!f.getFunctionSymbol().isDeterministic()) {
+                    throw new IllegalArgumentException(String.format("Pushing a term used inside the non-deterministic function %s below the DISTINCT is not supported.", term));
+                }
+                var variable = variableGenerator.generateNewVariable("pushPreventDistinct");
+                substitutionBuilder.put(variable, term);
+                return variable;
+            }
+
+            var childTerms = f.getTerms().stream()
+                    .map(t -> splitByPreventDistinctType(t, substitutionBuilder))
+                    .collect(ImmutableCollectors.toList());
+            if(!childTerms.equals(f.getTerms()) && !f.getFunctionSymbol().isDeterministic()) {
+                throw new IllegalArgumentException(String.format("Pushing a term used inside the non-deterministic function %s below the DISTINCT is not supported.", term));
+            }
+            return termFactory.getImmutableFunctionalTerm(
+                    f.getFunctionSymbol(),
+                    childTerms
+            );
+        }
+
+    }
+
+    /**
+     * Below the Construction, we may find the following nodes: DistinctNode, SliceNode.
+     * Some nodes may be missing but the order must be respected. There are no multiple instances of the same kind of node.
+     */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    protected static class Decomposition {
+        final Optional<SliceNode> sliceNode;
+        final Optional<DistinctNode> distinctNode;
+
+        final IQTree descendantTree;
+
+        private Decomposition(Optional<SliceNode> sliceNode,
+                              Optional<DistinctNode> distinctNode,
+                              IQTree descendantTree) {
+            this.sliceNode = sliceNode;
+            this.distinctNode = distinctNode;
+            this.descendantTree = descendantTree;
+        }
+
+        IQTree rebuildWithNewDescendantTree(IQTree newDescendantTree, IntermediateQueryFactory iqFactory) {
+            return Stream.of(distinctNode, sliceNode)
+                    .flatMap(Optional::stream)
+                    .reduce(newDescendantTree,
+                            (t, n) -> iqFactory.createUnaryIQTree(n, t),
+                            (t1, t2) -> { throw new MinorOntopInternalBugException("Must not be run in parallel"); });
+        }
+
+        static Decomposition decomposeTree(IQTree tree) {
+
+            QueryNode rootNode = tree.getRootNode();
+            Optional<SliceNode> sliceNode = Optional.of(rootNode)
+                    .filter(n -> n instanceof SliceNode)
+                    .map(n -> (SliceNode) n);
+
+            IQTree firstNonSliceTree = sliceNode
+                    .map(n -> ((UnaryIQTree) tree).getChild())
+                    .orElse(tree);
+
+            Optional<DistinctNode> distinctNode = Optional.of(firstNonSliceTree)
+                    .map(IQTree::getRootNode)
+                    .filter(n -> n instanceof DistinctNode)
+                    .map(n -> (DistinctNode) n);
+
+            IQTree descendantTree = distinctNode
+                    .map(n -> ((UnaryIQTree) firstNonSliceTree).getChild())
+                    .orElse(firstNonSliceTree);
+
+            return new Decomposition(sliceNode, distinctNode, descendantTree);
+        }
+    }
+
+}

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/PreventDistinctOptimizerImpl.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/PreventDistinctOptimizerImpl.java
@@ -1,6 +1,7 @@
 package it.unibz.inf.ontop.iq.optimizer.impl;
 
 import com.google.common.collect.*;
+import it.unibz.inf.ontop.iq.optimizer.splitter.PreventDistinctProjectionSplitter;
 import it.unibz.inf.ontop.exception.MinorOntopInternalBugException;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.injection.OptimizationSingletons;
@@ -12,26 +13,23 @@ import it.unibz.inf.ontop.iq.optimizer.PreventDistinctOptimizer;
 import it.unibz.inf.ontop.iq.transform.IQTreeTransformer;
 import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeVisitingTransformer;
 import it.unibz.inf.ontop.model.term.*;
-import it.unibz.inf.ontop.model.type.DBTermType;
-import it.unibz.inf.ontop.model.type.TermTypeInference;
-import it.unibz.inf.ontop.substitution.SubstitutionFactory;
-import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import it.unibz.inf.ontop.utils.VariableGenerator;
 
 import javax.inject.Inject;
 import java.util.Optional;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class PreventDistinctOptimizerImpl implements PreventDistinctOptimizer {
 
     private final IntermediateQueryFactory iqFactory;
     private final OptimizationSingletons optimizationSingletons;
+    private final PreventDistinctProjectionSplitter preventDistinctProjectionSplitter;
 
     @Inject
-    private PreventDistinctOptimizerImpl(IntermediateQueryFactory iqFactory, OptimizationSingletons optimizationSingletons) {
+    private PreventDistinctOptimizerImpl(IntermediateQueryFactory iqFactory, OptimizationSingletons optimizationSingletons, PreventDistinctProjectionSplitter preventDistinctProjectionSplitter) {
         this.iqFactory = iqFactory;
         this.optimizationSingletons = optimizationSingletons;
+        this.preventDistinctProjectionSplitter = preventDistinctProjectionSplitter;
     }
 
     @Override
@@ -39,85 +37,64 @@ public class PreventDistinctOptimizerImpl implements PreventDistinctOptimizer {
         VariableGenerator variableGenerator = query.getVariableGenerator();
         IQTreeTransformer transformer = createTransformer(variableGenerator);
         IQTree newTree = transformer.transform(query.getTree());
+        if(newTree.equals(query.getTree()))
+            return query;
         return iqFactory.createIQ(query.getProjectionAtom(), newTree);
     }
 
     protected IQTreeTransformer createTransformer(VariableGenerator variableGenerator) {
-        return new PreventDistinctTransformer(variableGenerator, optimizationSingletons);
+        return new PreventDistinctTransformer(variableGenerator, optimizationSingletons, preventDistinctProjectionSplitter);
     }
 
     private static class PreventDistinctTransformer extends DefaultRecursiveIQTreeVisitingTransformer {
 
-        private final TermFactory termFactory;
-        private final SubstitutionFactory substitutionFactory;
         private final VariableGenerator variableGenerator;
+        private final PreventDistinctProjectionSplitter preventDistinctProjectionSplitter;
 
-        public PreventDistinctTransformer(VariableGenerator variableGenerator, OptimizationSingletons optimizationSingletons) {
+        public PreventDistinctTransformer(VariableGenerator variableGenerator, OptimizationSingletons optimizationSingletons, PreventDistinctProjectionSplitter preventDistinctProjectionSplitter) {
             super(optimizationSingletons.getCoreSingletons());
             this.variableGenerator = variableGenerator;
-            this.termFactory = optimizationSingletons.getCoreSingletons().getTermFactory();
-            this.substitutionFactory = optimizationSingletons.getCoreSingletons().getSubstitutionFactory();
+            this.preventDistinctProjectionSplitter = preventDistinctProjectionSplitter;
         }
 
         @Override
         public IQTree transformConstruction(IQTree tree, ConstructionNode rootNode, IQTree child) {
             var decomposition = Decomposition.decomposeTree(child);
             if(decomposition.distinctNode.isPresent()) {
-                return performTransformation(rootNode, tree, decomposition);
+                var split = preventDistinctProjectionSplitter.split(tree, variableGenerator);
+                var newTree = iqFactory.createUnaryIQTree(split.getConstructionNode(),
+                        split.getSubTree());
+                if(newTree.equals(tree))
+                    return tree;
+                if(!validatePushedVariables(
+                        split.getPushedVariables(),
+                        Sets.difference(
+                                rootNode.getChildVariables(),
+                                split.getPushedVariables()).immutableCopy(),
+                        decomposition.descendantTree))
+                    throw new MinorOntopInternalBugException("Unable to push down substitution terms that are not supported with DISTINCT without a functional dependency.");
+                if(!validatePushedTerms(split.getPushedTerms()))
+                    throw new MinorOntopInternalBugException("Unable to push down substitution terms that are not supported with DISTINCT if the functional terms are not deterministic.");
+                return newTree;
             }
             return super.transformConstruction(tree, rootNode, child);
         }
 
-        private IQTree performTransformation(ConstructionNode constructionNode, IQTree originalTree, Decomposition decomposition) {
-            var subtree = decomposition.descendantTree;
+        private boolean validatePushedVariables(ImmutableSet<Variable> pushedVariables, ImmutableSet<Variable> keptVariables, IQTree child) {
+            var functionalDependencies = child.inferFunctionalDependencies();
+            return pushedVariables.stream()
+                    .allMatch(v -> functionalDependencies.getDeterminantsOf(v).stream()
+                                    .anyMatch(determinants ->
+                                            keptVariables.containsAll(determinants)
+                                            && Sets.intersection(determinants, pushedVariables).isEmpty()
+                                    ));
+        }
 
-
-            //Find terms that need to be pushed below the distinct.
-            ImmutableMap.Builder<Variable, ImmutableTerm> substitutionBuilder = ImmutableMap.builder();
-            var updatedTerms = constructionNode.getSubstitution().stream()
-                    .map(entry -> Maps.immutableEntry(entry.getKey(), splitByPreventDistinctType(entry.getValue(), substitutionBuilder)))
-                    .collect(ImmutableCollectors.toSet());
-            if(substitutionBuilder.build().isEmpty())
-                return originalTree;
-            var substitution = substitutionBuilder.build();
-            if(!substitution.values().stream()
-                    .allMatch(this::isDeterministic))
-                throw new IllegalArgumentException("Unable to push non-supported terms below DISTINCT, because they include a non-deterministic function.");
-
-
-            //Check if all variables used by these terms have a functional dependency pointing to them.
-            var pushedVariables = substitution.entrySet().stream()
-                    .flatMap(entry -> entry.getValue().getVariableStream())
-                    .collect(ImmutableCollectors.toSet());
-            var functionalDependencies = subtree.inferFunctionalDependencies();
-            if(pushedVariables.stream()
-                    .anyMatch(v -> functionalDependencies.getDeterminantsOf(v).stream()
-                            .noneMatch(determinants -> Sets.intersection(determinants, pushedVariables).isEmpty())))
-                throw new IllegalArgumentException(String.format("No Functional Dependency could be used to push the variables %s down.", pushedVariables));
-
-
-            //Construct the updated IQTree.
-            var topConstruction = iqFactory.createConstructionNode(
-                    constructionNode.getVariables(),
-                    updatedTerms.stream()
-                            .filter(entry -> !(entry.getValue() instanceof Variable))
-                            .collect(substitutionFactory.toSubstitution())
-            );
-            var bottomSubstitution = substitution.entrySet().stream()
-                    .map(entry -> Maps.immutableEntry(
-                            updatedTerms.stream().filter(e -> e.getValue().equals(entry.getKey())).findFirst().map(e -> e.getKey()).orElse(entry.getKey()),
-                            entry.getValue()))
-                    .collect(substitutionFactory.toSubstitution());
-            var bottomConstruction = iqFactory.createConstructionNode(
-                    Sets.difference(
-                            Sets.union(constructionNode.getChildVariables(), bottomSubstitution.getDomain()),
-                            pushedVariables
-                    ).immutableCopy(),
-                    bottomSubstitution
-            );
-
-            var newSubtree = decomposition.rebuildWithNewDescendantTree(iqFactory.createUnaryIQTree(bottomConstruction, subtree.acceptTransformer(this)), iqFactory);
-            return iqFactory.createUnaryIQTree(topConstruction, newSubtree);
+        private boolean validatePushedTerms(ImmutableSet<ImmutableTerm> pushedTerms) {
+            return pushedTerms.stream()
+                    .filter(term -> term instanceof ImmutableFunctionalTerm)
+                    .map(term -> (ImmutableFunctionalTerm) term)
+                    .allMatch(this::isDeterministic);
         }
 
         private boolean isDeterministic(ImmutableTerm term) {
@@ -128,45 +105,6 @@ public class PreventDistinctOptimizerImpl implements PreventDistinctOptimizer {
                 return false;
             return f.getTerms().stream()
                             .allMatch(this::isDeterministic);
-        }
-
-        private boolean shouldPreventDistinct(ImmutableTerm term) {
-            var type = term.inferType();
-            return type.flatMap(TermTypeInference::getTermType)
-                    .filter(t -> t instanceof DBTermType)
-                    .map(t -> (DBTermType) t)
-                    .map(DBTermType::isPreventDistinctRecommended)
-                    .orElse(false);
-        }
-
-        private ImmutableTerm splitByPreventDistinctType(ImmutableTerm term, ImmutableMap.Builder<Variable, ImmutableTerm> substitutionBuilder) {
-            if(shouldPreventDistinct(term)) {
-                throw new IllegalArgumentException(String.format("The term %s does not allow DISTINCT and could not be separated and pushed down", term));
-            }
-
-            if(!(term instanceof ImmutableFunctionalTerm)) {
-                return term;
-            }
-
-            var f = (ImmutableFunctionalTerm) term;
-
-            if(f.getTerms().stream().anyMatch(this::shouldPreventDistinct)
-                    || IntStream.range(0, f.getArity())
-                            .mapToObj(i -> f.getFunctionSymbol().getExpectedBaseType(i))
-                            .filter(t -> t instanceof DBTermType)
-                            .anyMatch(t -> ((DBTermType) t).isPreventDistinctRecommended())) {
-                var variable = variableGenerator.generateNewVariable("pushPreventDistinct");
-                substitutionBuilder.put(variable, term);
-                return variable;
-            }
-
-            var childTerms = f.getTerms().stream()
-                    .map(t -> splitByPreventDistinctType(t, substitutionBuilder))
-                    .collect(ImmutableCollectors.toList());
-            return termFactory.getImmutableFunctionalTerm(
-                    f.getFunctionSymbol(),
-                    childTerms
-            );
         }
 
     }
@@ -188,14 +126,6 @@ public class PreventDistinctOptimizerImpl implements PreventDistinctOptimizer {
             this.sliceNode = sliceNode;
             this.distinctNode = distinctNode;
             this.descendantTree = descendantTree;
-        }
-
-        IQTree rebuildWithNewDescendantTree(IQTree newDescendantTree, IntermediateQueryFactory iqFactory) {
-            return Stream.of(distinctNode, sliceNode)
-                    .flatMap(Optional::stream)
-                    .reduce(newDescendantTree,
-                            (t, n) -> iqFactory.createUnaryIQTree(n, t),
-                            (t1, t2) -> { throw new MinorOntopInternalBugException("Must not be run in parallel"); });
         }
 
         static Decomposition decomposeTree(IQTree tree) {

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/splitter/PreventDistinctProjectionSplitter.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/splitter/PreventDistinctProjectionSplitter.java
@@ -1,0 +1,5 @@
+package it.unibz.inf.ontop.iq.optimizer.splitter;
+
+public interface PreventDistinctProjectionSplitter extends ProjectionSplitter {
+
+}

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/splitter/ProjectionSplitter.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/splitter/ProjectionSplitter.java
@@ -1,0 +1,24 @@
+package it.unibz.inf.ontop.iq.optimizer.splitter;
+
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.iq.IQ;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.node.ConstructionNode;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+public interface ProjectionSplitter {
+
+    ProjectionSplit split(IQ iq);
+
+    ProjectionSplit split(IQTree tree, VariableGenerator variableGenerator);
+
+    interface ProjectionSplit {
+        ConstructionNode getConstructionNode();
+        IQTree getSubTree();
+        VariableGenerator getVariableGenerator();
+        ImmutableSet<Variable> getPushedVariables();
+        ImmutableSet<ImmutableTerm> getPushedTerms();
+    }
+}

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/splitter/impl/PreventDistinctProjectionSplitterImpl.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/splitter/impl/PreventDistinctProjectionSplitterImpl.java
@@ -1,0 +1,75 @@
+package it.unibz.inf.ontop.iq.optimizer.splitter.impl;
+
+import com.google.inject.Inject;
+import it.unibz.inf.ontop.iq.UnaryIQTree;
+import it.unibz.inf.ontop.iq.node.ConstructionNode;
+import it.unibz.inf.ontop.iq.node.DistinctNode;
+import it.unibz.inf.ontop.iq.optimizer.splitter.PreventDistinctProjectionSplitter;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.node.normalization.DistinctNormalizer;
+import it.unibz.inf.ontop.iq.tools.ProjectionDecomposer;
+import it.unibz.inf.ontop.model.term.ImmutableFunctionalTerm;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.type.DBTermType;
+import it.unibz.inf.ontop.model.type.TermTypeInference;
+import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+import it.unibz.inf.ontop.utils.CoreUtilsFactory;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+import java.util.stream.IntStream;
+
+public class PreventDistinctProjectionSplitterImpl extends ProjectionSplitterImpl implements PreventDistinctProjectionSplitter {
+
+    private final ProjectionDecomposer decomposer;
+
+    private final IntermediateQueryFactory iqFactory;
+
+    @Inject
+    private PreventDistinctProjectionSplitterImpl(IntermediateQueryFactory iqFactory,
+                                                  SubstitutionFactory substitutionFactory,
+                                                  CoreUtilsFactory coreUtilsFactory,
+                                                  DistinctNormalizer distinctNormalizer) {
+        super(iqFactory, substitutionFactory, distinctNormalizer);
+        this.decomposer = coreUtilsFactory.createProjectionDecomposer(
+            t -> !shouldSplit(t),
+            n -> true //TODO-Damian is this correct?
+        );
+        this.iqFactory = iqFactory;
+    }
+
+    @Override
+    public ProjectionSplit split(IQTree tree, VariableGenerator variableGenerator) {
+        return split(tree, variableGenerator, decomposer);
+    }
+
+    private static boolean shouldSplit(ImmutableFunctionalTerm term) {
+        return term.getTerms().stream().anyMatch(PreventDistinctProjectionSplitterImpl::shouldPreventDistinct)
+                || IntStream.range(0, term.getArity())
+                .mapToObj(i -> term.getFunctionSymbol().getExpectedBaseType(i))
+                .filter(t -> t instanceof DBTermType)
+                .anyMatch(t -> ((DBTermType) t).isPreventDistinctRecommended());
+    }
+
+    private static boolean shouldPreventDistinct(ImmutableTerm term) {
+        var type = term.inferType();
+        return type.flatMap(TermTypeInference::getTermType)
+                .filter(t -> t instanceof DBTermType)
+                .map(t -> (DBTermType) t)
+                .map(DBTermType::isPreventDistinctRecommended)
+                .orElse(false);
+    }
+
+    @Override
+    protected IQTree insertConstructionNode(IQTree tree, ConstructionNode constructionNode, VariableGenerator variableGenerator) {
+        var rootNode = tree.getRootNode();
+        if(!(rootNode instanceof DistinctNode))
+            return super.insertConstructionNode(tree, constructionNode, variableGenerator);
+
+        /* We can bypass the security check for pushing the CONSTRUCT into the DISTINCT used by the normal ProjectionSplitter,
+         * as the general circumstances of this use case already revolve around that scenario.
+         */
+        return iqFactory.createUnaryIQTree((DistinctNode) rootNode,
+                iqFactory.createUnaryIQTree(constructionNode, ((UnaryIQTree)tree).getChild()));
+    }
+}

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/splitter/impl/PreventDistinctProjectionSplitterImpl.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/splitter/impl/PreventDistinctProjectionSplitterImpl.java
@@ -33,7 +33,7 @@ public class PreventDistinctProjectionSplitterImpl extends ProjectionSplitterImp
         super(iqFactory, substitutionFactory, distinctNormalizer);
         this.decomposer = coreUtilsFactory.createProjectionDecomposer(
             t -> !shouldSplit(t),
-            n -> true //TODO-Damian is this correct?
+            n -> true
         );
         this.iqFactory = iqFactory;
     }

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/splitter/impl/ProjectionSplitterImpl.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/splitter/impl/ProjectionSplitterImpl.java
@@ -1,0 +1,197 @@
+package it.unibz.inf.ontop.iq.optimizer.splitter.impl;
+
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.iq.optimizer.splitter.ProjectionSplitter;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.IQ;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.UnaryIQTree;
+import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.node.normalization.DistinctNormalizer;
+import it.unibz.inf.ontop.iq.tools.ProjectionDecomposer;
+import it.unibz.inf.ontop.iq.tools.ProjectionDecomposer.ProjectionDecomposition;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.substitution.Substitution;
+import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+import java.util.Optional;
+
+public abstract class ProjectionSplitterImpl implements ProjectionSplitter {
+
+    private final IntermediateQueryFactory iqFactory;
+    private final SubstitutionFactory substitutionFactory;
+    private final DistinctNormalizer distinctNormalizer;
+
+    protected ProjectionSplitterImpl(IntermediateQueryFactory iqFactory,
+                                   SubstitutionFactory substitutionFactory,
+                                   DistinctNormalizer distinctNormalizer) {
+        this.iqFactory = iqFactory;
+        this.substitutionFactory = substitutionFactory;
+        this.distinctNormalizer = distinctNormalizer;
+    }
+
+    @Override
+    public ProjectionSplit split(IQ initialIQ) {
+        return split(initialIQ.getTree(), initialIQ.getVariableGenerator());
+    }
+
+    protected ProjectionSplit split(IQ initialIQ, ProjectionDecomposer decomposer) {
+        return split(initialIQ.getTree(), initialIQ.getVariableGenerator(), decomposer);
+    }
+
+    protected ProjectionSplit split(IQTree topTree, VariableGenerator variableGenerator, ProjectionDecomposer decomposer) {
+
+        return Optional.of(topTree)
+                .filter(t -> t.getRootNode() instanceof ConstructionNode)
+                .map(t -> (UnaryIQTree) t)
+                .map(t -> split(t, variableGenerator, decomposer))
+                .orElseGet(() -> new ProjectionSplitImpl(
+                        // "Useless" construction node --> no post-processing
+                        iqFactory.createConstructionNode(topTree.getVariables(), substitutionFactory.getSubstitution()),
+                        topTree,
+                        variableGenerator,
+                        ImmutableSet.of(),
+                        ImmutableSet.of()));
+    }
+
+
+    private ProjectionSplit split(UnaryIQTree initialTree, VariableGenerator variableGenerator, ProjectionDecomposer decomposer) {
+
+        ConstructionNode initialRootNode = (ConstructionNode) initialTree.getRootNode();
+        IQTree initialSubTree = initialTree.getChild();
+
+        ProjectionDecomposition decomposition = decomposer.decomposeSubstitution(initialRootNode.getSubstitution(), variableGenerator);
+
+        ConstructionNode postProcessingNode = iqFactory.createConstructionNode(initialRootNode.getVariables(),
+                decomposition.getTopSubstitution()
+                .orElseGet(substitutionFactory::getSubstitution));
+
+        ImmutableSet<Variable> newSubTreeVariables = postProcessingNode.getChildVariables();
+
+        /*
+         * NB: the presence of a subSubstitution implies the need to project new variables.
+         */
+        IQTree newSubTree = initialSubTree.getVariables().equals(newSubTreeVariables)
+                ? initialSubTree
+                : iqFactory.createUnaryIQTree(
+                    decomposition.getSubSubstitution()
+                        .map(s -> iqFactory.createConstructionNode(newSubTreeVariables, s))
+                        .orElseGet(() -> iqFactory.createConstructionNode(newSubTreeVariables)),
+                    initialSubTree);
+
+        return new ProjectionSplitImpl(postProcessingNode,
+                normalizeNewSubTree(newSubTree, variableGenerator),
+                variableGenerator,
+                decomposition.getSubSubstitution()
+                        .map(Substitution::getRangeVariables)
+                        .orElseGet(ImmutableSet::of),
+                decomposition.getSubSubstitution()
+                        .map(Substitution::getRangeSet)
+                        .orElseGet(ImmutableSet::of));
+    }
+
+    /**
+     * Tries to push down the possible root construction node under a SLICE and a DISTINCT
+     *
+     */
+    protected IQTree normalizeNewSubTree(IQTree newSubTree, VariableGenerator variableGenerator) {
+        return Optional.of(newSubTree.getRootNode())
+                .filter(n -> n instanceof ConstructionNode)
+                .map(n -> (ConstructionNode) n)
+                .map(c -> insertConstructionNode(((UnaryIQTree) newSubTree).getChild(), c, variableGenerator))
+                .orElse(newSubTree);
+    }
+
+    /**
+     * Recursive
+     */
+    protected IQTree insertConstructionNode(IQTree tree, ConstructionNode constructionNode, VariableGenerator variableGenerator) {
+        QueryNode rootNode = tree.getRootNode();
+        if (rootNode instanceof SliceNode)
+            return iqFactory.createUnaryIQTree(
+                    (UnaryOperatorNode) rootNode,
+                    // Recursive
+                    insertConstructionNode(((UnaryIQTree)tree).getChild(), constructionNode, variableGenerator));
+        /*
+         * Distinct:
+         * If
+         *  1. the construction node could be fully lifted above the distinct,
+         *  2. AND the distinct old projects the variables required by the construction node
+         * THEN it can be pushed under the DISTINCT
+         *
+         * "Reverses" the binding lift operation except that here either all the bindings are pushed down or none.
+         *
+         * TODO: relax the condition 1?
+         *
+         */
+        else if (rootNode instanceof DistinctNode) {
+            IQTree childTree = ((UnaryIQTree) tree).getChild();
+
+            // Stops if the child tree is projecting more variables than what the construction node expects
+            if (!childTree.getVariables().equals(constructionNode.getChildVariables()))
+                return iqFactory.createUnaryIQTree(
+                        constructionNode,
+                        tree
+                );
+
+            UnaryIQTree possibleChildTree = iqFactory.createUnaryIQTree(constructionNode, childTree);
+
+            DistinctNode distinctNode = (DistinctNode) rootNode;
+
+            IQTree liftedTree = distinctNormalizer.normalizeForOptimization(distinctNode, possibleChildTree, variableGenerator,
+                    iqFactory.createIQTreeCache());
+
+            return liftedTree.getRootNode().equals(constructionNode)
+                    ? iqFactory.createUnaryIQTree(distinctNode, possibleChildTree)
+                    : iqFactory.createUnaryIQTree(constructionNode, tree);
+        }
+        else
+            return iqFactory.createUnaryIQTree(constructionNode, tree);
+    }
+
+    static class ProjectionSplitImpl implements ProjectionSplit {
+
+        private final ConstructionNode constructionNode;
+        private final IQTree subTree;
+        private final VariableGenerator variableGenerator;
+        private final ImmutableSet<Variable> pushedVariables;
+        private final ImmutableSet<ImmutableTerm> pushedTerms;
+
+        ProjectionSplitImpl(ConstructionNode constructionNode, IQTree subTree,
+                                VariableGenerator variableGenerator, ImmutableSet<Variable> pushedVariables,
+                            ImmutableSet<ImmutableTerm> pushedTerms) {
+            this.constructionNode = constructionNode;
+            this.subTree = subTree;
+            this.variableGenerator = variableGenerator;
+            this.pushedVariables = pushedVariables;
+            this.pushedTerms = pushedTerms;
+        }
+
+        @Override
+        public ConstructionNode getConstructionNode() {
+            return constructionNode;
+        }
+
+        @Override
+        public IQTree getSubTree() {
+            return subTree;
+        }
+
+        @Override
+        public VariableGenerator getVariableGenerator() {
+            return variableGenerator;
+        }
+
+        @Override
+        public ImmutableSet<Variable> getPushedVariables() {
+            return pushedVariables;
+        }
+
+        @Override
+        public ImmutableSet<ImmutableTerm> getPushedTerms() {
+            return pushedTerms;
+        }
+    }
+}

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/splitter/impl/ProjectionSplitterImpl.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/splitter/impl/ProjectionSplitterImpl.java
@@ -73,7 +73,7 @@ public abstract class ProjectionSplitterImpl implements ProjectionSplitter {
         /*
          * NB: the presence of a subSubstitution implies the need to project new variables.
          */
-        IQTree newSubTree = initialSubTree.getVariables().equals(newSubTreeVariables)
+        IQTree newSubTree = initialSubTree.getVariables().containsAll(newSubTreeVariables)
                 ? initialSubTree
                 : iqFactory.createUnaryIQTree(
                     decomposition.getSubSubstitution()

--- a/core/optimization/src/main/resources/it/unibz/inf/ontop/injection/optimization-default.properties
+++ b/core/optimization/src/main/resources/it/unibz/inf/ontop/injection/optimization-default.properties
@@ -13,6 +13,7 @@ it.unibz.inf.ontop.iq.optimizer.TermTypeTermLifter = it.unibz.inf.ontop.iq.optim
 it.unibz.inf.ontop.iq.transformer.TermTypeTermLiftTransformer = it.unibz.inf.ontop.iq.transformer.impl.DefaultTermTypeTermVisitingTreeTransformer
 it.unibz.inf.ontop.iq.optimizer.OrderBySimplifier = it.unibz.inf.ontop.iq.optimizer.impl.OrderBySimplifierImpl
 it.unibz.inf.ontop.iq.optimizer.AggregationSimplifier = it.unibz.inf.ontop.iq.optimizer.impl.AggregationSimplifierImpl
+it.unibz.inf.ontop.iq.optimizer.PreventDistinctOptimizer = it.unibz.inf.ontop.iq.optimizer.impl.PreventDistinctOptimizerImpl
 it.unibz.inf.ontop.iq.optimizer.PostProcessableFunctionLifter = it.unibz.inf.ontop.iq.optimizer.impl.PostProcessableFunctionLifterImpl
 it.unibz.inf.ontop.iq.transformer.DefinitionPushDownTransformer = it.unibz.inf.ontop.iq.transformer.impl.DefinitionPushDownTransformerImpl
 it.unibz.inf.ontop.iq.optimizer.LeftJoinIQOptimizer = it.unibz.inf.ontop.iq.optimizer.impl.DefaultCompositeLeftJoinIQOptimizer

--- a/core/optimization/src/main/resources/it/unibz/inf/ontop/injection/optimization-default.properties
+++ b/core/optimization/src/main/resources/it/unibz/inf/ontop/injection/optimization-default.properties
@@ -32,3 +32,4 @@ it.unibz.inf.ontop.iq.optimizer.BelowDistinctJoinWithClassUnionOptimizer = it.un
 it.unibz.inf.ontop.iq.optimizer.FlattenLifter=it.unibz.inf.ontop.iq.optimizer.impl.CompositeFlattenLifter
 it.unibz.inf.ontop.iq.optimizer.FilterLifter=it.unibz.inf.ontop.iq.optimizer.impl.FilterLifterImpl
 it.unibz.inf.ontop.iq.optimizer.BooleanExpressionPushDownOptimizer=it.unibz.inf.ontop.iq.optimizer.impl.BooleanExpressionPushDownOptimizerImpl
+it.unibz.inf.ontop.iq.optimizer.splitter.PreventDistinctProjectionSplitter=it.unibz.inf.ontop.iq.optimizer.splitter.impl.PreventDistinctProjectionSplitterImpl

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/PreventDistinctTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/PreventDistinctTest.java
@@ -100,6 +100,45 @@ public class PreventDistinctTest {
     }
 
     @Test
+    public void testPreventDistinctMoreVariables() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ANS1_AR3_PREDICATE, X, A, Y);
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(T1_AR2, ImmutableMap.of(0, A, 1, B));
+        DistinctNode distinctNode = IQ_FACTORY.createDistinctNode();
+        Substitution<ImmutableTerm> substitution = SUBSTITUTION_FACTORY.getSubstitution(X,
+                TERM_FACTORY.getImmutableFunctionalTerm(SANITIZE_FUNCTION, B),
+                Y, A);
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, X, Y), substitution);
+
+        UnaryIQTree tree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createUnaryIQTree(
+                        distinctNode,
+                        dataNode
+                ));
+
+        IQ initialQuery = IQ_FACTORY.createIQ(
+                projectionAtom,
+                tree);
+
+        IQTree expectedResult = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, X, Y), SUBSTITUTION_FACTORY.getSubstitution(Y, A)),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createDistinctNode(),
+                        IQ_FACTORY.createUnaryIQTree(
+                                IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, X), SUBSTITUTION_FACTORY.getSubstitution(X, TERM_FACTORY.getImmutableFunctionalTerm(
+                                        SANITIZE_FUNCTION,
+                                        B
+                                ))),
+                                dataNode
+                        )
+                )
+        );
+
+        optimizeAndCompare(initialQuery, IQ_FACTORY.createIQ(projectionAtom, expectedResult));
+    }
+
+    @Test
     public void testPreventDistinctIndirect() {
         DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ANS1_AR2_PREDICATE, X, A);
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/PreventDistinctTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/PreventDistinctTest.java
@@ -40,7 +40,7 @@ public class PreventDistinctTest {
     private final static FunctionSymbol UNARY_FUNCTION;
     private final static FunctionSymbol BINARY_FUNCTION;
 
-    private final static Variable PUSH_PREVENT_DISTINCT_0;
+    private final static Variable PUSH_PREVENT_DISTINCT;
 
     static {
         OfflineMetadataProviderBuilder3 builder = createMetadataProviderBuilder();
@@ -54,7 +54,7 @@ public class PreventDistinctTest {
         UNARY_FUNCTION = makeFunctionSymbol("UNARY", ImmutableList.of(ALLOW_DISTINCT_TYPE), ALLOW_DISTINCT_TYPE);
         BINARY_FUNCTION = makeFunctionSymbol("BINARY", ImmutableList.of(PREVENT_DISTINCT_TYPE, PREVENT_DISTINCT_TYPE), ALLOW_DISTINCT_TYPE);
 
-        PUSH_PREVENT_DISTINCT_0 = TERM_FACTORY.getVariable("pushPreventDistinctf0");
+        PUSH_PREVENT_DISTINCT = TERM_FACTORY.getVariable("pushPreventDistinct");
     }
 
     @Test
@@ -121,12 +121,12 @@ public class PreventDistinctTest {
                 IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, X), SUBSTITUTION_FACTORY.getSubstitution(X,
                         TERM_FACTORY.getImmutableFunctionalTerm(
                                 UNARY_FUNCTION,
-                                PUSH_PREVENT_DISTINCT_0
+                                PUSH_PREVENT_DISTINCT
                         ))),
                 IQ_FACTORY.createUnaryIQTree(
                         IQ_FACTORY.createDistinctNode(),
                         IQ_FACTORY.createUnaryIQTree(
-                                IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, PUSH_PREVENT_DISTINCT_0), SUBSTITUTION_FACTORY.getSubstitution(PUSH_PREVENT_DISTINCT_0, TERM_FACTORY.getImmutableFunctionalTerm(
+                                IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, PUSH_PREVENT_DISTINCT), SUBSTITUTION_FACTORY.getSubstitution(PUSH_PREVENT_DISTINCT, TERM_FACTORY.getImmutableFunctionalTerm(
                                         SANITIZE_FUNCTION,
                                         B
                                 ))),

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/PreventDistinctTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/PreventDistinctTest.java
@@ -1,0 +1,242 @@
+package it.unibz.inf.ontop.iq.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.dbschema.RelationDefinition;
+import it.unibz.inf.ontop.iq.IQ;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.UnaryIQTree;
+import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.model.atom.DistinctVariableOnlyDataAtom;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.model.term.functionsymbol.FunctionSymbol;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.impl.AbstractTypedDBFunctionSymbol;
+import it.unibz.inf.ontop.model.type.*;
+import it.unibz.inf.ontop.model.type.impl.DBTermTypeImpl;
+import it.unibz.inf.ontop.substitution.Substitution;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static it.unibz.inf.ontop.OptimizationTestingTools.*;
+import static org.junit.Assert.assertEquals;
+
+public class PreventDistinctTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PreventDistinctTest.class);
+    public final static RelationDefinition T1_AR2;
+
+    private final static DBTermType ALLOW_DISTINCT_TYPE;
+    private final static DBTermType PREVENT_DISTINCT_TYPE;
+
+    private final static FunctionSymbol KEEP_PREVENT_FUNCTION;
+    private final static FunctionSymbol SANITIZE_FUNCTION;
+    private final static FunctionSymbol UNARY_FUNCTION;
+    private final static FunctionSymbol BINARY_FUNCTION;
+
+    private final static Variable PUSH_PREVENT_DISTINCT_0;
+
+    static {
+        OfflineMetadataProviderBuilder3 builder = createMetadataProviderBuilder();
+        T1_AR2 = builder.createRelationWithFD(1, 2, true);
+        var ancestry = TYPE_FACTORY.getDBTypeFactory().getDBStringType().getAncestry();
+        ALLOW_DISTINCT_TYPE = makeType("ALLOW_DISTINCT", ancestry, true);
+        PREVENT_DISTINCT_TYPE = makeType("PREVENT_DISTINCT", ancestry, false);
+
+        SANITIZE_FUNCTION = makeFunctionSymbol("SANITIZE", ImmutableList.of(PREVENT_DISTINCT_TYPE), ALLOW_DISTINCT_TYPE);
+        KEEP_PREVENT_FUNCTION = makeFunctionSymbol("KEEP_PREVENT", ImmutableList.of(PREVENT_DISTINCT_TYPE), PREVENT_DISTINCT_TYPE);
+        UNARY_FUNCTION = makeFunctionSymbol("UNARY", ImmutableList.of(ALLOW_DISTINCT_TYPE), ALLOW_DISTINCT_TYPE);
+        BINARY_FUNCTION = makeFunctionSymbol("BINARY", ImmutableList.of(PREVENT_DISTINCT_TYPE, PREVENT_DISTINCT_TYPE), ALLOW_DISTINCT_TYPE);
+
+        PUSH_PREVENT_DISTINCT_0 = TERM_FACTORY.getVariable("pushPreventDistinctf0");
+    }
+
+    @Test
+    public void testPreventDistinctDirect() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ANS1_AR2_PREDICATE, X, A);
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(T1_AR2, ImmutableMap.of(0, A, 1, B));
+        DistinctNode distinctNode = IQ_FACTORY.createDistinctNode();
+        Substitution<ImmutableTerm> substitution = SUBSTITUTION_FACTORY.getSubstitution(X,
+                TERM_FACTORY.getImmutableFunctionalTerm(SANITIZE_FUNCTION, B));
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, X), substitution);
+
+        UnaryIQTree tree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createUnaryIQTree(
+                        distinctNode,
+                        dataNode
+                ));
+
+        IQ initialQuery = IQ_FACTORY.createIQ(
+                projectionAtom,
+                tree);
+
+        IQTree expectedResult = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, X), SUBSTITUTION_FACTORY.getSubstitution()),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createDistinctNode(),
+                        IQ_FACTORY.createUnaryIQTree(
+                                IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, X), SUBSTITUTION_FACTORY.getSubstitution(X, TERM_FACTORY.getImmutableFunctionalTerm(
+                                        SANITIZE_FUNCTION,
+                                        B
+                                ))),
+                                dataNode
+                        )
+                )
+        );
+
+        optimizeAndCompare(initialQuery, IQ_FACTORY.createIQ(projectionAtom, expectedResult));
+    }
+
+    @Test
+    public void testPreventDistinctIndirect() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ANS1_AR2_PREDICATE, X, A);
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(T1_AR2, ImmutableMap.of(0, A, 1, B));
+        DistinctNode distinctNode = IQ_FACTORY.createDistinctNode();
+        Substitution<ImmutableTerm> substitution = SUBSTITUTION_FACTORY.getSubstitution(X,
+                TERM_FACTORY.getImmutableFunctionalTerm(UNARY_FUNCTION,
+                        TERM_FACTORY.getImmutableFunctionalTerm(SANITIZE_FUNCTION, B)));
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, X), substitution);
+
+        UnaryIQTree tree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createUnaryIQTree(
+                        distinctNode,
+                        dataNode
+                ));
+
+        IQ initialQuery = IQ_FACTORY.createIQ(
+                projectionAtom,
+                tree);
+
+        IQTree expectedResult = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, X), SUBSTITUTION_FACTORY.getSubstitution(X,
+                        TERM_FACTORY.getImmutableFunctionalTerm(
+                                UNARY_FUNCTION,
+                                PUSH_PREVENT_DISTINCT_0
+                        ))),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createDistinctNode(),
+                        IQ_FACTORY.createUnaryIQTree(
+                                IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, PUSH_PREVENT_DISTINCT_0), SUBSTITUTION_FACTORY.getSubstitution(PUSH_PREVENT_DISTINCT_0, TERM_FACTORY.getImmutableFunctionalTerm(
+                                        SANITIZE_FUNCTION,
+                                        B
+                                ))),
+                                dataNode
+                        )
+                )
+        );
+
+        optimizeAndCompare(initialQuery, IQ_FACTORY.createIQ(projectionAtom, expectedResult));
+    }
+
+    @Test
+    public void testPreventMultiple() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ANS1_AR2_PREDICATE, X, A);
+
+        ExtensionalDataNode dataNode = IQ_FACTORY.createExtensionalDataNode(T1_AR2, ImmutableMap.of(0, A, 1, B));
+        DistinctNode distinctNode = IQ_FACTORY.createDistinctNode();
+        Substitution<ImmutableTerm> substitution = SUBSTITUTION_FACTORY.getSubstitution(X,
+                TERM_FACTORY.getImmutableFunctionalTerm(BINARY_FUNCTION,
+                        TERM_FACTORY.getImmutableFunctionalTerm(KEEP_PREVENT_FUNCTION, B),
+                        TERM_FACTORY.getImmutableFunctionalTerm(KEEP_PREVENT_FUNCTION, B)));
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, X), substitution);
+
+        UnaryIQTree tree = IQ_FACTORY.createUnaryIQTree(
+                constructionNode,
+                IQ_FACTORY.createUnaryIQTree(
+                        distinctNode,
+                        dataNode
+                ));
+
+        IQ initialQuery = IQ_FACTORY.createIQ(
+                projectionAtom,
+                tree);
+
+        IQTree expectedResult = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, X), SUBSTITUTION_FACTORY.getSubstitution()),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createDistinctNode(),
+                        IQ_FACTORY.createUnaryIQTree(
+                                IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, X), SUBSTITUTION_FACTORY.getSubstitution(X, TERM_FACTORY.getImmutableFunctionalTerm(
+                                        BINARY_FUNCTION,
+                                        TERM_FACTORY.getImmutableFunctionalTerm(KEEP_PREVENT_FUNCTION, B),
+                                        TERM_FACTORY.getImmutableFunctionalTerm(KEEP_PREVENT_FUNCTION, B)
+                                ))),
+                                dataNode
+                        )
+                )
+        );
+
+        optimizeAndCompare(initialQuery, IQ_FACTORY.createIQ(projectionAtom, expectedResult));
+    }
+
+    private void optimizeAndCompare(IQ initialQuery, IQ expectedQuery) {
+        IQ optimizedQuery = GENERAL_STRUCTURAL_AND_SEMANTIC_IQ_OPTIMIZER.optimize(initialQuery);
+        LOGGER.debug("Initial query: {}", initialQuery);
+        assertEquals(expectedQuery, optimizedQuery);
+        LOGGER.debug("Optimized query: {}", optimizedQuery);
+    }
+
+    private static FunctionSymbol makeFunctionSymbol(String name, ImmutableList<TermType> types, DBTermType targetType) {
+        return new AbstractTypedDBFunctionSymbol(name, types, targetType) {
+            @Override
+            protected boolean isAlwaysInjectiveInTheAbsenceOfNonInjectiveFunctionalTerms() {
+                return true;
+            }
+
+            @Override
+            public boolean canBePostProcessed(ImmutableList<? extends ImmutableTerm> arguments) {
+                return false;
+            }
+
+            @Override
+            public String getNativeDBString(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+                return name;
+            }
+        };
+    }
+
+    private static DBTermType makeType(String name, TermTypeAncestry ancestry, boolean allowDistinct) {
+        return new DBTermTypeImpl(name, ancestry, false, DBTermType.Category.OTHER) {
+
+            @Override
+            public boolean isPreventDistinctRecommended() {
+                return !allowDistinct;
+            }
+
+            @Override
+            public Optional<RDFDatatype> getNaturalRDFDatatype() {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean isNeedingIRISafeEncoding() {
+                return false;
+            }
+
+            @Override
+            public boolean areEqualitiesStrict() {
+                return false;
+            }
+
+            @Override
+            public Optional<Boolean> areEqualitiesStrict(DBTermType otherType) {
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean areEqualitiesBetweenTwoDBAttributesStrict() {
+                return false;
+            }
+        };
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/BigQueryDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/BigQueryDBFunctionSymbolFactory.java
@@ -20,6 +20,7 @@ public class BigQueryDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
     private static final String REGEXP_CONTAINS_STR = "REGEXP_CONTAINS";
     private static final String TO_JSON = "TO_JSON";
     private static final String JSON_VALUE = "JSON_VALUE";
+    private static final String JSON_VALUE_ARRAY = "JSON_VALUE_ARRAY";
     private DBBooleanFunctionSymbol regexpContains;
 
     @Inject
@@ -44,7 +45,16 @@ public class BigQueryDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
         DBBooleanFunctionSymbol regexpContains = new DefaultSQLSimpleDBBooleanFunctionSymbol(REGEXP_CONTAINS_STR, 2, dbBooleanType,
                 abstractRootDBType);
         DBFunctionSymbol toJson = new DefaultSQLSimpleTypedDBFunctionSymbol(TO_JSON, 1, typeFactory.getDBTypeFactory().getDBJsonType(), true, abstractRootDBType);
-        DBFunctionSymbol jsonValue = new DefaultSQLSimpleTypedDBFunctionSymbol(JSON_VALUE, 2, abstractRootDBType, false, abstractRootDBType) {
+        DBFunctionSymbol jsonValue = new DefaultSQLSimpleTypedDBFunctionSymbol(JSON_VALUE, 2, typeFactory.getDBTypeFactory().getDBStringType(), false, abstractRootDBType) {
+            @Override
+            protected boolean mayReturnNullWithoutNullArguments() {
+                return true;
+            }
+        };
+        DBFunctionSymbol jsonValueArray = new DefaultSQLSimpleTypedDBFunctionSymbol(
+                JSON_VALUE_ARRAY, 2,
+                typeFactory.getDBTypeFactory().getDBArrayType(typeFactory.getDBTypeFactory().getDBStringType()),
+                false, abstractRootDBType) {
             @Override
             protected boolean mayReturnNullWithoutNullArguments() {
                 return true;
@@ -53,6 +63,7 @@ public class BigQueryDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
         table.put(REGEXP_CONTAINS_STR, 2, regexpContains);
         table.put(TO_JSON, 1, toJson);
         table.put(JSON_VALUE, 2, jsonValue);
+        table.put(JSON_VALUE_ARRAY, 2, jsonValueArray);
 
         return ImmutableTable.copyOf(table);
     }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/BigQueryDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/BigQueryDBFunctionSymbolFactory.java
@@ -18,6 +18,8 @@ public class BigQueryDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
     private static final String NOT_YET_SUPPORTED_MSG = "Not yet supported for BigQuery";
 
     private static final String REGEXP_CONTAINS_STR = "REGEXP_CONTAINS";
+    private static final String TO_JSON = "TO_JSON";
+    private static final String JSON_VALUE = "JSON_VALUE";
     private DBBooleanFunctionSymbol regexpContains;
 
     @Inject
@@ -41,7 +43,16 @@ public class BigQueryDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
         table.remove(REGEXP_LIKE_STR, 3);
         DBBooleanFunctionSymbol regexpContains = new DefaultSQLSimpleDBBooleanFunctionSymbol(REGEXP_CONTAINS_STR, 2, dbBooleanType,
                 abstractRootDBType);
+        DBFunctionSymbol toJson = new DefaultSQLSimpleTypedDBFunctionSymbol(TO_JSON, 1, typeFactory.getDBTypeFactory().getDBJsonType(), true, abstractRootDBType);
+        DBFunctionSymbol jsonValue = new DefaultSQLSimpleTypedDBFunctionSymbol(JSON_VALUE, 2, abstractRootDBType, false, abstractRootDBType) {
+            @Override
+            protected boolean mayReturnNullWithoutNullArguments() {
+                return true;
+            }
+        };
         table.put(REGEXP_CONTAINS_STR, 2, regexpContains);
+        table.put(TO_JSON, 1, toJson);
+        table.put(JSON_VALUE, 2, jsonValue);
 
         return ImmutableTable.copyOf(table);
     }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/BigQueryDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/BigQueryDBTypeFactory.java
@@ -22,6 +22,7 @@ public class BigQueryDBTypeFactory extends DefaultSQLDBTypeFactory {
     protected static final String GEOGRAPHY_STR = "GEOGRAPHY";
     protected static final String JSON_STR = "JSON";
     protected static final String RECORD_STR = "RECORD";
+    protected static final String STRUCT_STR = "STRUCT";
     protected static final String BYTES_STR = "BYTES";
 
     protected static final String ARRAY_STR = "ARRAY<T>";
@@ -58,7 +59,12 @@ public class BigQueryDBTypeFactory extends DefaultSQLDBTypeFactory {
                 return Optional.empty();
 
             return Optional.of(typeFactory.getDBTypeFactory().getDBTermType(contents));
-        });
+        }) {
+            @Override
+            public boolean isPreventDistinctRecommended() {
+                return true;
+            }
+        };
 
         List<GenericDBTermType> list = new ArrayList<>();
         list.add(abstractArrayType);
@@ -108,6 +114,12 @@ public class BigQueryDBTypeFactory extends DefaultSQLDBTypeFactory {
                 return true;
             }
         });
+        map.put(STRUCT_STR, new NonStringNonNumberNonBooleanNonDatetimeDBTermType(STRUCT_STR, rootAncestry, xsdString) {
+            @Override
+            public boolean isPreventDistinctRecommended() {
+                return true;
+            }
+        });
 
         map.remove(DOUBLE_PREC_STR);
         map.remove(VARCHAR_STR);
@@ -126,6 +138,7 @@ public class BigQueryDBTypeFactory extends DefaultSQLDBTypeFactory {
         map.put(DefaultTypeCode.GEOGRAPHY, GEOGRAPHY_STR);
         map.put(DefaultTypeCode.JSON, JSON_STR);
         map.put(DefaultTypeCode.HEXBINARY, BYTES_STR);
+        map.put(DefaultTypeCode.ARRAY, ARRAY_STR);
 
         return ImmutableMap.copyOf(map);
     }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/BigQueryDBTypeFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/BigQueryDBTypeFactory.java
@@ -21,6 +21,7 @@ public class BigQueryDBTypeFactory extends DefaultSQLDBTypeFactory {
 
     protected static final String GEOGRAPHY_STR = "GEOGRAPHY";
     protected static final String JSON_STR = "JSON";
+    protected static final String RECORD_STR = "RECORD";
     protected static final String BYTES_STR = "BYTES";
 
     protected static final String ARRAY_STR = "ARRAY<T>";
@@ -94,7 +95,19 @@ public class BigQueryDBTypeFactory extends DefaultSQLDBTypeFactory {
         map.put(BYTES_STR, bytesType);
 
         map.put(GEOGRAPHY_STR, new NonStringNonNumberNonBooleanNonDatetimeDBTermType(GEOGRAPHY_STR, rootAncestry, xsdString));
-        map.put(JSON_STR, new JsonDBTermTypeImpl(JSON_STR, rootAncestry));
+        map.put(JSON_STR, new JsonDBTermTypeImpl(JSON_STR, rootAncestry) {
+            @Override
+            public boolean isPreventDistinctRecommended() {
+                return true;
+            }
+        });
+        //TODO: once the STRUCT db-type is fully implemented, this part can be updated.
+        map.put(RECORD_STR, new NonStringNonNumberNonBooleanNonDatetimeDBTermType(RECORD_STR, rootAncestry, xsdString) {
+            @Override
+            public boolean isPreventDistinctRecommended() {
+                return true;
+            }
+        });
 
         map.remove(DOUBLE_PREC_STR);
         map.remove(VARCHAR_STR);

--- a/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/answering/reformulation/generation/PostProcessingProjectionSplitter.java
+++ b/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/answering/reformulation/generation/PostProcessingProjectionSplitter.java
@@ -1,17 +1,10 @@
 package it.unibz.inf.ontop.answering.reformulation.generation;
 
 import it.unibz.inf.ontop.iq.IQ;
-import it.unibz.inf.ontop.iq.IQTree;
-import it.unibz.inf.ontop.iq.node.ConstructionNode;
-import it.unibz.inf.ontop.utils.VariableGenerator;
+import it.unibz.inf.ontop.iq.optimizer.splitter.ProjectionSplitter;
 
-public interface PostProcessingProjectionSplitter {
+public interface PostProcessingProjectionSplitter extends ProjectionSplitter {
 
-    PostProcessingSplit split(IQ iq, boolean avoidPostProcessing);
+    ProjectionSplit split(IQ iq, boolean avoidPostProcessing);
 
-    interface PostProcessingSplit {
-        ConstructionNode getPostProcessingConstructionNode();
-        IQTree getSubTree();
-        VariableGenerator getVariableGenerator();
-    }
 }

--- a/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/answering/reformulation/generation/impl/PostProcessingProjectionSplitterImpl.java
+++ b/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/answering/reformulation/generation/impl/PostProcessingProjectionSplitterImpl.java
@@ -1,45 +1,35 @@
 package it.unibz.inf.ontop.answering.reformulation.generation.impl;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import it.unibz.inf.ontop.answering.reformulation.generation.PostProcessingProjectionSplitter;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.IQ;
 import it.unibz.inf.ontop.iq.IQTree;
-import it.unibz.inf.ontop.iq.UnaryIQTree;
-import it.unibz.inf.ontop.iq.node.*;
 import it.unibz.inf.ontop.iq.node.normalization.DistinctNormalizer;
+import it.unibz.inf.ontop.iq.optimizer.splitter.impl.ProjectionSplitterImpl;
 import it.unibz.inf.ontop.iq.tools.ProjectionDecomposer;
-import it.unibz.inf.ontop.iq.tools.ProjectionDecomposer.ProjectionDecomposition;
 import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.model.term.functionsymbol.db.DBFunctionSymbol;
 import it.unibz.inf.ontop.substitution.SubstitutionFactory;
 import it.unibz.inf.ontop.utils.CoreUtilsFactory;
 import it.unibz.inf.ontop.utils.VariableGenerator;
 
-import java.util.Optional;
+public class PostProcessingProjectionSplitterImpl extends ProjectionSplitterImpl implements PostProcessingProjectionSplitter {
 
-public class PostProcessingProjectionSplitterImpl implements PostProcessingProjectionSplitter {
-
-    private final IntermediateQueryFactory iqFactory;
-    private final SubstitutionFactory substitutionFactory;
     private final ProjectionDecomposer avoidPostProcessingDecomposer;
     private final ProjectionDecomposer proPostProcessingDecomposer;
-    private final DistinctNormalizer distinctNormalizer;
 
     @Inject
     private PostProcessingProjectionSplitterImpl(IntermediateQueryFactory iqFactory,
                                                  SubstitutionFactory substitutionFactory,
                                                  CoreUtilsFactory coreUtilsFactory,
                                                  DistinctNormalizer distinctNormalizer) {
-        this.iqFactory = iqFactory;
-        this.substitutionFactory = substitutionFactory;
+        super(iqFactory, substitutionFactory, distinctNormalizer);
         this.avoidPostProcessingDecomposer = coreUtilsFactory.createProjectionDecomposer(
                 PostProcessingProjectionSplitterImpl::hasFunctionalToBePostProcessed,
                 t -> !(t.isNull() || (t instanceof Variable) || (t instanceof DBConstant)));
         this.proPostProcessingDecomposer = coreUtilsFactory.createProjectionDecomposer(
                 ImmutableFunctionalTerm::canBePostProcessed, t -> true);
-        this.distinctNormalizer = distinctNormalizer;
     }
 
     private static boolean hasFunctionalToBePostProcessed(ImmutableFunctionalTerm functionalTerm) {
@@ -61,139 +51,13 @@ public class PostProcessingProjectionSplitterImpl implements PostProcessingProje
     }
 
     @Override
-    public PostProcessingSplit split(IQ initialIQ, boolean avoidPostProcessing) {
-
-        IQTree topTree = initialIQ.getTree();
-        VariableGenerator variableGenerator = initialIQ.getVariableGenerator();
-
-        return Optional.of(topTree)
-                .filter(t -> t.getRootNode() instanceof ConstructionNode)
-                .map(t -> (UnaryIQTree) t)
-                .map(t -> split(t, variableGenerator, avoidPostProcessing))
-                .orElseGet(() -> new PostProcessingSplitImpl(
-                        // "Useless" construction node --> no post-processing
-                        iqFactory.createConstructionNode(topTree.getVariables(), substitutionFactory.getSubstitution()),
-                        topTree,
-                        variableGenerator));
+    public ProjectionSplit split(IQ initialIQ, boolean avoidPostProcessing) {
+        return split(initialIQ, avoidPostProcessing ? avoidPostProcessingDecomposer : proPostProcessingDecomposer);
     }
 
 
-    private PostProcessingSplit split(UnaryIQTree initialTree, VariableGenerator variableGenerator, boolean avoidPostProcessing) {
-
-        ConstructionNode initialRootNode = (ConstructionNode) initialTree.getRootNode();
-        IQTree initialSubTree = initialTree.getChild();
-
-        ProjectionDecomposer decomposer = avoidPostProcessing ? avoidPostProcessingDecomposer : proPostProcessingDecomposer;
-
-        ProjectionDecomposition decomposition = decomposer.decomposeSubstitution(initialRootNode.getSubstitution(), variableGenerator);
-
-        ConstructionNode postProcessingNode = iqFactory.createConstructionNode(initialRootNode.getVariables(),
-                decomposition.getTopSubstitution()
-                .orElseGet(substitutionFactory::getSubstitution));
-
-        ImmutableSet<Variable> newSubTreeVariables = postProcessingNode.getChildVariables();
-
-        /*
-         * NB: the presence of a subSubstitution implies the need to project new variables.
-         */
-        IQTree newSubTree = initialSubTree.getVariables().equals(newSubTreeVariables)
-                ? initialSubTree
-                : iqFactory.createUnaryIQTree(
-                    decomposition.getSubSubstitution()
-                        .map(s -> iqFactory.createConstructionNode(newSubTreeVariables, s))
-                        .orElseGet(() -> iqFactory.createConstructionNode(newSubTreeVariables)),
-                    initialSubTree);
-
-        return new PostProcessingSplitImpl(postProcessingNode,
-                normalizeNewSubTree(newSubTree, variableGenerator),
-                variableGenerator);
-    }
-
-    /**
-     * Tries to push down the possible root construction node under a SLICE and a DISTINCT
-     *
-     */
-    private IQTree normalizeNewSubTree(IQTree newSubTree, VariableGenerator variableGenerator) {
-        return Optional.of(newSubTree.getRootNode())
-                .filter(n -> n instanceof ConstructionNode)
-                .map(n -> (ConstructionNode) n)
-                .map(c -> insertConstructionNode(((UnaryIQTree) newSubTree).getChild(), c, variableGenerator))
-                .orElse(newSubTree);
-    }
-
-    /**
-     * Recursive
-     */
-    private IQTree insertConstructionNode(IQTree tree, ConstructionNode constructionNode, VariableGenerator variableGenerator) {
-        QueryNode rootNode = tree.getRootNode();
-        if (rootNode instanceof SliceNode)
-            return iqFactory.createUnaryIQTree(
-                    (UnaryOperatorNode) rootNode,
-                    // Recursive
-                    insertConstructionNode(((UnaryIQTree)tree).getChild(), constructionNode, variableGenerator));
-        /*
-         * Distinct:
-         * If
-         *  1. the construction node could be fully lifted above the distinct,
-         *  2. AND the distinct old projects the variables required by the construction node
-         * THEN it can be pushed under the DISTINCT
-         *
-         * "Reverses" the binding lift operation except that here either all the bindings are pushed down or none.
-         *
-         * TODO: relax the condition 1?
-         *
-         */
-        else if (rootNode instanceof DistinctNode) {
-            IQTree childTree = ((UnaryIQTree) tree).getChild();
-
-            // Stops if the child tree is projecting more variables than what the construction node expects
-            if (!childTree.getVariables().equals(constructionNode.getChildVariables()))
-                return iqFactory.createUnaryIQTree(
-                        constructionNode,
-                        tree
-                );
-
-            UnaryIQTree possibleChildTree = iqFactory.createUnaryIQTree(constructionNode, childTree);
-
-            DistinctNode distinctNode = (DistinctNode) rootNode;
-
-            IQTree liftedTree = distinctNormalizer.normalizeForOptimization(distinctNode, possibleChildTree, variableGenerator,
-                    iqFactory.createIQTreeCache());
-
-            return liftedTree.getRootNode().equals(constructionNode)
-                    ? iqFactory.createUnaryIQTree(distinctNode, possibleChildTree)
-                    : iqFactory.createUnaryIQTree(constructionNode, tree);
-        }
-        else
-            return iqFactory.createUnaryIQTree(constructionNode, tree);
-    }
-
-    static class PostProcessingSplitImpl implements PostProcessingSplit {
-
-        private final ConstructionNode postProcessingConstructionNode;
-        private final IQTree subTree;
-        private final VariableGenerator variableGenerator;
-
-        PostProcessingSplitImpl(ConstructionNode postProcessingConstructionNode, IQTree subTree,
-                                VariableGenerator variableGenerator) {
-            this.postProcessingConstructionNode = postProcessingConstructionNode;
-            this.subTree = subTree;
-            this.variableGenerator = variableGenerator;
-        }
-
-        @Override
-        public ConstructionNode getPostProcessingConstructionNode() {
-            return postProcessingConstructionNode;
-        }
-
-        @Override
-        public IQTree getSubTree() {
-            return subTree;
-        }
-
-        @Override
-        public VariableGenerator getVariableGenerator() {
-            return variableGenerator;
-        }
+    @Override
+    public ProjectionSplit split(IQTree tree, VariableGenerator variableGenerator) {
+        return split(tree, variableGenerator, avoidPostProcessingDecomposer);
     }
 }

--- a/engine/reformulation/sql/src/main/java/it/unibz/inf/ontop/answering/reformulation/generation/impl/SQLGeneratorImpl.java
+++ b/engine/reformulation/sql/src/main/java/it/unibz/inf/ontop/answering/reformulation/generation/impl/SQLGeneratorImpl.java
@@ -3,6 +3,7 @@ package it.unibz.inf.ontop.answering.reformulation.generation.impl;
 
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import it.unibz.inf.ontop.iq.optimizer.splitter.ProjectionSplitter;
 import it.unibz.inf.ontop.injection.OntopReformulationSQLSettings;
 import it.unibz.inf.ontop.iq.transform.IQTree2NativeNodeGenerator;
 import it.unibz.inf.ontop.answering.reformulation.generation.NativeQueryGenerator;
@@ -93,7 +94,7 @@ public class SQLGeneratorImpl implements NativeQueryGenerator {
         IQ liftedIQ = functionLifter.optimize(rdfTypeLiftedIQ);
         LOGGER.debug("After lifting the post-processable function symbols:\n{}\n", liftedIQ);
 
-        PostProcessingProjectionSplitter.PostProcessingSplit split = projectionSplitter.split(liftedIQ, avoidPostProcessing);
+        ProjectionSplitter.ProjectionSplit split = projectionSplitter.split(liftedIQ, avoidPostProcessing);
 
         IQTree normalizedSubTree = normalizeSubTree(split.getSubTree(), split.getVariableGenerator());
         // Late detection of emptiness
@@ -103,7 +104,7 @@ public class SQLGeneratorImpl implements NativeQueryGenerator {
 
         NativeNode nativeNode = generateNativeNode(normalizedSubTree, tolerateUnknownTypes);
 
-        UnaryIQTree newTree = iqFactory.createUnaryIQTree(split.getPostProcessingConstructionNode(), nativeNode);
+        UnaryIQTree newTree = iqFactory.createUnaryIQTree(split.getConstructionNode(), nativeNode);
 
         return iqFactory.createIQ(query.getProjectionAtom(), newTree);
     }


### PR DESCRIPTION
Implemented a flag for data types to indicate that they should not be used with `DISTINCT`.

Should a case appear where a function uses such a data type, the construction will be split into a part that is possible above DISTINCT and a part that must be below it, and Ontop will attempt to create a new construction node below the DISTINCT that contains the function call, so that the limitation may be circumvented.

Also supports cases with more complex function calls, (`F(G(X))`, `F(G(X), H(X))`, etc.).

The following conditions must hold for this transformation to be applied:
    - A functional dependency from another projected variable to the variables used in the pushed-down expression must exist.
    - The functions that are pushed down must all be deterministic.