### PR TITLE
Left-join merge made to robust to complex strict-equalities

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/EmployeeTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/EmployeeTest.java
@@ -1,0 +1,54 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EmployeeTest extends AbstractRDF4JTest {
+
+    private static final String OBDA_FILE = "/employee/employee.obda";
+    private static final String SQL_SCRIPT = "/employee/employee.sql";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void testMergeLJsWithValues() {
+        String sparql = "PREFIX schema: <http://schema.org/>\n" +
+                "PREFIX : <http://employee.example.org/voc#>\n" +
+                "\n" +
+                "SELECT *\n" +
+                "WHERE {\n" +
+                "  VALUES ?p { \n" +
+                "   <http://employee.example.org/data/person/1> \n " +
+                "   <http://employee.example.org/data/person/2> \n" +
+                "  } \n" +
+                "  OPTIONAL { \n" +
+                "      ?p :firstName ?fName . \n" +
+                "  }\n" +
+                "  OPTIONAL { \n" +
+                "     ?p  :lastName ?lastName . \n" +
+                "  }\n" +
+                "}\n";
+
+        String sql = reformulateIntoNativeQuery(sparql);
+
+        assertEquals(1, StringUtils.countMatches(sql, "LEFT OUTER JOIN"));
+
+        int countResults = runQueryAndCount(sparql);
+        assertEquals(2, countResults);
+    }
+}

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/ComplexStrictEqualityLeftJoinExpliciter.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/ComplexStrictEqualityLeftJoinExpliciter.java
@@ -18,6 +18,7 @@ import it.unibz.inf.ontop.substitution.SubstitutionFactory;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import it.unibz.inf.ontop.utils.VariableGenerator;
 
+import java.util.AbstractCollection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -126,6 +127,9 @@ public class ComplexStrictEqualityLeftJoinExpliciter {
                         .collect(substitutionFactory.toSubstitution()));
     }
 
+    /**
+     * NB: excludes equalities to constants
+     */
     private boolean isDecomposibleStrictEquality(ImmutableExpression expression, ImmutableSet<Variable> leftVariables,
                                                  ImmutableSet<Variable> rightSpecificVariables) {
         if  (!(expression.getFunctionSymbol() instanceof DBStrictEqFunctionSymbol))
@@ -140,6 +144,8 @@ public class ComplexStrictEqualityLeftJoinExpliciter {
                 .collect(ImmutableCollectors.toList());
 
         return subTermVariables.stream()
+                .noneMatch(AbstractCollection::isEmpty)
+                && subTermVariables.stream()
                 .anyMatch(leftVariables::containsAll)
                 && subTermVariables.stream()
                 .anyMatch(rightSpecificVariables::containsAll);

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/ComplexStrictEqualityLeftJoinExpliciter.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/ComplexStrictEqualityLeftJoinExpliciter.java
@@ -1,0 +1,200 @@
+package it.unibz.inf.ontop.iq.optimizer.impl.lj;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import it.unibz.inf.ontop.exception.MinorOntopInternalBugException;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.node.LeftJoinNode;
+import it.unibz.inf.ontop.model.term.ImmutableExpression;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.DBStrictEqFunctionSymbol;
+import it.unibz.inf.ontop.substitution.Substitution;
+import it.unibz.inf.ontop.substitution.SubstitutionFactory;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * NOT the "normalizeForOptimization" normal form!
+ */
+@Singleton
+public class ComplexStrictEqualityLeftJoinExpliciter {
+
+    private final TermFactory termFactory;
+    private final SubstitutionFactory substitutionFactory;
+    private final IntermediateQueryFactory iqFactory;
+
+    @Inject
+    protected ComplexStrictEqualityLeftJoinExpliciter(TermFactory termFactory, SubstitutionFactory substitutionFactory,
+                                                      IntermediateQueryFactory iqFactory) {
+        this.termFactory = termFactory;
+        this.substitutionFactory = substitutionFactory;
+        this.iqFactory = iqFactory;
+    }
+
+    public LeftJoinNormalization makeComplexEqualitiesImplicit(IQTree leftChild, IQTree rightChild,
+                                                               Optional<ImmutableExpression> ljCondition, VariableGenerator variableGenerator) {
+        if (ljCondition.isPresent())
+            return makeComplexEqualitiesImplicit(leftChild, rightChild, ljCondition.get(), variableGenerator);
+
+        return new LeftJoinNormalization(leftChild, rightChild, ljCondition, false);
+    }
+
+    protected LeftJoinNormalization makeComplexEqualitiesImplicit(IQTree leftChild, IQTree rightChild,
+                                                               ImmutableExpression ljCondition, VariableGenerator variableGenerator) {
+
+        var leftVariables = leftChild.getVariables();
+
+        ImmutableSet<Variable> rightSpecificVariables = Sets.difference(rightChild.getVariables(), leftVariables)
+                .immutableCopy();
+
+        var conditionMap = ljCondition.flattenAND()
+                .collect(ImmutableCollectors.partitioningBy(e -> isDecomposibleStrictEquality(e, leftVariables, rightSpecificVariables)));
+        var strictEqualities = conditionMap.get(true);
+        if (strictEqualities == null || strictEqualities.isEmpty())
+            return new LeftJoinNormalization(leftChild, rightChild, Optional.of(ljCondition), false);
+
+        var newLJCondition = Optional.ofNullable(conditionMap.get(false))
+                .filter(cs -> !cs.isEmpty())
+                .map(termFactory::getConjunction);
+
+        var substitutionPair = computeSubstitutionPair(ImmutableSet.copyOf(strictEqualities),
+                rightSpecificVariables, variableGenerator);
+
+        var newRight = iqFactory.createUnaryIQTree(
+                iqFactory.createConstructionNode(
+                        Sets.union(substitutionPair.rightSubstitution.getDomain(), rightChild.getVariables()).immutableCopy(),
+                        substitutionPair.rightSubstitution),
+                rightChild);
+
+        IQTree newLeft = normalizeLeft(leftChild, substitutionPair.leftSubstitution, variableGenerator);
+
+        return new LeftJoinNormalization(newLeft, newRight, newLJCondition,
+                newLeft.getVariables().size() != leftVariables.size());
+    }
+
+    private SubstitutionPair computeSubstitutionPair(ImmutableSet<ImmutableExpression> strictEqualities,
+                                                     ImmutableSet<Variable> rightSpecificVariables,
+                                                     VariableGenerator variableGenerator) {
+        Map<Variable, ImmutableTerm> leftSubstitutionMap = new HashMap<>();
+        Map<Variable, ImmutableTerm> rightSubstitutionMap = new HashMap<>();
+
+        for (ImmutableExpression strictEquality : strictEqualities) {
+            ImmutableTerm rightArgument = strictEquality.getTerms().stream()
+                    .filter(t -> t.getVariableStream().anyMatch(rightSpecificVariables::contains))
+                    .findAny()
+                    .orElseThrow(() -> new MinorOntopInternalBugException("Was expecting a right argument"));
+
+            ImmutableTerm leftArgument = strictEquality.getTerm(0).equals(rightArgument)
+                    ? strictEquality.getTerm(1)
+                    : strictEquality.getTerm(0);
+
+            if (leftArgument instanceof Variable) {
+                rightSubstitutionMap.put((Variable) leftArgument, rightArgument);
+            }
+            else {
+                Variable leftVariable = variableGenerator.generateNewVariable();
+                leftSubstitutionMap.put(leftVariable, leftArgument);
+                rightSubstitutionMap.put(leftVariable, rightArgument);
+            }
+        }
+        return new SubstitutionPair(
+                leftSubstitutionMap.entrySet().stream().collect(substitutionFactory.toSubstitution()),
+                rightSubstitutionMap.entrySet().stream().collect(substitutionFactory.toSubstitution()));
+    }
+
+    private boolean isDecomposibleStrictEquality(ImmutableExpression expression, ImmutableSet<Variable> leftVariables,
+                                                 ImmutableSet<Variable> rightSpecificVariables) {
+        if  (!(expression.getFunctionSymbol() instanceof DBStrictEqFunctionSymbol))
+            return false;
+
+        // TODO: support other arities
+        if (expression.getArity() != 2)
+            return false;
+
+        var subTermVariables = expression.getTerms().stream()
+                .map(t -> t.getVariableStream().collect(ImmutableCollectors.toSet()))
+                .collect(ImmutableCollectors.toList());
+
+        return subTermVariables.stream()
+                .anyMatch(leftVariables::containsAll)
+                && subTermVariables.stream()
+                .anyMatch(rightSpecificVariables::containsAll);
+    }
+
+    private IQTree normalizeLeft(IQTree tree, Substitution<ImmutableTerm> downSubstitution, VariableGenerator variableGenerator) {
+
+        if (!((tree.getRootNode() instanceof LeftJoinNode) &&
+                tree.getChildren().get(0).getVariables()
+                        // Blocks the substitution if there is any right-specific variable in the substitution (unlikely)
+                        // Stops the normalization
+                        .containsAll(downSubstitution.getRangeVariables())))
+            return downSubstitution.isEmpty()
+                    ? tree
+                    : iqFactory.createUnaryIQTree(
+                            iqFactory.createConstructionNode(
+                                    Sets.union(downSubstitution.getDomain(), tree.getVariables()).immutableCopy(),
+                                    downSubstitution),
+                            tree);
+
+        var leftChild = tree.getChildren().get(0);
+        var rightChild = tree.getChildren().get(1);
+
+        var leftJoinNode = (LeftJoinNode) tree.getRootNode();
+
+        var leftJoinCondition = leftJoinNode.getOptionalFilterCondition();
+        if (leftJoinCondition.isEmpty()) {
+            var newLeft = normalizeLeft(leftChild, downSubstitution, variableGenerator);
+            return iqFactory.createBinaryNonCommutativeIQTree(
+                    leftJoinNode,
+                    newLeft, rightChild);
+        }
+
+        var localNormalization = makeComplexEqualitiesImplicit(leftChild, rightChild,
+                leftJoinCondition.get(), variableGenerator);
+
+        var newLeft = normalizeLeft(localNormalization.leftChild, downSubstitution, variableGenerator);
+
+        return iqFactory.createBinaryNonCommutativeIQTree(
+                iqFactory.createLeftJoinNode(localNormalization.ljCondition),
+                newLeft,
+                localNormalization.rightChild);
+    }
+
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public static class LeftJoinNormalization {
+        public final IQTree leftChild;
+        public final IQTree rightChild;
+        public final Optional<ImmutableExpression> ljCondition;
+
+        public boolean isIntroducingNewVariables;
+
+        public LeftJoinNormalization(IQTree leftChild, IQTree rightChild, Optional<ImmutableExpression> ljCondition,
+                                     boolean isIntroducingNewVariables) {
+            this.leftChild = leftChild;
+            this.rightChild = rightChild;
+            this.ljCondition = ljCondition;
+            this.isIntroducingNewVariables = isIntroducingNewVariables;
+        }
+    }
+
+    public static class SubstitutionPair {
+        public final Substitution<ImmutableTerm> leftSubstitution;
+        public final Substitution<ImmutableTerm> rightSubstitution;
+
+        public SubstitutionPair(Substitution<ImmutableTerm> leftSubstitution, Substitution<ImmutableTerm> rightSubstitution) {
+            this.leftSubstitution = leftSubstitution;
+            this.rightSubstitution = rightSubstitution;
+        }
+    }
+
+}

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/MergeLJOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/MergeLJOptimizer.java
@@ -16,6 +16,7 @@ import it.unibz.inf.ontop.iq.node.QueryNode;
 import it.unibz.inf.ontop.iq.node.normalization.impl.RightProvenanceNormalizer;
 import it.unibz.inf.ontop.iq.node.normalization.impl.RightProvenanceNormalizer.RightProvenance;
 import it.unibz.inf.ontop.iq.optimizer.LeftJoinIQOptimizer;
+import it.unibz.inf.ontop.iq.optimizer.impl.lj.ComplexStrictEqualityLeftJoinExpliciter.LeftJoinNormalization;
 import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeVisitingTransformer;
 import it.unibz.inf.ontop.model.atom.AtomFactory;
 import it.unibz.inf.ontop.model.atom.DistinctVariableOnlyDataAtom;
@@ -43,17 +44,20 @@ public class MergeLJOptimizer implements LeftJoinIQOptimizer {
     private final IntermediateQueryFactory iqFactory;
     private final CardinalitySensitiveJoinTransferLJOptimizer otherLJOptimizer;
     private final LJWithNestingOnRightToInnerJoinOptimizer ljReductionOptimizer;
+    private final ComplexStrictEqualityLeftJoinExpliciter ljConditionExpliciter;
 
     @Inject
     protected MergeLJOptimizer(RightProvenanceNormalizer rightProvenanceNormalizer,
                                CoreSingletons coreSingletons,
                                CardinalitySensitiveJoinTransferLJOptimizer joinTransferLJOptimizer,
-                               LJWithNestingOnRightToInnerJoinOptimizer ljReductionOptimizer) {
+                               LJWithNestingOnRightToInnerJoinOptimizer ljReductionOptimizer,
+                               ComplexStrictEqualityLeftJoinExpliciter ljConditionExpliciter) {
         this.rightProvenanceNormalizer = rightProvenanceNormalizer;
         this.coreSingletons = coreSingletons;
         this.iqFactory = coreSingletons.getIQFactory();
         this.otherLJOptimizer = joinTransferLJOptimizer;
         this.ljReductionOptimizer = ljReductionOptimizer;
+        this.ljConditionExpliciter = ljConditionExpliciter;
     }
 
     @Override
@@ -65,7 +69,8 @@ public class MergeLJOptimizer implements LeftJoinIQOptimizer {
                 rightProvenanceNormalizer,
                 coreSingletons,
                 otherLJOptimizer,
-                ljReductionOptimizer);
+                ljReductionOptimizer,
+                ljConditionExpliciter);
 
         IQTree newTree = initialTree.acceptTransformer(transformer);
 
@@ -83,11 +88,13 @@ public class MergeLJOptimizer implements LeftJoinIQOptimizer {
         private final AtomFactory atomFactory;
         private final SubstitutionFactory substitutionFactory;
         private final LJWithNestingOnRightToInnerJoinOptimizer ljReductionOptimizer;
+        private final ComplexStrictEqualityLeftJoinExpliciter ljConditionExpliciter;
 
         protected Transformer(VariableGenerator variableGenerator, RightProvenanceNormalizer rightProvenanceNormalizer,
                               CoreSingletons coreSingletons,
                               CardinalitySensitiveJoinTransferLJOptimizer joinTransferOptimizer,
-                              LJWithNestingOnRightToInnerJoinOptimizer ljReductionOptimizer) {
+                              LJWithNestingOnRightToInnerJoinOptimizer ljReductionOptimizer,
+                              ComplexStrictEqualityLeftJoinExpliciter ljConditionExpliciter) {
             super(coreSingletons);
             this.variableGenerator = variableGenerator;
             this.rightProvenanceNormalizer = rightProvenanceNormalizer;
@@ -96,6 +103,7 @@ public class MergeLJOptimizer implements LeftJoinIQOptimizer {
             this.atomFactory = coreSingletons.getAtomFactory();
             this.substitutionFactory = coreSingletons.getSubstitutionFactory();
             this.ljReductionOptimizer = ljReductionOptimizer;
+            this.ljConditionExpliciter = ljConditionExpliciter;
         }
 
         @Override
@@ -103,18 +111,28 @@ public class MergeLJOptimizer implements LeftJoinIQOptimizer {
             IQTree newLeftChild = transform(leftChild);
             IQTree newRightChild = transform(rightChild);
 
-            Optional<ImmutableExpression> optionalLJCondition = rootNode.getOptionalFilterCondition();
-
-            if (!tolerateLJConditionLifting(optionalLJCondition, newLeftChild, newRightChild))
+            if (!(newLeftChild.getRootNode() instanceof LeftJoinNode))
                 return buildUnoptimizedLJTree(tree, leftChild, rightChild, newLeftChild, newRightChild, rootNode);
 
-            ImmutableSet<Variable> rightSpecificVariables = Sets.difference(newRightChild.getVariables(), newLeftChild.getVariables())
+            LeftJoinNormalization normalization = ljConditionExpliciter.makeComplexEqualitiesImplicit(
+                    newLeftChild, newRightChild, rootNode.getOptionalFilterCondition(), variableGenerator);
+
+            if (!tolerateLJConditionLifting(normalization.ljCondition, newLeftChild, newRightChild))
+                return buildUnoptimizedLJTree(tree, leftChild, rightChild, newLeftChild, newRightChild, rootNode);
+
+            ImmutableSet<Variable> rightSpecificVariables = Sets.difference(normalization.rightChild.getVariables(),
+                            normalization.leftChild.getVariables())
                     .immutableCopy();
 
-            Optional<IQTree> simplifiedTree = tryToSimplify(newLeftChild, newRightChild, optionalLJCondition,
+            Optional<IQTree> simplifiedTree = tryToSimplify(normalization.leftChild, normalization.rightChild, normalization.ljCondition,
                     rightSpecificVariables, new LinkedList<>());
 
             return simplifiedTree
+                    .map(t -> normalization.isIntroducingNewVariables
+                            ? iqFactory.createUnaryIQTree(
+                                    iqFactory.createConstructionNode(tree.getVariables()), t)
+                            : t)
+                    .map(t -> t.normalizeForOptimization(variableGenerator))
                     .orElseGet(() -> buildUnoptimizedLJTree(tree, leftChild, rightChild, newLeftChild, newRightChild, rootNode));
         }
 

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/MergeLJOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/MergeLJOptimizer.java
@@ -310,9 +310,10 @@ public class MergeLJOptimizer implements LeftJoinIQOptimizer {
                     atomFactory.getRDFAnswerPredicate(1),
                     ImmutableList.of(rightProvenance.getProvenanceVariable()));
 
+            IQ minusIQ = iqFactory.createIQ(minusFakeProjectionAtom, minusTree);
+
             IQTree optimizedTree = ljReductionOptimizer.optimize(
-                    joinTransferOptimizer.optimize(
-                            iqFactory.createIQ(minusFakeProjectionAtom, minusTree)))
+                    joinTransferOptimizer.optimize(minusIQ.normalizeForOptimization()))
                     .normalizeForOptimization().getTree();
 
             return optimizedTree.isDeclaredAsEmpty();

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -3315,10 +3315,52 @@ public class LeftJoinOptimizationTest {
 
         IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, topLJTree));
 
-        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, E, 1, C,2, D));
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, F, 1, C,2, D));
 
         IQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
-                        TERM_FACTORY.getStrictEquality(TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, A), E)),
+                        TERM_FACTORY.getStrictEquality(TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, A), F)),
+                dataNode1, newRightDataNode);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, newLJTree));
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testMergeLJs18() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, E, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, F, 2, D));
+
+        DBTermType integerType = TYPE_FACTORY.getDBTypeFactory().getDBLargeIntegerType();
+        DBTermType stringType = TYPE_FACTORY.getDBTypeFactory().getDBStringType();
+        DBTermType booleanType = TYPE_FACTORY.getDBTypeFactory().getDBBooleanType();
+
+        ImmutableFunctionalTerm leftCast = TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, A);
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(leftCast, TERM_FACTORY.getDBCastFunctionalTerm(booleanType, stringType, E))),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(leftCast, TERM_FACTORY.getDBCastFunctionalTerm(booleanType, stringType, F))
+                ),
+                subLJTree,
+                dataNode3);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, topLJTree));
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, F, 1, C,2, D));
+
+        IQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(leftCast, TERM_FACTORY.getDBCastFunctionalTerm(booleanType, stringType, F))),
                 dataNode1, newRightDataNode);
 
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, newLJTree));

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -3237,10 +3237,10 @@ public class LeftJoinOptimizationTest {
 
         IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, topLJTree));
 
-        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, E, 1, C,2, D));
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, F, 1, C,2, D));
 
         IQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
-                        TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, E))),
+                        TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, F))),
                 dataNode1, newRightDataNode);
 
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, newLJTree));
@@ -3276,10 +3276,10 @@ public class LeftJoinOptimizationTest {
 
         IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, topLJTree));
 
-        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, E, 1, C,2, D));
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, F, 1, C,2, D));
 
         IQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
-                        TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, E))),
+                        TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, F))),
                 dataNode1, newRightDataNode);
 
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, newLJTree));

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -3209,6 +3209,123 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
+    @Test
+    public void testMergeLJs15() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, E, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, F, 2, D));
+
+        DBTermType integerType = TYPE_FACTORY.getDBTypeFactory().getDBLargeIntegerType();
+        DBTermType stringType = TYPE_FACTORY.getDBTypeFactory().getDBStringType();
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, E))),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, F), A)
+                ),
+                subLJTree,
+                dataNode3);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, topLJTree));
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, E, 1, C,2, D));
+
+        IQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, E))),
+                dataNode1, newRightDataNode);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, newLJTree));
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testMergeLJs16() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, E, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, F, 2, D));
+
+        DBTermType integerType = TYPE_FACTORY.getDBTypeFactory().getDBLargeIntegerType();
+        DBTermType stringType = TYPE_FACTORY.getDBTypeFactory().getDBStringType();
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, E))),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, F))
+                ),
+                subLJTree,
+                dataNode3);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, topLJTree));
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, E, 1, C,2, D));
+
+        IQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, E))),
+                dataNode1, newRightDataNode);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, newLJTree));
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testMergeLJs17() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, E, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, F, 2, D));
+
+        DBTermType integerType = TYPE_FACTORY.getDBTypeFactory().getDBLargeIntegerType();
+        DBTermType stringType = TYPE_FACTORY.getDBTypeFactory().getDBStringType();
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, A), E)),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, A), F)
+                ),
+                subLJTree,
+                dataNode3);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, topLJTree));
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, E, 1, C,2, D));
+
+        IQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, A), E)),
+                dataNode1, newRightDataNode);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, newLJTree));
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
     /**
      * FK is only one direction (no cycle)
      */

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -3368,6 +3368,236 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
+    @Test
+    public void testMergeLJs19() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, ONE_STR, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, ONE_STR, 2, D));
+
+        ImmutableExpression condition = TERM_FACTORY.getStrictEquality(A, ONE_STR);
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                       condition),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(condition),
+                subLJTree,
+                dataNode3);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, topLJTree));
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, ONE_STR, 1, CF0,2, DF1));
+
+        IQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, newRightDataNode);
+
+        ConstructionNode newConstructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                SUBSTITUTION_FACTORY.getSubstitution(
+                        C, TERM_FACTORY.getIfElseNull(condition, CF0),
+                        D, TERM_FACTORY.getIfElseNull(condition, DF1)));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(newConstructionNode, newLJTree));
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+
+    @Ignore("TODO: support it (it introduces an implicit constraint that currently block the optimization")
+    @Test
+    public void testMergeLJs20() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, E, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, F, 1, G,2, D));
+
+        DBTermType integerType = TYPE_FACTORY.getDBTypeFactory().getDBLargeIntegerType();
+        DBTermType stringType = TYPE_FACTORY.getDBTypeFactory().getDBStringType();
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getConjunction(
+                                TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, E)),
+                                TERM_FACTORY.getStrictEquality(B, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, C))
+                                )),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getConjunction(
+                                TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, F)),
+                                TERM_FACTORY.getStrictEquality(B, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, G))
+                        )),
+                subLJTree,
+                dataNode3);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, topLJTree));
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, F, 1, C,2, D));
+
+        IQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                TERM_FACTORY.getConjunction(
+                        TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, F)),
+                        TERM_FACTORY.getStrictEquality(B, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, C)))),
+                dataNode1, newRightDataNode);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, newLJTree));
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testMergeLJs21() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, E, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, F, 1, G,2, D));
+
+        DBTermType integerType = TYPE_FACTORY.getDBTypeFactory().getDBLargeIntegerType();
+        DBTermType stringType = TYPE_FACTORY.getDBTypeFactory().getDBStringType();
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getConjunction(
+                                TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, E)),
+                                TERM_FACTORY.getStrictEquality(B, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, C))
+                        )),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getConjunction(
+                                TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, F)),
+                                TERM_FACTORY.getStrictEquality(B, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, G))
+                        )),
+                subLJTree,
+                dataNode3);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, topLJTree));
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, F, 1, C,2, D));
+
+        IQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getConjunction(
+                                TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, F)),
+                                TERM_FACTORY.getStrictEquality(B, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, C)))),
+                dataNode1, newRightDataNode);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, newLJTree));
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Ignore("TODO: support composite UC inference after transformation in ConstructionNode, to get that query optimized")
+    @Test
+    public void testMergeLJs22() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, E, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, F, 1, G,2, D));
+
+        DBTermType integerType = TYPE_FACTORY.getDBTypeFactory().getDBLargeIntegerType();
+        DBTermType stringType = TYPE_FACTORY.getDBTypeFactory().getDBStringType();
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getConjunction(
+                                TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, E)),
+                                TERM_FACTORY.getStrictEquality(B, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, C)),
+                                TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, C, TWO)
+                        )),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getConjunction(
+                                TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, F)),
+                                TERM_FACTORY.getStrictEquality(B, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, G))
+                        )),
+                subLJTree,
+                dataNode3);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, topLJTree));
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE3, ImmutableMap.of(0, F, 1, C,2, D));
+
+        IQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getConjunction(
+                                TERM_FACTORY.getStrictEquality(A, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, F)),
+                                TERM_FACTORY.getStrictEquality(B, TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, C)))),
+                dataNode1, newRightDataNode);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, newLJTree));
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testMergeLJs23() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, E, 1, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, F, 2, D));
+
+        DBTermType integerType = TYPE_FACTORY.getDBTypeFactory().getDBLargeIntegerType();
+        DBTermType stringType = TYPE_FACTORY.getDBTypeFactory().getDBStringType();
+        DBTermType booleanType = TYPE_FACTORY.getDBTypeFactory().getDBBooleanType();
+
+        ImmutableFunctionalTerm leftCast = TERM_FACTORY.getDBCastFunctionalTerm(integerType, stringType, A);
+
+        IQTree subLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                TERM_FACTORY.getConjunction(
+                        TERM_FACTORY.getStrictEquality(leftCast, TERM_FACTORY.getDBCastFunctionalTerm(booleanType, stringType, E)),
+                        TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, C, TWO))),
+                dataNode1, dataNode2);
+
+        BinaryNonCommutativeIQTree topLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(leftCast, TERM_FACTORY.getDBCastFunctionalTerm(booleanType, stringType, F))
+                ),
+                subLJTree,
+                dataNode3);
+
+        ConstructionNode constructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(constructionNode, topLJTree));
+
+        ExtensionalDataNode newRightDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1a, ImmutableMap.of(0, F, 1, CF2,2, D));
+
+        IQTree newLJTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(
+                        TERM_FACTORY.getStrictEquality(leftCast, TERM_FACTORY.getDBCastFunctionalTerm(booleanType, stringType, F))),
+                dataNode1, newRightDataNode);
+
+        ConstructionNode newConstructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                SUBSTITUTION_FACTORY.getSubstitution(C,
+                        TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBNumericInequality(InequalityLabel.LT, CF2, TWO), CF2)));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(newConstructionNode, newLJTree));
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
     /**
      * FK is only one direction (no cycle)
      */


### PR DESCRIPTION
Improvement of #663. Particularly useful when IRI template arguments have different datatypes.

For instance, this optimization transforms

```
CONSTRUCT [a, b, c, d] []
   LJ STRICT_EQ2(LARGE_INTToSTRING(f),a)
      LJ STRICT_EQ2(a,LARGE_INTToSTRING(e))
         EXTENSIONAL TABLE1(0:a,2:b)
         EXTENSIONAL TABLE1A(0:e,1:c)
      EXTENSIONAL TABLE1A(0:f,2:d)
```
into
```
CONSTRUCT [a, b, c, d] []
   LJ STRICT_EQ2(a,LARGE_INTToSTRING(f))
      EXTENSIONAL TABLE1(0:a,2:b)
      EXTENSIONAL TABLE1A(0:f,1:c,2:d)
```