### PR TITLE
Added partial RegEx support to SQLServer

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DBRegexMatchAsLikeFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DBRegexMatchAsLikeFunctionSymbolImpl.java
@@ -1,0 +1,195 @@
+package it.unibz.inf.ontop.model.term.functionsymbol.db.impl;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.exception.MinorOntopInternalBugException;
+import it.unibz.inf.ontop.model.term.Constant;
+import it.unibz.inf.ontop.model.term.ImmutableExpression;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.DBBooleanFunctionSymbol;
+import it.unibz.inf.ontop.model.type.DBTermType;
+
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/*
+ * Represents the REGEXP_MATCH function symbol as a `[a] LIKE [b]` expression. The version with arity 3 only supports the flag 'i'.
+ */
+public class DBRegexMatchAsLikeFunctionSymbolImpl extends AbstractTypedDBFunctionSymbol
+        implements DBBooleanFunctionSymbol {
+
+    protected DBRegexMatchAsLikeFunctionSymbolImpl(String name, DBTermType dbStringType,
+                                                   DBTermType dbBooleanType, int arity) {
+        super(name, arity == 2 ? ImmutableList.of(dbStringType, dbStringType) : ImmutableList.of(dbStringType, dbStringType, dbStringType), dbBooleanType);
+    }
+
+    @Override
+    public boolean blocksNegation() {
+        return true;
+    }
+
+    @Override
+    public ImmutableExpression negate(ImmutableList<? extends ImmutableTerm> subTerms, TermFactory termFactory) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean canBePostProcessed(ImmutableList<? extends ImmutableTerm> arguments) {
+        return false;
+    }
+
+    /**
+     * Splits a regular expression into tokens for the purpose of translation to a LIKE expression.
+     */
+    private ImmutableList<String> tokenizeRegEx(String regEx) {
+        ImmutableList.Builder<String> tokens = ImmutableList.builder();
+        int bracketDepth = 0;
+        String current = "";
+        for(var character : regEx.toCharArray()) {
+            if(!current.equals("\\")
+                    && bracketDepth == 0
+                    && !ImmutableSet.of('*', '+', '?').contains(character)) {
+                tokens.add(current);
+                current = "";
+            }
+            current += character;
+            if(character == '[' || character == '(')
+                bracketDepth += 1;
+            if(character == ']' || character == ')')
+                bracketDepth -= 1;
+        }
+        if(bracketDepth != 0) {
+            throw new MinorOntopInternalBugException("Error parsing RegEx: expected ']' or ')'.");
+        }
+        if(current.equals("\\")) {
+            throw new MinorOntopInternalBugException("Error parsing RegEx: Invalid escape sequence.");
+        }
+        tokens.add(current);
+
+        return tokens.build();
+    }
+
+    /**
+     * Translates a token to its corresponding LIKE expression equivalent.
+     */
+    private String translateToken(String token) {
+        /*
+         * The following RegEx patterns are supported and can be translated:
+         *          .*              =>          %
+         *          .               =>          _
+         *          .+              =>          _%
+         *          [x]             =>          [x]
+         *          [^x]            =>          [^x]
+         *          \d, \w, \s      =>          [0-9], [0-9A-z], [ \t\n]
+         *          \D, \W, \S      =>          [^0-9], [^0-9A-z], [^ \t\n]
+         *          \[, \]          =>          [[], []]
+         *          \<symbol>       =>          <symbol>
+         * The following literals must be escaped:
+         *          _               =>          [_]
+         *          %               =>          [%]
+         * The following RegEx patterns cannot be translated (and must fail explicitly):
+         *          (x)*, (x)+
+         *          ?
+         *          |
+         *          {n}
+         *          ()
+         *          $ and ^ when not at start or end of pattern
+         */
+        if(token.equals("_"))
+            return "[_]";
+        if(token.equals("%"))
+            return "[%]";
+        if(token.equals(".*"))
+            return "%";
+        if(token.equals("."))
+            return "_";
+        if(token.equals(".+"))
+            return "_%";
+        if(token.equals("\\d"))
+            return "[0-9]";
+        if(token.equals("\\w"))
+            return "[0-9A-z]";
+        if(token.equals("\\s"))
+            return "[ \\t\\n]";
+        if(token.equals("\\D"))
+            return "[^0-9]";
+        if(token.equals("\\W"))
+            return "[^0-9A-z]";
+        if(token.equals("\\S"))
+            return "[^ \\t\\n]";
+        if(token.equals("\\[") || token.equals("\\]"))
+            return String.format("[%s]", token.substring(1));
+        if(ImmutableSet.of("\\*", "\\.", "\\^", "\\$", "\\?", "\\+", "\\(", "\\)", "\\{", "\\}", "\\|", "\\\\").contains(token)) {
+            return token.substring(1);
+        }
+        if(token.endsWith("*") || token.endsWith("+") || token.endsWith("?")) {
+            throw new MinorOntopInternalBugException("Multiplicity modifiers are only allowed after the '.' wildcard when translating a RegEx to a LIKE comparison.");
+        }
+        if(token.startsWith("(") || token.endsWith(")")) {
+            throw new MinorOntopInternalBugException("Round parentheses are not allowed when translating a RegEx to a LIKE comparison.");
+        }
+        if(token.startsWith("{") || token.endsWith("}")) {
+            throw new MinorOntopInternalBugException("Curly parentheses are not allowed when translating a RegEx to a LIKE comparison.");
+        }
+        if(token.contains("|")) {
+            throw new MinorOntopInternalBugException("The '|' operator is not allowed when translating a RegEx to a LIKE comparison.");
+        }
+        if(token.contains("$") || token.contains("^")) {
+            throw new MinorOntopInternalBugException("The '^' and '$' operators are only allowed at the pattern start and end respectively, when translating a RegEx to a LIKE comparison.");
+        }
+
+        return token;
+    }
+
+    /**
+     * Translates a RegEx into a LIKE expression pattern by first tokenizing it and then translating every individual token.
+     */
+    private String translateRegex(String regex) {
+        var tokens = tokenizeRegEx(regex);
+        return tokens.stream()
+                .map(this::translateToken)
+                .collect(Collectors.joining());
+    }
+
+    @Override
+    public String getNativeDBString(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        if(!(terms.get(1) instanceof Constant))
+            throw new MinorOntopInternalBugException("Regex patterns must be constants when used with SQLServer.");
+        String pattern = ((Constant)terms.get(1)).getValue();
+        boolean forceStart = false;
+        boolean forceEnd = false;
+        if(pattern.startsWith("^")) {
+            forceStart = true;
+            pattern = pattern.substring(1);
+        }
+        if(pattern.endsWith("$")) {
+            forceEnd = true;
+            pattern = pattern.substring(0, pattern.length() - 1);
+        }
+        String newPattern = translateRegex(pattern);
+        if(!forceStart) {
+            newPattern = "%" + newPattern;
+        }
+        if(!forceEnd) {
+            newPattern = newPattern + "%";
+        }
+
+        String str = termConverter.apply(terms.get(0));
+        if(terms.size() == 2)
+            return String.format("(%s LIKE '%s')", str, newPattern);
+        else
+            return String.format("(CASE WHEN %s = 'i' THEN LOWER(%s) ELSE %s END LIKE CASE WHEN %s = 'i' THEN LOWER(%s) ELSE '%s' END)",
+                    termConverter.apply(terms.get(2)),
+                    str,
+                    str,
+                    termConverter.apply(terms.get(2)),
+                    newPattern,
+                    newPattern);
+    }
+
+    @Override
+    protected boolean isAlwaysInjectiveInTheAbsenceOfNonInjectiveFunctionalTerms() {
+        return false;
+    }
+}

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DBRegexMatchAsLikeFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DBRegexMatchAsLikeFunctionSymbolImpl.java
@@ -126,6 +126,9 @@ public class DBRegexMatchAsLikeFunctionSymbolImpl extends AbstractTypedDBFunctio
         if(token.endsWith("*") || token.endsWith("+") || token.endsWith("?")) {
             throw new MinorOntopInternalBugException("Multiplicity modifiers are only allowed after the '.' wildcard when translating a RegEx to a LIKE comparison.");
         }
+        if(token.startsWith("[") && token.endsWith("]")) {
+            return token;
+        }
         if(token.startsWith("(") || token.endsWith(")")) {
             throw new MinorOntopInternalBugException("Round parentheses are not allowed when translating a RegEx to a LIKE comparison.");
         }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SQLServerDBIriStringResolverFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SQLServerDBIriStringResolverFunctionSymbolImpl.java
@@ -1,0 +1,42 @@
+package it.unibz.inf.ontop.model.term.functionsymbol.db.impl;
+
+import com.google.common.collect.ImmutableList;
+import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.model.term.DBConstant;
+import it.unibz.inf.ontop.model.term.ImmutableFunctionalTerm;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.type.DBTermType;
+import org.apache.commons.rdf.api.IRI;
+import org.eclipse.rdf4j.common.net.ParsedIRI;
+
+import java.util.function.Function;
+
+public class SQLServerDBIriStringResolverFunctionSymbolImpl extends DBIriStringResolverFunctionSymbolImpl {
+
+    private final String noSpecialCharacter;
+
+    protected SQLServerDBIriStringResolverFunctionSymbolImpl(IRI baseIRI, DBTermType rootDBType, DBTermType dbStringType) {
+        super(baseIRI, "[a-zA-Z].*:", rootDBType, dbStringType);
+        noSpecialCharacter = ".*[-_,.#/;:|<>\\^(){}\\[\\]!?0-9].*:";
+    }
+
+    @Override
+    public String getNativeDBString(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        ImmutableTerm argLexical = terms.get(0);
+
+        ImmutableFunctionalTerm functionalTerm = termFactory.getIfThenElse(
+                termFactory.getConjunction(
+                        termFactory.getDBRegexpMatches(ImmutableList.of(argLexical, termFactory.getDBStringConstant(iriPrefixRegex))),
+                        termFactory.getDBNot(termFactory.getDBRegexpMatches(ImmutableList.of(
+                                argLexical,
+                                termFactory.getDBStringConstant(noSpecialCharacter)
+                        )))
+                ),
+                argLexical,
+                termFactory.getNullRejectingDBConcatFunctionalTerm(ImmutableList.of(termFactory.getDBStringConstant(baseIRI.toString()), argLexical)));
+
+        return termConverter.apply(functionalTerm.simplify());
+    }
+
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SQLServerDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SQLServerDBFunctionSymbolFactory.java
@@ -32,6 +32,8 @@ public class SQLServerDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbo
 
     // Created in init()
     private DBFunctionSymbol substr2FunctionSymbol;
+    private DBBooleanFunctionSymbol regexpLike2;
+    private DBBooleanFunctionSymbol regexpLike3;
 
     @Inject
     private SQLServerDBFunctionSymbolFactory(TypeFactory typeFactory) {
@@ -46,6 +48,9 @@ public class SQLServerDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbo
         // Non-regular
         substr2FunctionSymbol = new DBFunctionSymbolWithSerializerImpl(SUBSTR_STR + "2",
                 ImmutableList.of(abstractRootDBType, abstractRootDBType), dbStringType, false, this::serializeSubString2);
+
+        regexpLike2 = new DBRegexMatchAsLikeFunctionSymbolImpl(REGEXP_LIKE_STR + "2", dbStringType, dbBooleanType, 2);
+        regexpLike3 = new DBRegexMatchAsLikeFunctionSymbolImpl(REGEXP_LIKE_STR + "3", dbStringType, dbBooleanType, 3);
     }
 
     /**
@@ -116,6 +121,8 @@ public class SQLServerDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbo
         // Removals not replaced by regular function symbols
         table.remove(SUBSTRING_STR, 2);
         table.remove(SUBSTR_STR, 2);
+        table.remove(REGEXP_LIKE_STR, 2);
+        table.remove(REGEXP_LIKE_STR, 3);
 
         return ImmutableTable.copyOf(table);
     }
@@ -143,22 +150,6 @@ public class SQLServerDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbo
     @Override
     protected String serializeDBRowNumber(Function<ImmutableTerm, String> converter, TermFactory termFactory) {
         return "ROW_NUMBER() OVER (ORDER BY (SELECT NULL))";
-    }
-
-    /**
-     * TODO: update
-     */
-    @Override
-    public DBBooleanFunctionSymbol getDBRegexpMatches2() {
-        return super.getDBRegexpMatches2();
-    }
-
-    /**
-     * TODO: update
-     */
-    @Override
-    public DBBooleanFunctionSymbol getDBRegexpMatches3() {
-        return super.getDBRegexpMatches3();
     }
 
     @Override
@@ -363,6 +354,17 @@ public class SQLServerDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbo
     public DBFunctionSymbol getDBSubString2() {
         return substr2FunctionSymbol;
     }
+
+    @Override
+    public DBBooleanFunctionSymbol getDBRegexpMatches2() {
+        return regexpLike2;
+    }
+
+    @Override
+    public DBBooleanFunctionSymbol getDBRegexpMatches3() {
+        return regexpLike3;
+    }
+
 
     @Override
     protected DBFunctionSymbol createDBAvg(DBTermType inputType, boolean isDistinct) {

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SQLServerDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SQLServerDBFunctionSymbolFactory.java
@@ -12,6 +12,7 @@ import it.unibz.inf.ontop.model.type.DBTermType;
 import it.unibz.inf.ontop.model.type.DBTypeFactory;
 import it.unibz.inf.ontop.model.type.TypeFactory;
 import it.unibz.inf.ontop.model.type.impl.SQLServerDBTypeFactory;
+import org.apache.commons.rdf.api.IRI;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -270,6 +271,10 @@ public class SQLServerDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbo
     @Override
     public DBFunctionSymbol getDBRegexpReplace4() {
         throw new UnsupportedOperationException(UNSUPPORTED_MSG);
+    }
+
+    protected DBFunctionSymbol createDBIriStringResolver(IRI baseIRI) {
+        return new SQLServerDBIriStringResolverFunctionSymbolImpl(baseIRI, typeFactory.getDBTypeFactory().getAbstractRootDBType(), dbStringType);
     }
 
     /**

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mssql/BindWithFunctionsSQLServerTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mssql/BindWithFunctionsSQLServerTest.java
@@ -59,13 +59,6 @@ public class BindWithFunctionsSQLServerTest extends AbstractBindTestWithFunction
         super.testHashSHA384();
     }
 
-    @Test
-    @Disabled("TODO: support regex")
-    @Override
-    public void testIRI7() {
-        super.testIRI7();
-    }
-
     @Disabled("Current MS SQL Server handling does not allow operation between DATE and DATETIME, db example has only DATE")
     @Test
     @Override

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mssql/BindWithFunctionsSQLServerTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mssql/BindWithFunctionsSQLServerTest.java
@@ -42,12 +42,6 @@ public class BindWithFunctionsSQLServerTest extends AbstractBindTestWithFunction
                 "\"0E-19, 10.0000000000000000000\"^^xsd:string");
     }
 
-    @Disabled("not supported?")
-    @Test
-    public void testREGEX() {
-        super.testREGEX();
-    }
-
     @Disabled("not supported")
     @Test
     public void testREPLACE() {


### PR DESCRIPTION
SQLServer does not directly support regular expressions and the `REGEXP_MATCH` function.

Implemented a new FunctionSymbol that can be used to translate REGEXP_MATCH calls into `(<expression> LIKE <pattern>)` calls, where `pattern` is derived from the regular expression pattern provided.

As the `LIKE` operator is quite primitive compared to RegEx, only a limited number of patterns are supported this way.

Notes:
- The arity-3 version of this function is also implemented, but only for the flag "i".
- `REGEXP_REPLACE` cannot be implemented in a similar fashion, as we would need to find and replace _any number_ of pattern occurrences to implement it, which cannot be done easily.