### PR TITLE
Typing for math operators used in the mapping / lenses

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/injection/CoreSingletons.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/injection/CoreSingletons.java
@@ -2,6 +2,7 @@ package it.unibz.inf.ontop.injection;
 
 import it.unibz.inf.ontop.dbschema.DatabaseInfoSupplier;
 import it.unibz.inf.ontop.iq.node.normalization.ConstructionSubstitutionNormalizer;
+import it.unibz.inf.ontop.iq.type.NotYetTypedBinaryMathOperationTransformer;
 import it.unibz.inf.ontop.iq.type.NotYetTypedEqualityTransformer;
 import it.unibz.inf.ontop.iq.type.PartiallyTypedSimpleCastTransformer;
 import it.unibz.inf.ontop.iq.type.SingleTermTypeExtractor;
@@ -48,6 +49,7 @@ public interface CoreSingletons {
     ConstructionSubstitutionNormalizer getConstructionSubstitutionNormalizer();
 
     NotYetTypedEqualityTransformer getNotYetTypedEqualityTransformer();
+    NotYetTypedBinaryMathOperationTransformer getNotYetTypedBinaryMathOperationTransformer();
 
     PartiallyTypedSimpleCastTransformer getPartiallyTypeSimpleCastTransformer();
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/injection/impl/CoreSingletonsImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/injection/impl/CoreSingletonsImpl.java
@@ -8,6 +8,7 @@ import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.injection.OntopModelSettings;
 import it.unibz.inf.ontop.injection.QueryTransformerFactory;
 import it.unibz.inf.ontop.iq.node.normalization.ConstructionSubstitutionNormalizer;
+import it.unibz.inf.ontop.iq.type.NotYetTypedBinaryMathOperationTransformer;
 import it.unibz.inf.ontop.iq.type.NotYetTypedEqualityTransformer;
 import it.unibz.inf.ontop.iq.type.PartiallyTypedSimpleCastTransformer;
 import it.unibz.inf.ontop.iq.type.SingleTermTypeExtractor;
@@ -35,6 +36,7 @@ public class CoreSingletonsImpl implements CoreSingletons {
     private final ConstructionSubstitutionNormalizer constructionSubstitutionNormalizer;
     private final QueryTransformerFactory queryTransformerFactory;
     private final NotYetTypedEqualityTransformer notYetTypedEqualityTransformer;
+    private final NotYetTypedBinaryMathOperationTransformer notYetTypedBinaryMathOperationTransformer;
     private final PartiallyTypedSimpleCastTransformer partiallyTypedSimpleCastTransformer;
     private final DatabaseInfoSupplier databaseInfoSupplier;
 
@@ -49,6 +51,7 @@ public class CoreSingletonsImpl implements CoreSingletons {
                                ConstructionSubstitutionNormalizer constructionSubstitutionNormalizer,
                                QueryTransformerFactory queryTransformerFactory,
                                NotYetTypedEqualityTransformer notYetTypedEqualityTransformer,
+                               NotYetTypedBinaryMathOperationTransformer notYetTypedBinaryMathOperationTransformer,
                                PartiallyTypedSimpleCastTransformer partiallyTypedSimpleCastTransformer,
                                DatabaseInfoSupplier databaseInfoSupplier) {
         this.termFactory = termFactory;
@@ -64,6 +67,7 @@ public class CoreSingletonsImpl implements CoreSingletons {
         this.constructionSubstitutionNormalizer = constructionSubstitutionNormalizer;
         this.queryTransformerFactory = queryTransformerFactory;
         this.notYetTypedEqualityTransformer = notYetTypedEqualityTransformer;
+        this.notYetTypedBinaryMathOperationTransformer = notYetTypedBinaryMathOperationTransformer;
         this.partiallyTypedSimpleCastTransformer = partiallyTypedSimpleCastTransformer;
         this.databaseInfoSupplier = databaseInfoSupplier;
     }
@@ -131,6 +135,11 @@ public class CoreSingletonsImpl implements CoreSingletons {
     @Override
     public NotYetTypedEqualityTransformer getNotYetTypedEqualityTransformer() {
         return notYetTypedEqualityTransformer;
+    }
+
+    @Override
+    public NotYetTypedBinaryMathOperationTransformer getNotYetTypedBinaryMathOperationTransformer() {
+        return notYetTypedBinaryMathOperationTransformer;
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/injection/impl/OntopModelModule.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/injection/impl/OntopModelModule.java
@@ -17,6 +17,7 @@ import it.unibz.inf.ontop.iq.tools.ProjectionDecomposer;
 import it.unibz.inf.ontop.iq.tools.TypeConstantDictionary;
 import it.unibz.inf.ontop.iq.transform.NoNullValueEnforcer;
 import it.unibz.inf.ontop.iq.transform.QueryRenamer;
+import it.unibz.inf.ontop.iq.type.NotYetTypedBinaryMathOperationTransformer;
 import it.unibz.inf.ontop.iq.type.NotYetTypedEqualityTransformer;
 import it.unibz.inf.ontop.iq.type.PartiallyTypedSimpleCastTransformer;
 import it.unibz.inf.ontop.iq.type.SingleTermTypeExtractor;
@@ -70,6 +71,7 @@ public class OntopModelModule extends OntopAbstractModule {
         bindFromSettings(AggregationNormalizer.class);
         bindFromSettings(NotRequiredVariableRemover.class);
         bindFromSettings(NotYetTypedEqualityTransformer.class);
+        bindFromSettings(NotYetTypedBinaryMathOperationTransformer.class);
         bindFromSettings(PartiallyTypedSimpleCastTransformer.class);
         bindFromSettings(RDF.class);
         bindFromSettings(SingleTermTypeExtractor.class);

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/type/NotYetTypedBinaryMathOperationTransformer.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/type/NotYetTypedBinaryMathOperationTransformer.java
@@ -1,0 +1,9 @@
+package it.unibz.inf.ontop.iq.type;
+
+import it.unibz.inf.ontop.iq.transform.IQTreeTransformer;
+
+/**
+ * Transforms the binary operations which are still UNTYPED into their typed variants, where possible.
+ */
+public interface NotYetTypedBinaryMathOperationTransformer extends IQTreeTransformer {
+}

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/type/impl/NotYetTypedBinaryMathOperationTransformerImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/type/impl/NotYetTypedBinaryMathOperationTransformerImpl.java
@@ -82,7 +82,7 @@ public class NotYetTypedBinaryMathOperationTransformerImpl implements NotYetType
                         term2);
             }
             else
-                return termFactory.getDBNonStrictDefaultEquality(term1, term2);
+                return termFactory.getImmutableFunctionalTerm(functionSymbol, term1, term2);
         }
     }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/type/impl/NotYetTypedBinaryMathOperationTransformerImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/type/impl/NotYetTypedBinaryMathOperationTransformerImpl.java
@@ -55,6 +55,8 @@ public class NotYetTypedBinaryMathOperationTransformerImpl implements NotYetType
             if (newTerms.size() != 2)
                 throw new MinorOntopInternalBugException("Was expecting untyped math operations to be binary");
 
+            DefaultUntypedDBMathBinaryOperator operator = (DefaultUntypedDBMathBinaryOperator)functionSymbol;
+
             ImmutableTerm term1 = newTerms.get(0);
             ImmutableTerm term2 = newTerms.get(1);
 
@@ -75,7 +77,7 @@ public class NotYetTypedBinaryMathOperationTransformerImpl implements NotYetType
                 DBTermType type2 = types.get(1);
 
                 return termFactory.getDBBinaryNumericFunctionalTerm(
-                        functionSymbol.getName().substring(7), //Strip "UNTYPED" from function symbol name.
+                        operator.getMathOperatorString(),
                         type1,
                         type2,
                         term1,

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/type/impl/NotYetTypedBinaryMathOperationTransformerImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/type/impl/NotYetTypedBinaryMathOperationTransformerImpl.java
@@ -1,0 +1,89 @@
+package it.unibz.inf.ontop.iq.type.impl;
+
+import com.google.common.collect.ImmutableList;
+import it.unibz.inf.ontop.exception.MinorOntopInternalBugException;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.transform.IQTreeTransformer;
+import it.unibz.inf.ontop.iq.type.NotYetTypedBinaryMathOperationTransformer;
+import it.unibz.inf.ontop.iq.type.SingleTermTypeExtractor;
+import it.unibz.inf.ontop.model.term.*;
+import it.unibz.inf.ontop.model.term.functionsymbol.FunctionSymbol;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.impl.DefaultUntypedDBMathBinaryOperator;
+import it.unibz.inf.ontop.model.type.DBTermType;
+import it.unibz.inf.ontop.model.type.TermType;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+public class NotYetTypedBinaryMathOperationTransformerImpl implements NotYetTypedBinaryMathOperationTransformer {
+
+    private final IQTreeTransformer expressionTransformer;
+
+    @Inject
+    protected NotYetTypedBinaryMathOperationTransformerImpl(IntermediateQueryFactory iqFactory,
+                                                            SingleTermTypeExtractor typeExtractor,
+                                                            TermFactory termFactory) {
+        this.expressionTransformer = new ExpressionTransformer(iqFactory,
+                                                                typeExtractor,
+                                                                termFactory);
+    }
+
+    @Override
+    public IQTree transform(IQTree tree) {
+        return expressionTransformer.transform(tree);
+    }
+
+
+    protected static class ExpressionTransformer extends AbstractExpressionTransformer {
+
+        protected ExpressionTransformer(IntermediateQueryFactory iqFactory,
+                                        SingleTermTypeExtractor typeExtractor,
+                                        TermFactory termFactory) {
+            super(iqFactory, typeExtractor, termFactory);
+        }
+
+        @Override
+        protected boolean isFunctionSymbolToReplace(FunctionSymbol functionSymbol) {
+            return functionSymbol instanceof DefaultUntypedDBMathBinaryOperator;
+        }
+
+        @Override
+        protected ImmutableFunctionalTerm replaceFunctionSymbol(FunctionSymbol functionSymbol,
+                                                                ImmutableList<ImmutableTerm> newTerms, IQTree tree) {
+            if (newTerms.size() != 2)
+                throw new MinorOntopInternalBugException("Was expecting untyped math operations to be binary");
+
+            ImmutableTerm term1 = newTerms.get(0);
+            ImmutableTerm term2 = newTerms.get(1);
+
+            ImmutableList<Optional<TermType>> extractedTypes = newTerms.stream()
+                    .map(t -> typeExtractor.extractSingleTermType(t, tree))
+                    .collect(ImmutableCollectors.toList());
+
+            if (extractedTypes.stream()
+                    .allMatch(type -> type
+                            .filter(t -> t instanceof DBTermType)
+                            .isPresent())) {
+                ImmutableList<DBTermType> types = extractedTypes.stream()
+                        .map(Optional::get)
+                        .map(t -> (DBTermType) t)
+                        .collect(ImmutableCollectors.toList());
+
+                DBTermType type1 = types.get(0);
+                DBTermType type2 = types.get(1);
+
+                return termFactory.getDBBinaryNumericFunctionalTerm(
+                        functionSymbol.getName().substring(7), //Strip "UNTYPED" from function symbol name.
+                        type1,
+                        type2,
+                        term1,
+                        term2);
+            }
+            else
+                return termFactory.getDBNonStrictDefaultEquality(term1, term2);
+        }
+    }
+
+}

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/TermFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/TermFactory.java
@@ -527,6 +527,9 @@ public interface TermFactory {
 	ImmutableFunctionalTerm getDBBinaryNumericFunctionalTerm(String dbNumericOperationName, DBTermType dbNumericType,
 															 ImmutableTerm dbTerm1, ImmutableTerm dbTerm2);
 
+	ImmutableFunctionalTerm getDBBinaryNumericFunctionalTerm(String dbNumericOperationName, DBTermType argumentType1, DBTermType argumentType2,
+															 ImmutableTerm dbTerm1, ImmutableTerm dbTerm2);
+
 	ImmutableFunctionalTerm getUnaryLatelyTypedFunctionalTerm(
 			ImmutableTerm lexicalTerm, ImmutableTerm inputRDFTypeTerm, DBTermType targetType,
 			java.util.function.Function<DBTermType, Optional<DBFunctionSymbol>> dbFunctionSymbolFct);

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/DBFunctionSymbolFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/DBFunctionSymbolFactory.java
@@ -223,6 +223,8 @@ public interface DBFunctionSymbolFactory {
 
     DBMathBinaryOperator getDBMathBinaryOperator(String dbMathOperatorName, DBTermType dbNumericType);
 
+    DBMathBinaryOperator getDBMathBinaryOperator(String dbMathOperatorName, DBTermType arg1Type, DBTermType arg2Type);
+
     /**
      * Please use getDBMathBinaryOperator(...) if you know the type
      */

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/DBMathBinaryOperator.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/DBMathBinaryOperator.java
@@ -5,4 +5,6 @@ package it.unibz.inf.ontop.model.term.functionsymbol.db;
  */
 public interface DBMathBinaryOperator extends DBFunctionSymbol {
 
+    String getMathOperatorString();
+
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultTypedDBMathBinaryOperator.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultTypedDBMathBinaryOperator.java
@@ -14,12 +14,14 @@ import java.util.function.Function;
 public class DefaultTypedDBMathBinaryOperator extends FunctionSymbolImpl implements DBMathBinaryOperator {
 
     private final String template;
+    private final String operatorString;
     private final DBTermType dbNumericType;
 
     protected DefaultTypedDBMathBinaryOperator(String operatorString, DBTermType dbNumericType) {
         super(dbNumericType.toString() + operatorString, ImmutableList.of(dbNumericType, dbNumericType));
         this.template = "(%s " + operatorString + " %s)";
         this.dbNumericType = dbNumericType;
+        this.operatorString = operatorString;
     }
 
     @Override
@@ -62,5 +64,10 @@ public class DefaultTypedDBMathBinaryOperator extends FunctionSymbolImpl impleme
     @Override
     public boolean isPreferringToBePostProcessedOverBeingBlocked() {
         return false;
+    }
+
+    @Override
+    public String getMathOperatorString() {
+        return operatorString;
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultUntypedDBMathBinaryOperator.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultUntypedDBMathBinaryOperator.java
@@ -22,10 +22,12 @@ import java.util.function.Function;
 public class DefaultUntypedDBMathBinaryOperator extends FunctionSymbolImpl implements DBMathBinaryOperator {
 
     private final String template;
+    private final String operatorString;
 
     protected DefaultUntypedDBMathBinaryOperator(String operatorString, DBTermType rootDBTermType) {
         super("UNTYPED" + operatorString, ImmutableList.of(rootDBTermType, rootDBTermType));
         this.template = "(%s " + operatorString + " %s)";
+        this.operatorString = operatorString;
     }
 
     @Override
@@ -65,5 +67,10 @@ public class DefaultUntypedDBMathBinaryOperator extends FunctionSymbolImpl imple
     @Override
     public boolean isPreferringToBePostProcessedOverBeingBlocked() {
         return false;
+    }
+
+    @Override
+    public String getMathOperatorString() {
+        return operatorString;
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/impl/TermFactoryImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/impl/TermFactoryImpl.java
@@ -471,6 +471,14 @@ public class TermFactoryImpl implements TermFactory {
 	}
 
 	@Override
+	public ImmutableFunctionalTerm getDBBinaryNumericFunctionalTerm(String dbNumericOperationName, DBTermType argumentType1, DBTermType argumentType2,
+																	ImmutableTerm dbTerm1, ImmutableTerm dbTerm2) {
+		return getImmutableFunctionalTerm(
+				dbFunctionSymbolFactory.getDBMathBinaryOperator(dbNumericOperationName, argumentType1, argumentType2),
+				dbTerm1, dbTerm2);
+	}
+
+	@Override
 	public ImmutableFunctionalTerm getUnaryLatelyTypedFunctionalTerm(ImmutableTerm lexicalTerm,
 																	 ImmutableTerm inputRDFTypeTerm, DBTermType targetType,
 																	 java.util.function.Function<DBTermType, Optional<DBFunctionSymbol>> dbFunctionSymbolFct) {

--- a/core/model/src/main/resources/it/unibz/inf/ontop/injection/default.properties
+++ b/core/model/src/main/resources/it/unibz/inf/ontop/injection/default.properties
@@ -46,6 +46,7 @@ it.unibz.inf.ontop.iq.node.normalization.DistinctNormalizer = it.unibz.inf.ontop
 it.unibz.inf.ontop.iq.node.normalization.AggregationNormalizer = it.unibz.inf.ontop.iq.node.normalization.impl.AggregationNormalizerImpl
 it.unibz.inf.ontop.iq.node.normalization.NotRequiredVariableRemover = it.unibz.inf.ontop.iq.node.normalization.impl.NotRequiredVariableRemoverImpl
 it.unibz.inf.ontop.iq.type.NotYetTypedEqualityTransformer = it.unibz.inf.ontop.iq.type.impl.NotYetTypedEqualityTransformerImpl
+it.unibz.inf.ontop.iq.type.NotYetTypedBinaryMathOperationTransformer = it.unibz.inf.ontop.iq.type.impl.NotYetTypedBinaryMathOperationTransformerImpl
 it.unibz.inf.ontop.iq.type.PartiallyTypedSimpleCastTransformer = it.unibz.inf.ontop.iq.type.impl.PartiallyTypedSimpleCastTransformerImpl
 
 it.unibz.inf.ontop.model.term.TermFactory = it.unibz.inf.ontop.model.term.impl.TermFactoryImpl

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/LensNormalizerImpl.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/LensNormalizerImpl.java
@@ -6,16 +6,19 @@ import it.unibz.inf.ontop.dbschema.LensNormalizer;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.IQ;
 import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.type.NotYetTypedBinaryMathOperationTransformer;
 import it.unibz.inf.ontop.iq.type.NotYetTypedEqualityTransformer;
 
 public class LensNormalizerImpl implements LensNormalizer {
 
     private final NotYetTypedEqualityTransformer equalityTransformer;
+    private final NotYetTypedBinaryMathOperationTransformer binaryMathOperationTransformer;
     private final IntermediateQueryFactory iqFactory;
 
     @Inject
-    protected LensNormalizerImpl(NotYetTypedEqualityTransformer equalityTransformer, IntermediateQueryFactory iqFactory) {
+    protected LensNormalizerImpl(NotYetTypedEqualityTransformer equalityTransformer, NotYetTypedBinaryMathOperationTransformer binaryMathOperationTransformer, IntermediateQueryFactory iqFactory) {
         this.equalityTransformer = equalityTransformer;
+        this.binaryMathOperationTransformer = binaryMathOperationTransformer;
         this.iqFactory = iqFactory;
     }
 
@@ -31,11 +34,12 @@ public class LensNormalizerImpl implements LensNormalizer {
     protected IQ normalizeIQ(IQ iq) {
         IQ normalizedIQ = iq.normalizeForOptimization();
         IQTree newTree = equalityTransformer.transform(normalizedIQ.getTree());
+        IQTree finalTree = binaryMathOperationTransformer.transform(newTree);
 
         // TODO: add new optimization
 
-        return (newTree == normalizedIQ.getTree())
+        return (finalTree == normalizedIQ.getTree())
                 ? normalizedIQ
-                : iqFactory.createIQ(iq.getProjectionAtom(), newTree);
+                : iqFactory.createIQ(iq.getProjectionAtom(), finalTree);
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/BigQueryDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/BigQueryDBFunctionSymbolFactory.java
@@ -8,6 +8,7 @@ import it.unibz.inf.ontop.model.term.functionsymbol.db.*;
 import it.unibz.inf.ontop.model.type.DBTermType;
 import it.unibz.inf.ontop.model.type.DBTypeFactory;
 import it.unibz.inf.ontop.model.type.TypeFactory;
+import it.unibz.inf.ontop.model.vocabulary.SPARQL;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -270,5 +271,14 @@ public class BigQueryDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
     @Override
     protected DBFunctionSymbol createDBSample(DBTermType termType) {
         return new DBSampleFunctionSymbolImpl(termType, "ANY_VALUE");
+    }
+
+
+    @Override
+    protected DBTermType inferOutputTypeMathOperator(String dbMathOperatorName, DBTermType arg1Type, DBTermType arg2Type) {
+        if (dbMathOperatorName.equals(SPARQL.NUMERIC_DIVIDE))
+            return dbDecimalType;
+
+        return super.inferOutputTypeMathOperator(dbMathOperatorName, arg1Type, arg2Type);
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
@@ -13,6 +13,7 @@ import it.unibz.inf.ontop.model.term.functionsymbol.db.DBTypeConversionFunctionS
 import it.unibz.inf.ontop.model.type.DBTermType;
 import it.unibz.inf.ontop.model.type.DBTypeFactory;
 import it.unibz.inf.ontop.model.type.TypeFactory;
+import it.unibz.inf.ontop.model.vocabulary.SPARQL;
 
 
 import java.util.HashMap;
@@ -107,6 +108,14 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     @Override
     protected DBTypeConversionFunctionSymbol createDateTimeDenormFunctionSymbol(DBTermType timestampType) {
         return super.createDateTimeDenormFunctionSymbol(timestampType);
+    }
+
+    @Override
+    protected DBTermType inferOutputTypeMathOperator(String dbMathOperatorName, DBTermType arg1Type, DBTermType arg2Type) {
+        if (dbMathOperatorName.equals(SPARQL.NUMERIC_DIVIDE))
+            return dbDecimalType;
+
+        return super.inferOutputTypeMathOperator(dbMathOperatorName, arg1Type, arg2Type);
     }
 
     @Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/OracleDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/OracleDBFunctionSymbolFactory.java
@@ -9,6 +9,7 @@ import it.unibz.inf.ontop.model.type.DBTermType;
 import it.unibz.inf.ontop.model.type.DBTypeFactory;
 import it.unibz.inf.ontop.model.type.RDFDatatype;
 import it.unibz.inf.ontop.model.type.TypeFactory;
+import it.unibz.inf.ontop.model.vocabulary.SPARQL;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -575,5 +576,13 @@ public class OracleDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
     @Override
     protected DBFunctionSymbol createDBSample(DBTermType termType) {
         return new DBSampleFunctionSymbolImpl(termType, "ANY_VALUE");
+    }
+
+    @Override
+    protected DBTermType inferOutputTypeMathOperator(String dbMathOperatorName, DBTermType arg1Type, DBTermType arg2Type) {
+        if (dbMathOperatorName.equals(SPARQL.NUMERIC_DIVIDE))
+            return dbDecimalType;
+
+        return super.inferOutputTypeMathOperator(dbMathOperatorName, arg1Type, arg2Type);
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SnowflakeDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SnowflakeDBFunctionSymbolFactory.java
@@ -8,6 +8,7 @@ import it.unibz.inf.ontop.model.term.functionsymbol.db.*;
 import it.unibz.inf.ontop.model.type.DBTermType;
 import it.unibz.inf.ontop.model.type.DBTypeFactory;
 import it.unibz.inf.ontop.model.type.TypeFactory;
+import it.unibz.inf.ontop.model.vocabulary.SPARQL;
 
 import java.util.function.Function;
 
@@ -288,5 +289,14 @@ public class SnowflakeDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbo
     @Override
     protected DBFunctionSymbol createDBSample(DBTermType termType) {
         return new DBSampleFunctionSymbolImpl(termType, "ANY_VALUE");
+    }
+
+
+    @Override
+    protected DBTermType inferOutputTypeMathOperator(String dbMathOperatorName, DBTermType arg1Type, DBTermType arg2Type) {
+        if (dbMathOperatorName.equals(SPARQL.NUMERIC_DIVIDE))
+            return dbDecimalType;
+
+        return super.inferOutputTypeMathOperator(dbMathOperatorName, arg1Type, arg2Type);
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SparkSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SparkSQLDBFunctionSymbolFactory.java
@@ -10,6 +10,7 @@ import it.unibz.inf.ontop.model.term.TermFactory;
 import it.unibz.inf.ontop.model.term.functionsymbol.db.*;
 import it.unibz.inf.ontop.model.type.DBTermType;
 import it.unibz.inf.ontop.model.type.TypeFactory;
+import it.unibz.inf.ontop.model.vocabulary.SPARQL;
 
 
 import java.util.function.Function;
@@ -304,6 +305,14 @@ public class SparkSQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
     @Override
     protected DBFunctionSymbol createDBSample(DBTermType termType) {
         return new DBSampleFunctionSymbolImpl(termType, "FIRST");
+    }
+
+    @Override
+    protected DBTermType inferOutputTypeMathOperator(String dbMathOperatorName, DBTermType arg1Type, DBTermType arg2Type) {
+        if (dbMathOperatorName.equals(SPARQL.NUMERIC_DIVIDE))
+            return dbDecimalType;
+
+        return super.inferOutputTypeMathOperator(dbMathOperatorName, arg1Type, arg2Type);
     }
 }
 

--- a/mapping/sql/core/src/main/java/it/unibz/inf/ontop/spec/mapping/impl/SQLMappingExtractor.java
+++ b/mapping/sql/core/src/main/java/it/unibz/inf/ontop/spec/mapping/impl/SQLMappingExtractor.java
@@ -10,6 +10,7 @@ import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.injection.OntopMappingSQLSettings;
 import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.transform.NoNullValueEnforcer;
+import it.unibz.inf.ontop.iq.type.NotYetTypedBinaryMathOperationTransformer;
 import it.unibz.inf.ontop.spec.OBDASpecInput;
 import it.unibz.inf.ontop.spec.dbschema.ImplicitDBConstraintsProviderFactory;
 import it.unibz.inf.ontop.spec.mapping.MappingAssertion;
@@ -43,6 +44,7 @@ public class SQLMappingExtractor implements MappingExtractor {
     private final MappingCanonicalTransformer canonicalTransformer;
     private final MappingCaster mappingCaster;
     private final NotYetTypedEqualityTransformer mappingEqualityTransformer;
+    private final NotYetTypedBinaryMathOperationTransformer mappingBinaryMathOperationTransformer;
     private final NoNullValueEnforcer noNullValueEnforcer;
     private final IntermediateQueryFactory iqFactory;
     private final JDBCMetadataProviderFactory metadataProviderFactory;
@@ -71,6 +73,7 @@ public class SQLMappingExtractor implements MappingExtractor {
                                 MappingCanonicalTransformer canonicalTransformer,
                                 MappingCaster mappingCaster,
                                 NotYetTypedEqualityTransformer mappingEqualityTransformer,
+                                NotYetTypedBinaryMathOperationTransformer mappingBinaryMathOperatioNTransformer,
                                 NoNullValueEnforcer noNullValueEnforcer,
                                 IntermediateQueryFactory iqFactory,
                                 MetaMappingExpander metamappingExpander,
@@ -87,6 +90,7 @@ public class SQLMappingExtractor implements MappingExtractor {
         this.canonicalTransformer = canonicalTransformer;
         this.mappingCaster = mappingCaster;
         this.mappingEqualityTransformer = mappingEqualityTransformer;
+        this.mappingBinaryMathOperationTransformer = mappingBinaryMathOperatioNTransformer;
         this.noNullValueEnforcer = noNullValueEnforcer;
         this.iqFactory = iqFactory;
         this.lensMetadataProviderFactory = lensMetadataProviderFactory;
@@ -155,7 +159,8 @@ public class SQLMappingExtractor implements MappingExtractor {
         for (MappingAssertion assertion : expMapping) {
             IQTree tree = assertion.getQuery().getTree();
             IQTree equalityTransformedTree = mappingEqualityTransformer.transform(tree);
-            IQTree normalizedTree = equalityTransformedTree.normalizeForOptimization(assertion.getQuery().getVariableGenerator());
+            IQTree binaryMathOperationsTransformedTree = mappingBinaryMathOperationTransformer.transform(equalityTransformedTree);
+            IQTree normalizedTree = binaryMathOperationsTransformedTree.normalizeForOptimization(assertion.getQuery().getVariableGenerator());
             IQTree noNullTree = noNullValueEnforcer.transform(normalizedTree);
             if (noNullTree.isDeclaredAsEmpty())
                 continue;

--- a/mapping/sql/core/src/main/java/it/unibz/inf/ontop/spec/mapping/pp/impl/MetaMappingExpanderImpl.java
+++ b/mapping/sql/core/src/main/java/it/unibz/inf/ontop/spec/mapping/pp/impl/MetaMappingExpanderImpl.java
@@ -9,6 +9,7 @@ import it.unibz.inf.ontop.injection.OntopSQLCredentialSettings;
 import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.node.NativeNode;
 import it.unibz.inf.ontop.iq.transform.IQTree2NativeNodeGenerator;
+import it.unibz.inf.ontop.iq.type.NotYetTypedBinaryMathOperationTransformer;
 import it.unibz.inf.ontop.model.atom.RDFAtomPredicate;
 import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.model.vocabulary.RDF;
@@ -31,6 +32,7 @@ public class MetaMappingExpanderImpl implements MetaMappingExpander {
     private final IntermediateQueryFactory iqFactory;
     private final TermFactory termFactory;
     private final NotYetTypedEqualityTransformer mappingEqualityTransformer;
+    private final NotYetTypedBinaryMathOperationTransformer mappingBinaryMathOperationTransformer;
     private final IQTree2NativeNodeGenerator nativeNodeGenerator;
     private final OntopSQLCredentialSettings settings;
 
@@ -39,12 +41,14 @@ public class MetaMappingExpanderImpl implements MetaMappingExpander {
                                     IntermediateQueryFactory iqFactory,
                                     TermFactory termFactory,
                                     NotYetTypedEqualityTransformer mappingEqualityTransformer,
+                                    NotYetTypedBinaryMathOperationTransformer mappingBinaryMathOperationTransformer,
                                     IQTree2NativeNodeGenerator nativeNodeGenerator,
                                     OntopSQLCredentialSettings settings) {
         this.substitutionFactory = substitutionFactory;
         this.iqFactory = iqFactory;
         this.termFactory = termFactory;
         this.mappingEqualityTransformer = mappingEqualityTransformer;
+        this.mappingBinaryMathOperationTransformer = mappingBinaryMathOperationTransformer;
         this.nativeNodeGenerator = nativeNodeGenerator;
         this.settings = settings;
     }
@@ -115,7 +119,8 @@ public class MetaMappingExpanderImpl implements MetaMappingExpander {
             IQTree tree = iqFactory.createUnaryIQTree(iqFactory.createDistinctNode(), constructionTree);
 
             IQTree transformedTree = mappingEqualityTransformer.transform(tree);
-            return nativeNodeGenerator.generate(transformedTree, dbParameters, true);
+            IQTree binaryMathOperationTransformedTree = mappingBinaryMathOperationTransformer.transform(transformedTree);
+            return nativeNodeGenerator.generate(binaryMathOperationTransformedTree, dbParameters, true);
         }
 
         MappingAssertion createExpansion(Substitution<ImmutableTerm> values) {

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/AbstractBindTestWithFunctions.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/AbstractBindTestWithFunctions.java
@@ -1380,4 +1380,14 @@ public abstract class AbstractBindTestWithFunctions extends AbstractDockerRDF4JT
         assertEquals(10, runQueryAndCount(query));
     }
 
+    @Test
+    public void testDivisionOutputType() {
+        String query = "PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\nSELECT ?v WHERE { dc:divisionResult dc:value ?v } ";
+        executeAndCompareValues(query, getDivisionOutputTypeExpectedResults());
+    }
+
+    protected ImmutableSet<String> getDivisionOutputTypeExpectedResults() {
+        return ImmutableSet.of("\"3\"^^xsd:integer");
+    }
+
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/BindWithFunctionsBigQueryTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/bigquery/BindWithFunctionsBigQueryTest.java
@@ -169,4 +169,9 @@ public class BindWithFunctionsBigQueryTest extends AbstractBindTestWithFunctions
     public void testDaysBetweenDateMappingInput() {
         super.testDaysBetweenDateMappingInput();
     }
+
+    @Override
+    protected ImmutableSet<String> getDivisionOutputTypeExpectedResults() {
+        return ImmutableSet.of("\"3.3333333333333335\"^^xsd:decimal");
+    }
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mariadb/BindWithFunctionsMariaDBTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mariadb/BindWithFunctionsMariaDBTest.java
@@ -71,4 +71,9 @@ public class BindWithFunctionsMariaDBTest extends AbstractBindTestWithFunctions 
         return ImmutableList.of("\"0.5000000000000000000000000000000000\"^^xsd:float");
     }
 
+    @Override
+    protected ImmutableSet<String> getDivisionOutputTypeExpectedResults() {
+        return ImmutableSet.of("\"3.3333\"^^xsd:decimal");
+    }
+
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mysql/BindWithFunctionsMySQLTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mysql/BindWithFunctionsMySQLTest.java
@@ -71,4 +71,9 @@ public class BindWithFunctionsMySQLTest extends AbstractBindTestWithFunctions {
         return ImmutableList.of("\"0.500000000000000000000000000000\"^^xsd:float");
     }
 
+    @Override
+    protected ImmutableSet<String> getDivisionOutputTypeExpectedResults() {
+        return ImmutableSet.of("\"3.3333\"^^xsd:decimal");
+    }
+
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/oracle/BindWithFunctionsOracleTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/oracle/BindWithFunctionsOracleTest.java
@@ -110,4 +110,9 @@ public class BindWithFunctionsOracleTest extends AbstractBindTestWithFunctions {
         super.testDaysBetweenDateMappingInput();
     }
 
+    @Override
+    protected ImmutableSet<String> getDivisionOutputTypeExpectedResults() {
+        return ImmutableSet.of("\"3.33333333333333333333333333333333333333E00\"^^xsd:decimal");
+    }
+
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/snowflake/BindWithFunctionsSnowflakeTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/snowflake/BindWithFunctionsSnowflakeTest.java
@@ -85,4 +85,9 @@ public class BindWithFunctionsSnowflakeTest extends AbstractBindTestWithFunction
     public void testSecondsBetweenMappingInput() {
         super.testSecondsBetweenMappingInput();
     }
+
+    @Override
+    protected ImmutableSet<String> getDivisionOutputTypeExpectedResults() {
+        return ImmutableSet.of("\"3.333333\"^^xsd:decimal");
+    }
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/spark/BindWithFunctionsSparkTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/spark/BindWithFunctionsSparkTest.java
@@ -106,4 +106,9 @@ public class BindWithFunctionsSparkTest extends AbstractBindTestWithFunctions {
     @Disabled("Duration functions currently not supported for Spark SQL")
     @Test
     public void testSecondsBetweenMappingInput() { super.testSecondsBetweenMappingInput(); }
+
+    @Override
+    protected ImmutableSet<String> getDivisionOutputTypeExpectedResults() {
+        return ImmutableSet.of("\"3.3333333333333335\"^^xsd:decimal");
+    }
 }

--- a/test/lightweight-tests/src/test/resources/books/athena/books-athena.obda
+++ b/test/lightweight-tests/src/test/resources/books/athena/books-athena.obda
@@ -8,4 +8,8 @@ ns:  http://example.org/ns#
 mappingId	mapping1
 target	:{id} a :Book ; dc:title {title}@en ; ns:price {price} ; ns:discount {discount} ; ns:pubYear {publication_date} ; dc:description {description}@en .
 source	SELECT id, title, price, discount, publication_date, description, lang FROM books.books WHERE lang = 'en'
+
+mappingId	divisionTest
+target	dc:divisionResult dc:value {value} .
+source	SELECT (10 / 3) as value
 ]]

--- a/test/lightweight-tests/src/test/resources/books/bigquery/books-bigquery.obda
+++ b/test/lightweight-tests/src/test/resources/books/bigquery/books-bigquery.obda
@@ -8,4 +8,8 @@ ns:  http://example.org/ns#
 mappingId	mapping1
 target	:{id} a :Book ; dc:title {title}@en ; ns:price {price} ; ns:discount {discount} ; ns:pubYear {publication_date} ; dc:description {description}@en .
 source	SELECT id, title, price, discount, publication_date, description, lang FROM books.books WHERE lang = 'en'
+
+mappingId	divisionTest
+target	dc:divisionResult dc:value {value} .
+source	SELECT (10 / 3) as value
 ]]

--- a/test/lightweight-tests/src/test/resources/books/books.obda
+++ b/test/lightweight-tests/src/test/resources/books/books.obda
@@ -8,4 +8,8 @@ ns:  http://example.org/ns#
 mappingId	mapping1
 target	:{id} a :Book ; dc:title {title}@en ; ns:price {price} ; ns:discount {discount} ; ns:pubYear {publication_date} ; dc:description {description}@en .
 source	SELECT id, title, price, discount, publication_date, description, lang FROM books WHERE lang = 'en'
+
+mappingId	divisionTest
+target	dc:divisionResult dc:value {value} .
+source	SELECT (10 / 3) as value
 ]]

--- a/test/lightweight-tests/src/test/resources/books/db2/books-db2.obda
+++ b/test/lightweight-tests/src/test/resources/books/db2/books-db2.obda
@@ -8,5 +8,9 @@ ns:  http://example.org/ns#
 mappingId	mapping1
 target	:{id} a :Book ; dc:title {title}@en ; ns:price {price} ; ns:discount {discount} ; ns:pubYear {publication_date} ; dc:description {description}@en .
 source	SELECT id, title, price, discount, publication_date, description, lang FROM db2inst1.books WHERE lang = 'en'
+
+mappingId	divisionTest
+target	dc:divisionResult dc:value {value} .
+source	SELECT (10 / 3) as value
 ]]
 

--- a/test/lightweight-tests/src/test/resources/books/dremio/books-dremio.obda
+++ b/test/lightweight-tests/src/test/resources/books/dremio/books-dremio.obda
@@ -8,4 +8,8 @@ ns:  http://example.org/ns#
 mappingId	mapping1
 target	:{id} a :Book ; dc:title {title}@en ; ns:price {price} ; ns:discount {discount} ; ns:pubYear {publication_date} ; dc:description {description}@en .
 source	SELECT id, title, price, discount, publication_date, description, lang FROM books WHERE lang = 'en'
+
+mappingId	divisionTest
+target	dc:divisionResult dc:value {value} .
+source	SELECT (10 / 3) as value
 ]]

--- a/test/lightweight-tests/src/test/resources/books/duckdb/books-duckdb.obda
+++ b/test/lightweight-tests/src/test/resources/books/duckdb/books-duckdb.obda
@@ -8,4 +8,8 @@ ns:  http://example.org/ns#
 mappingId	mapping1
 target	:{id} a :Book ; dc:title {title}@en ; ns:price {price} ; ns:discount {discount} ; ns:pubYear {publication_date} ; dc:description {description}@en .
 source	SELECT id, title, price, discount, publication_date, description, lang FROM books.books WHERE lang = 'en'
+
+mappingId	divisionTest
+target	dc:divisionResult dc:value {value} .
+source	SELECT (10 / 3) as value
 ]]

--- a/test/lightweight-tests/src/test/resources/books/oracle/books-oracle.obda
+++ b/test/lightweight-tests/src/test/resources/books/oracle/books-oracle.obda
@@ -8,4 +8,8 @@ ns:  http://example.org/ns#
 mappingId	mapping1
 target	:{id} a :Book ; dc:title {title}@en ; ns:price {price} ; ns:discount {discount} ; ns:pubYear {publication_date} ; dc:description {description}@en .
 source	SELECT id, title, price, discount, publication_date, description, lang FROM books.books WHERE lang = 'en'
+
+mappingId	divisionTest
+target	dc:divisionResult dc:value {value} .
+source	SELECT (10 / 3) as value FROM dual
 ]]

--- a/test/lightweight-tests/src/test/resources/books/redshift/books-redshift.obda
+++ b/test/lightweight-tests/src/test/resources/books/redshift/books-redshift.obda
@@ -8,4 +8,8 @@ ns:  http://example.org/ns#
 mappingId	mapping1
 target	:{id} a :Book ; dc:title {title}@en ; ns:price {price} ; ns:discount {discount} ; ns:pubYear {publication_date} ; dc:description {description}@en .
 source	SELECT id, title, price, discount, publication_date, description, lang FROM books WHERE lang = 'en'
+
+mappingId	divisionTest
+target	dc:divisionResult dc:value {value} .
+source	SELECT (10 / 3) as value
 ]]

--- a/test/lightweight-tests/src/test/resources/books/snowflake/books-snowflake.obda
+++ b/test/lightweight-tests/src/test/resources/books/snowflake/books-snowflake.obda
@@ -8,4 +8,8 @@ ns:  http://example.org/ns#
 mappingId	mapping1
 target	:{id} a :Book ; dc:title {title}@en ; ns:price {price} ; ns:discount {discount} ; ns:pubYear {publication_date} ; dc:description {description}@en .
 source	SELECT id, title, price, discount, publication_date, description, lang FROM ontop_test.books.books WHERE lang = 'en'
+
+mappingId	divisionTest
+target	dc:divisionResult dc:value {value} .
+source	SELECT (10 / 3) as value
 ]]


### PR DESCRIPTION
Implemented feature to support type inference for mathematical binary expressions used in mapping and lens files.
Implemented transformer that transforms un-typed math binary function symbols into types ones, if their types can be inferred during execution.