### PR TITLE
Ignoring invalid mapping entries will now also ignore invalid lenses

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/IgnoreInvalidMappingEntriesTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/IgnoreInvalidMappingEntriesTest.java
@@ -24,10 +24,11 @@ public class IgnoreInvalidMappingEntriesTest extends AbstractRDF4JTest {
     private static final String OBDA_FILE = "/ignore-invalid-mapping-entries/test.obda";
     private static final String SQL_SCRIPT = "/ignore-invalid-mapping-entries/test.sql";
     private static final String PROPERTY_FILE = "/ignore-invalid-mapping-entries/ignore-invalid.properties";
+    private static final String LENS_FILE = "/ignore-invalid-mapping-entries/lenses.json";
 
     @BeforeClass
     public static void before() throws IOException, SQLException {
-        initOBDA(SQL_SCRIPT, OBDA_FILE, null, PROPERTY_FILE, null);
+        initOBDA(SQL_SCRIPT, OBDA_FILE, null, PROPERTY_FILE, LENS_FILE);
     }
 
     @AfterClass
@@ -71,6 +72,27 @@ public class IgnoreInvalidMappingEntriesTest extends AbstractRDF4JTest {
                 "SELECT  ?v \n" +
                 "WHERE {\n" +
                 " ?v a :Bird . \n" +
+                "}";
+        assertEquals(0, runQueryAndCount(query));
+    }
+
+    @Test
+    public void testAccessNonExistentLensColumn() {
+        String query = "PREFIX : <http://www.ontop-vkg.com/ignore-invalid-test#>\n" +
+                "SELECT  ?v \n" +
+                "WHERE {\n" +
+                " ?d a :Dog1 . \n" +
+                " ?d :colour ?v . \n" +
+                "}";
+        assertEquals(0, runQueryAndCount(query));
+    }
+
+    @Test
+    public void testAccessInvalidLens() {
+        String query = "PREFIX : <http://www.ontop-vkg.com/ignore-invalid-test#>\n" +
+                "SELECT  ?v \n" +
+                "WHERE {\n" +
+                " ?v a :Dog2 . \n" +
                 "}";
         assertEquals(0, runQueryAndCount(query));
     }

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/IgnoreInvalidMappingEntriesTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/IgnoreInvalidMappingEntriesTest.java
@@ -103,16 +103,16 @@ public class IgnoreInvalidMappingEntriesTest extends AbstractRDF4JTest {
         String dbExtract = "/ignore-invalid-mapping-entries/test.db-extract.json";
         ImmutableSet<Lens> lenses = loadLensesH2(AbstractRDF4JTest.class.getResource(lens).getPath(),
                 AbstractRDF4JTest.class.getResource(dbExtract).getPath());
-        assertEquals(1, lenses.size());
+        assertEquals(2, lenses.size());
     }
 
     @Test
-    public void testInvalidLensNonExistendTable() throws Exception {
+    public void testInvalidLensNonExistentTable() throws Exception {
         String lens = "/ignore-invalid-mapping-entries/lenses-table.json";
         String dbExtract = "/ignore-invalid-mapping-entries/test.db-extract.json";
         ImmutableSet<Lens> lenses = loadLensesH2(AbstractRDF4JTest.class.getResource(lens).getPath(),
                 AbstractRDF4JTest.class.getResource(dbExtract).getPath());
-        assertEquals(1, lenses.size());
+        assertEquals(2, lenses.size());
     }
 
     public static ImmutableSet<Lens> loadLensesH2(String viewFilePath,

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/IgnoreInvalidMappingEntriesTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/IgnoreInvalidMappingEntriesTest.java
@@ -1,11 +1,20 @@
 package it.unibz.inf.ontop.rdf4j.repository;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+import it.unibz.inf.ontop.dbschema.ImmutableMetadata;
+import it.unibz.inf.ontop.dbschema.Lens;
+import it.unibz.inf.ontop.dbschema.LensMetadataProvider;
+import it.unibz.inf.ontop.dbschema.SerializedMetadataProvider;
+import it.unibz.inf.ontop.injection.OntopSQLCoreConfiguration;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.sql.SQLException;
 
 import static org.junit.Assert.assertEquals;
@@ -64,5 +73,62 @@ public class IgnoreInvalidMappingEntriesTest extends AbstractRDF4JTest {
                 " ?v a :Bird . \n" +
                 "}";
         assertEquals(0, runQueryAndCount(query));
+    }
+
+    @Test
+    public void testInvalidLensNonExistentColumn() throws Exception {
+        String lens = "/ignore-invalid-mapping-entries/lenses-column.json";
+        String dbExtract = "/ignore-invalid-mapping-entries/test.db-extract.json";
+        ImmutableSet<Lens> lenses = loadLensesH2(AbstractRDF4JTest.class.getResource(lens).getPath(),
+                AbstractRDF4JTest.class.getResource(dbExtract).getPath());
+        assertEquals(1, lenses.size());
+    }
+
+    @Test
+    public void testInvalidLensNonExistendTable() throws Exception {
+        String lens = "/ignore-invalid-mapping-entries/lenses-table.json";
+        String dbExtract = "/ignore-invalid-mapping-entries/test.db-extract.json";
+        ImmutableSet<Lens> lenses = loadLensesH2(AbstractRDF4JTest.class.getResource(lens).getPath(),
+                AbstractRDF4JTest.class.getResource(dbExtract).getPath());
+        assertEquals(1, lenses.size());
+    }
+
+    public static ImmutableSet<Lens> loadLensesH2(String viewFilePath,
+                                                  String dbMetadataFilePath)
+            throws Exception {
+
+        return loadViewDefinitions(
+                viewFilePath,
+                dbMetadataFilePath,
+                OntopSQLCoreConfiguration.defaultBuilder()
+                        .jdbcUrl("jdbc:h2:mem:nowhere")
+                        .jdbcDriver("org.h2.Driver")
+                        .propertyFile(AbstractRDF4JTest.class.getResource(PROPERTY_FILE).getPath())
+                        .build()
+        );
+    }
+
+    private static ImmutableSet<Lens> loadViewDefinitions(String viewFilePath, String dbMetadataFilePath, OntopSQLCoreConfiguration configuration) throws Exception {
+        Injector injector = configuration.getInjector();
+        SerializedMetadataProvider.Factory serializedMetadataProviderFactory = injector.getInstance(SerializedMetadataProvider.Factory.class);
+        LensMetadataProvider.Factory viewMetadataProviderFactory = injector.getInstance(LensMetadataProvider.Factory.class);
+
+        SerializedMetadataProvider dbMetadataProvider;
+        try (Reader dbMetadataReader = new FileReader(dbMetadataFilePath)) {
+            dbMetadataProvider = serializedMetadataProviderFactory.getMetadataProvider(dbMetadataReader);
+        }
+
+        LensMetadataProvider viewMetadataProvider;
+        try (Reader viewReader = new FileReader(viewFilePath)) {
+            viewMetadataProvider = viewMetadataProviderFactory.getMetadataProvider(dbMetadataProvider, viewReader);
+        }
+
+        ImmutableMetadata metadata = ImmutableMetadata.extractImmutableMetadata(viewMetadataProvider);
+
+        return metadata.getAllRelations().stream()
+                .filter(r -> r instanceof Lens)
+                .map(r -> (Lens) r)
+                .collect(ImmutableCollectors.toSet());
+
     }
 }

--- a/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/ignore-invalid.properties
+++ b/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/ignore-invalid.properties
@@ -1,2 +1,3 @@
 ontop.ignoreInvalidMappingEntries = true
+ontop.ignoreInvalidLensEntries = true
 ontop.allowRetrievingBlackBoxViewMetadataFromDB = true

--- a/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/lenses-column.json
+++ b/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/lenses-column.json
@@ -1,0 +1,32 @@
+{
+  "relations": [
+    {
+      "name": ["\"lenses\"", "\"invalid\""],
+      "baseRelation": ["\"rabbits\""],
+      "columns": {
+        "added":  [
+          {
+            "name": "\"new_breed\"",
+            "expression": "CONCAT(\"breed\",'!')"
+          }
+        ],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"valid\""],
+      "baseRelation": ["\"dogs\""],
+      "columns": {
+        "added":  [
+          {
+            "name": "\"new_breed\"",
+            "expression": "CONCAT(\"breed\",'!')"
+          }
+        ],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    }
+  ]
+}

--- a/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/lenses-table.json
+++ b/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/lenses-table.json
@@ -1,0 +1,27 @@
+{
+  "relations": [
+    {
+      "name": ["\"lenses\"", "\"invalid\""],
+      "baseRelation": ["\"birds\""],
+      "columns": {
+        "added":  [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"valid\""],
+      "baseRelation": ["\"dogs\""],
+      "columns": {
+        "added":  [
+          {
+            "name": "\"new_breed\"",
+            "expression": "CONCAT(\"breed\",'!')"
+          }
+        ],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    }
+  ]
+}

--- a/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/lenses.json
+++ b/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/lenses.json
@@ -1,0 +1,32 @@
+{
+  "relations": [
+    {
+      "name": ["\"lenses\"", "\"valid\""],
+      "baseRelation": ["\"dogs\""],
+      "columns": {
+        "added":  [
+          {
+            "name": "\"new_breed\"",
+            "expression": "CONCAT(\"breed\",'!')"
+          }
+        ],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"invalid\""],
+      "baseRelation": ["\"inv\""],
+      "columns": {
+        "added":  [
+          {
+            "name": "\"new_breed\"",
+            "expression": "CONCAT(\"breed\",'!')"
+          }
+        ],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    }
+  ]
+}

--- a/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/test.db-extract.json
+++ b/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/test.db-extract.json
@@ -1,0 +1,52 @@
+{
+  "metadata": {
+    "driverName": "PostgreSQL JDBC Driver",
+    "dbmsVersion": "12.5 (Debian 12.5-1.pgdg100+1)",
+    "driverVersion": "42.2.12",
+    "idFactoryType": "POSTGRESQL",
+    "extractionTime": "2021-01-15T09:27:31",
+    "dbmsProductName": "PostgreSQL",
+    "quotationString": "\""
+  },
+  "relations": [
+    {
+      "name": [
+        "\"rabbits\""
+      ],
+      "columns": [
+        {
+          "name": "\"name\"",
+          "datatype": "varchar(100)",
+          "isNullable": false
+        },
+        {
+          "name": "\"age\"",
+          "datatype": "int4",
+          "isNullable": false
+        }
+      ]
+    },
+    {
+      "name": [
+        "\"dogs\""
+      ],
+      "columns": [
+        {
+          "name": "\"name\"",
+          "datatype": "varchar(100)",
+          "isNullable": false
+        },
+        {
+          "name": "\"breed\"",
+          "datatype": "varchar(100)",
+          "isNullable": false
+        },
+        {
+          "name": "\"age\"",
+          "datatype": "int4",
+          "isNullable": false
+        }
+      ]
+    }
+  ]
+}

--- a/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/test.obda
+++ b/binding/rdf4j/src/test/resources/ignore-invalid-mapping-entries/test.obda
@@ -32,5 +32,13 @@ source		SELECT name, breed FROM rabbits;
 mappingId	MAPID-birds
 target		:animals/{name} a :Animal; a :Bird; .
 source		SELECT name FROM birds;
+
+mappingId	MAPID-dog1
+target		:animals/{name} a :Animal; a :Dog1; :colour {colour} .
+source		SELECT name, colour FROM \"lenses\".\"valid\";
+
+mappingId	MAPID-dog2
+target		:animals/{name} a :Animal; a :Dog2 .
+source		SELECT name FROM \"lenses\".\"invalid\";
 ]]
 

--- a/core/model/src/main/resources/property_description.json
+++ b/core/model/src/main/resources/property_description.json
@@ -69,7 +69,7 @@
   },
   "ontop.ignoreInvalidLensEntries": {
     "type": "Boolean",
-    "description": "Since 5.1.0. Default value: `false`. If `true`, lens entries that result in an error will be ignored instead of failing the initialization procedure."
+    "description": "Since 5.1.0. Default value: `false`. If `true`, lens entries that result in an error will be created as empty instead of failing the initialization procedure. Expected to be used together with `ontop.ignoreInvalidMappingEntries`."
   },
   "ontop.enableValuesNode": {
     "type": "Boolean",

--- a/core/model/src/main/resources/property_description.json
+++ b/core/model/src/main/resources/property_description.json
@@ -67,6 +67,10 @@
     "type": "Boolean",
     "description": "Since 5.1.0. Default value: `false`. If `true`, mapping entries that result in an error will be ignored instead of failing the initialization procedure."
   },
+  "ontop.ignoreInvalidLensEntries": {
+    "type": "Boolean",
+    "description": "Since 5.1.0. Default value: `false`. If `true`, lens entries that result in an error will be ignored instead of failing the initialization procedure."
+  },
   "ontop.enableValuesNode": {
     "type": "Boolean",
     "description": "Since 4.2.0. Default value: `true`. If false Union Nodes are used instead of Values Nodes for facts."

--- a/core/obda/src/main/java/it/unibz/inf/ontop/injection/OntopOBDASettings.java
+++ b/core/obda/src/main/java/it/unibz/inf/ontop/injection/OntopOBDASettings.java
@@ -15,6 +15,7 @@ public interface OntopOBDASettings extends OntopModelSettings {
      * ignored instead.
      */
     boolean ignoreInvalidMappingEntries();
+    boolean ignoreInvalidLensEntries();
 
     //--------------------------
     // Keys
@@ -23,4 +24,5 @@ public interface OntopOBDASettings extends OntopModelSettings {
     String  SAME_AS = "ontop.sameAs";
     String ALLOW_RETRIEVING_BLACK_BOX_VIEW_METADATA_FROM_DB = "ontop.allowRetrievingBlackBoxViewMetadataFromDB";
     String IGNORE_INVALID_MAPPING_ENTRIES = "ontop.ignoreInvalidMappingEntries";
+    String IGNORE_INVALID_LENS_ENTRIES = "ontop.ignoreInvalidLensEntries";
 }

--- a/core/obda/src/main/java/it/unibz/inf/ontop/injection/impl/OntopOBDASettingsImpl.java
+++ b/core/obda/src/main/java/it/unibz/inf/ontop/injection/impl/OntopOBDASettingsImpl.java
@@ -39,4 +39,9 @@ public class OntopOBDASettingsImpl extends OntopModelSettingsImpl implements Ont
     public boolean ignoreInvalidMappingEntries() {
         return getRequiredBoolean(IGNORE_INVALID_MAPPING_ENTRIES);
     }
+
+    @Override
+    public boolean ignoreInvalidLensEntries() {
+        return getRequiredBoolean(IGNORE_INVALID_LENS_ENTRIES);
+    }
 }

--- a/core/obda/src/main/resources/it/unibz/inf/ontop/injection/obda-default.properties
+++ b/core/obda/src/main/resources/it/unibz/inf/ontop/injection/obda-default.properties
@@ -9,6 +9,7 @@ ontop.sameAs=false
 
 ontop.allowRetrievingBlackBoxViewMetadataFromDB = false
 ontop.ignoreInvalidMappingEntries = false
+ontop.ignoreInvalidLensEntries = false
 
 
 ##########################################

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/LensMetadataProviderImpl.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/LensMetadataProviderImpl.java
@@ -45,7 +45,7 @@ public class LensMetadataProviderImpl implements LensMetadataProvider {
     @Nullable
     private MetadataLookup mergedMetadataLookupForFK;
 
-    private final boolean ignoreInvalidMappingEntries;
+    private final boolean ignoreInvalidLensEntries;
 
     @AssistedInject
     protected LensMetadataProviderImpl(@Assisted MetadataProvider parentMetadataProvider,
@@ -88,7 +88,7 @@ public class LensMetadataProviderImpl implements LensMetadataProvider {
         // Depends on this provider for supporting views of level >1
         this.dependencyCacheMetadataLookup = new CachingMetadataLookupWithDependencies(this);
 
-        ignoreInvalidMappingEntries = ((OntopOBDASettings)coreSingletons.getSettings()).ignoreInvalidMappingEntries();
+        ignoreInvalidLensEntries = ((OntopOBDASettings)coreSingletons.getSettings()).ignoreInvalidLensEntries();
     }
 
     /**
@@ -121,7 +121,7 @@ public class LensMetadataProviderImpl implements LensMetadataProvider {
                     cachedLenses.put(id, jsonLens.createViewDefinition(getDBParameters(), dependencyCacheMetadataLookup.getCachingMetadataLookupFor(id)));
                 return cachedLenses.get(id);
             } catch (IllegalArgumentException | MetadataExtractionException e) {
-                if(!ignoreInvalidMappingEntries)
+                if(!ignoreInvalidLensEntries)
                     throw e;
                 cachedLenses.put(id, new DatabaseTableDefinition(ImmutableList.of(id), new RelationDefinition.AttributeListBuilder() {
 
@@ -195,7 +195,7 @@ public class LensMetadataProviderImpl implements LensMetadataProvider {
             try {
                 parentMetadataProvider.insertIntegrityConstraints(relation, metadataLookupForFK);
             } catch (IllegalArgumentException | MetadataExtractionException e) {
-                if(!ignoreInvalidMappingEntries)
+                if(!ignoreInvalidLensEntries)
                     throw e;
             }
         }


### PR DESCRIPTION
When a lens with invalid properties (e.g. accessing invalid table, reading invalid column) is encountered and the ignoreInvalidMappingEntries property is set, such invalid lenses will now also be ignored.

The LensMetadataProvider will instead return an empty relation definition in those cases.