### PR TITLE
Fixed Old Version SQLServer LimitOffset normalization

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SQLServerLimitOffsetOldVersionNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SQLServerLimitOffsetOldVersionNormalizer.java
@@ -83,9 +83,10 @@ public class SQLServerLimitOffsetOldVersionNormalizer extends DefaultRecursiveIQ
         } else {
             newChild = child;
         }
+        IQTree normalizedChild = this.transform(newChild, variableGenerator);
 
         IQTree newTree = iqFactory.createUnaryIQTree(newFilter,
-                iqFactory.createUnaryIQTree(newConstruction, newChild));
+                iqFactory.createUnaryIQTree(newConstruction, normalizedChild));
 
         // Additional CONSTRUCTION necessary when subtree leaf in NaryIQTree (e.g. sub-query)
         return iqFactory.createUnaryIQTree(


### PR DESCRIPTION
Previously, the Limit and Offset normalizer for old versions of SQLServer did not apply the transformation to subqueries in case they contain another slice node.

Because of that, complex queries failed on old versions of SQLServer.

This pull request fixes this issue.