### PR TITLE
Removed immutableCopy call from stream.reduce in FunctionalDependenciesImpl

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/FunctionalDependenciesImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/FunctionalDependenciesImpl.java
@@ -96,13 +96,13 @@ public class FunctionalDependenciesImpl implements FunctionalDependencies {
         var collectedDependencies = Streams.concat(dependencyPairs.stream(), inferTransitiveDependencies(dependencyPairs))
                 .collect(Collectors.groupingBy(Map.Entry::getKey))
                 .entrySet().stream()
-                .map(e -> new FunctionalDependency(e.getKey(), e.getValue().stream()
+                .map(e -> new FunctionalDependency(e.getKey(), ImmutableSet.copyOf(e.getValue().stream()
                         .reduce(
-                                ImmutableSet.of(),
-                                (set, entry) -> Sets.union(set, entry.getValue()).immutableCopy(),
-                                (set1, set2) -> Sets.union(set1, set2).immutableCopy()
+                                Set.of(),
+                                (set, entry) -> Sets.union(set, entry.getValue()),
+                                (set1, set2) -> Sets.union(set1, set2)
                         )
-                ))
+                )))
                 .collect(ImmutableCollectors.toSet());
 
         var dependenciesToRemove = collectedDependencies.stream()


### PR DESCRIPTION
Calling immutableCopy during each step of the `reduce` is not efficient. Instead made `reduce` work with SetViews and only created an immutable copy at the end.