### PR TITLE
Functional-dependency-based left-join optimization made more robust to nesting on the right

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/ProjectDenormalizedTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/ProjectDenormalizedTest.java
@@ -44,6 +44,24 @@ public class ProjectDenormalizedTest extends AbstractRDF4JTest {
     }
 
     @Test
+    public void testProvince1() {
+        String query = "PREFIX : <http://example.org/voc#>\n" +
+                "SELECT * \n" +
+                "WHERE {\n" +
+                "   ?p a :Province . \n " +
+                "   OPTIONAL { ?p :name ?provinceName } \n" +
+                "   OPTIONAL { \n" +
+                "      ?p :region ?r . \n " +
+                "      OPTIONAL { ?r :name ?regionName } \n" +
+                "   }\n" +
+                "}";
+
+        String sql = reformulateIntoNativeQuery(query);
+        assertFalse("Left joins found in " + sql, sql.toLowerCase().contains("left"));
+
+    }
+
+    @Test
     public void testProject1() {
         String query = "PREFIX : <http://example.org/voc#>\n" +
                 "SELECT * \n" +
@@ -84,6 +102,56 @@ public class ProjectDenormalizedTest extends AbstractRDF4JTest {
                 "        OPTIONAL { ?r :name ?regionName } \n" +
                 "     }\n" +
                 "   } \n" +
+                "}";
+
+        String sql = reformulateIntoNativeQuery(query);
+        assertFalse("Left joins found in " + sql, sql.toLowerCase().contains("left"));
+        assertFalse("Distinct found in " + sql, sql.toLowerCase().contains("distinct"));
+    }
+
+    @Test
+    public void testProject3() {
+        String query = "PREFIX : <http://example.org/voc#>\n" +
+                "SELECT ?project ?v ?provinceName ?regionName \n" +
+                "WHERE {\n" +
+                " ?project a :Project \n" +
+                " OPTIONAL { \n" +
+                "   ?project :municipality ?m . \n" +
+                "   OPTIONAL { ?m :name ?v }  \n" +
+                "   OPTIONAL { " +
+                "     ?m :province ?p . \n " +
+                "     OPTIONAL { ?p :name ?provinceName } \n" +
+                "     OPTIONAL { \n" +
+                "        ?p :region ?r . \n " +
+                "        OPTIONAL { ?r :name ?regionName } \n" +
+                "     }\n" +
+                "   } \n" +
+                " } \n" +
+                "}";
+
+        String sql = reformulateIntoNativeQuery(query);
+        assertFalse("Left joins found in " + sql, sql.toLowerCase().contains("left"));
+        assertFalse("Distinct found in " + sql, sql.toLowerCase().contains("distinct"));
+    }
+
+    @Test
+    public void testProject4() {
+        String query = "PREFIX : <http://example.org/voc#>\n" +
+                "SELECT DISTINCT ?project ?v ?provinceName ?regionName \n" +
+                "WHERE {\n" +
+                " ?project a :Project \n" +
+                " OPTIONAL { \n" +
+                "   ?project :municipality ?m . \n" +
+                "   OPTIONAL { ?m :name ?v }  \n" +
+                "   OPTIONAL { " +
+                "     ?m :province ?p . \n " +
+                "     OPTIONAL { ?p :name ?provinceName } \n" +
+                "     OPTIONAL { \n" +
+                "        ?p :region ?r . \n " +
+                "        OPTIONAL { ?r :name ?regionName } \n" +
+                "     }\n" +
+                "   } \n" +
+                " } \n" +
                 "}";
 
         String sql = reformulateIntoNativeQuery(query);

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/ProjectDenormalizedTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/ProjectDenormalizedTest.java
@@ -1,0 +1,93 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertFalse;
+
+public class ProjectDenormalizedTest extends AbstractRDF4JTest {
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA("/project-denormalized/db.sql", "/project-denormalized/project.obda", null, null, "/project-denormalized/lenses.json");
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void testMunicipality1() {
+        String query = "PREFIX : <http://example.org/voc#>\n" +
+                "SELECT * \n" +
+                "WHERE {\n" +
+                " ?m a :Municipality . \n" +
+                " OPTIONAL { ?m :name ?v }  \n" +
+                " OPTIONAL { " +
+                "   ?m :province ?p . \n " +
+                "   OPTIONAL { ?p :name ?provinceName } \n" +
+                "   OPTIONAL { \n" +
+                "      ?p :region ?r . \n " +
+                "      OPTIONAL { ?r :name ?regionName } \n" +
+                "   }\n" +
+                " } \n" +
+                "}";
+
+        String sql = reformulateIntoNativeQuery(query);
+        assertFalse("Left joins found in " + sql, sql.toLowerCase().contains("left"));
+
+    }
+
+    @Test
+    public void testProject1() {
+        String query = "PREFIX : <http://example.org/voc#>\n" +
+                "SELECT * \n" +
+                "WHERE {\n" +
+                " ?project a :Project \n" +
+                " OPTIONAL { \n" +
+                "   ?project :municipality ?m . \n" +
+                "   OPTIONAL { ?m :name ?v }  \n" +
+                "   OPTIONAL { " +
+                "     ?m :province ?p . \n " +
+                "     OPTIONAL { ?p :name ?provinceName } \n" +
+                "     OPTIONAL { \n" +
+                "        ?p :region ?r . \n " +
+                "        OPTIONAL { ?r :name ?regionName } \n" +
+                "     }\n" +
+                "   } \n" +
+                " } \n" +
+                "}";
+
+        String sql = reformulateIntoNativeQuery(query);
+        assertFalse("Left joins found in " + sql, sql.toLowerCase().contains("left"));
+        assertFalse("Distinct found in " + sql, sql.toLowerCase().contains("distinct"));
+    }
+
+    @Test
+    public void testProject2() {
+        String query = "PREFIX : <http://example.org/voc#>\n" +
+                "SELECT * \n" +
+                "WHERE {\n" +
+                " ?project a :Project . \n" +
+                " ?project :municipality ?m . \n" +
+                "   OPTIONAL { ?m :name ?v }  \n" +
+                "   OPTIONAL { " +
+                "     ?m :province ?p . \n " +
+                "     OPTIONAL { ?p :name ?provinceName } \n" +
+                "     OPTIONAL { \n" +
+                "        ?p :region ?r . \n " +
+                "        OPTIONAL { ?r :name ?regionName } \n" +
+                "     }\n" +
+                "   } \n" +
+                "}";
+
+        String sql = reformulateIntoNativeQuery(query);
+        assertFalse("Left joins found in " + sql, sql.toLowerCase().contains("left"));
+        assertFalse("Distinct found in " + sql, sql.toLowerCase().contains("distinct"));
+    }
+}

--- a/binding/rdf4j/src/test/resources/project-denormalized/db.sql
+++ b/binding/rdf4j/src/test/resources/project-denormalized/db.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "project"(
+    "id" INT NOT NULL,
+    "mun_id" INT,
+    "mun_label" VARCHAR(40),
+    "province_id" INT,
+    "province_label" VARCHAR(40),
+    "region_id" INT,
+    "region_label" VARCHAR(40)
+);
+ALTER TABLE "project" ADD CONSTRAINT CONSTRAINT_8 PRIMARY KEY("id");

--- a/binding/rdf4j/src/test/resources/project-denormalized/lenses.json
+++ b/binding/rdf4j/src/test/resources/project-denormalized/lenses.json
@@ -1,0 +1,45 @@
+{
+  "relations": [
+    {
+      "name": [
+        "\"lenses\"",
+        "\"projects\""
+      ],
+      "baseRelation": [
+        "\"project\""
+      ],
+      "otherFunctionalDependencies": {
+        "added": [
+          {
+            "determinants": [
+              "\"mun_id\""
+            ],
+            "dependents": [
+              "\"mun_label\"",
+              "\"province_id\"",
+              "\"region_id\""
+            ]
+          },
+          {
+            "determinants": [
+              "\"province_id\""
+            ],
+            "dependents": [
+              "\"province_label\"",
+              "\"region_id\""
+            ]
+          },
+          {
+            "determinants": [
+              "\"region_id\""
+            ],
+            "dependents": [
+              "\"region_label\""
+            ]
+          }
+        ]
+      },
+      "type": "BasicLens"
+    }
+  ]
+}

--- a/binding/rdf4j/src/test/resources/project-denormalized/lenses.json
+++ b/binding/rdf4j/src/test/resources/project-denormalized/lenses.json
@@ -17,7 +17,9 @@
             "dependents": [
               "\"mun_label\"",
               "\"province_id\"",
-              "\"region_id\""
+              "\"province_label\"",
+              "\"region_id\"",
+              "\"region_label\""
             ]
           },
           {
@@ -26,7 +28,8 @@
             ],
             "dependents": [
               "\"province_label\"",
-              "\"region_id\""
+              "\"region_id\"",
+              "\"region_label\""
             ]
           },
           {

--- a/binding/rdf4j/src/test/resources/project-denormalized/project.obda
+++ b/binding/rdf4j/src/test/resources/project-denormalized/project.obda
@@ -1,0 +1,27 @@
+[PrefixDeclaration]
+:		http://example.org/voc#
+ex:		http://example.org/
+owl:		http://www.w3.org/2002/07/owl#
+rdf:		http://www.w3.org/1999/02/22-rdf-syntax-ns#
+xsd:		http://www.w3.org/2001/XMLSchema#
+rdfs:		http://www.w3.org/2000/01/rdf-schema#
+
+[MappingDeclaration] @collection [[
+mappingId	project
+target		ex:project/{id} a :Project ; :municipality ex:mun/{mun_id} ; :province ex:province/{province_id} ; :region ex:region/{region_id} .
+source		SELECT * FROM "lenses"."projects"
+
+mappingId	mun
+target		ex:mun/{mun_id} a :Municipality ; :province ex:province/{province_id} ; :region ex:region/{region_id} ; :name {mun_label} .
+source		SELECT * FROM "lenses"."projects"
+
+mappingId	province
+target		ex:province/{province_id} a :Province ; :region ex:region/{region_id} ; :name {province_label} .
+source		SELECT * FROM "lenses"."projects"
+
+mappingId	mun
+target		ex:region/{region_id} a :Region ; :name {region_label} .
+source		SELECT * FROM "lenses"."projects"
+
+]]
+

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/AbstractLJTransformer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/AbstractLJTransformer.java
@@ -53,12 +53,26 @@ public abstract class AbstractLJTransformer extends DefaultNonRecursiveIQTreeTra
         // Cannot reuse
         IQTree transformedRightChild = preTransformLJRightChild(rightChild, rootNode.getOptionalFilterCondition());
 
+        if (preventRecursiveOptimizationOnRightChild()
+                && !transformedRightChild.equals(rightChild))
+            return iqFactory.createBinaryNonCommutativeIQTree(rootNode, transformedLeftChild, transformedRightChild)
+                                        .normalizeForOptimization(variableGenerator);
+
         return furtherTransformLeftJoin(rootNode, transformedLeftChild, transformedRightChild)
                 .orElseGet(() -> transformedLeftChild.equals(leftChild)
                         && transformedRightChild.equals(rightChild)
                                 ? tree
                                 : iqFactory.createBinaryNonCommutativeIQTree(rootNode, transformedLeftChild, transformedRightChild))
                                         .normalizeForOptimization(variableGenerator);
+    }
+
+    /**
+     * If the right child has just been optimized by this optimizer, stops the optimization.
+     * This allows to run other optimizers before running again this one.
+     * This helps further simplifying the right child before applying the optimization at this level.
+     */
+    protected boolean preventRecursiveOptimizationOnRightChild() {
+        return false;
     }
 
     /**

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalityInsensitiveJoinTransferLJOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalityInsensitiveJoinTransferLJOptimizer.java
@@ -122,6 +122,15 @@ public class CardinalityInsensitiveJoinTransferLJOptimizer implements LeftJoinIQ
                     .map(idx -> new SelectedNode(idx, rightDataNode));
         }
 
+        /**
+         * Enables applying self-join elimination after the self-left-join has been reduced
+         * to an inner join on the right child.
+         */
+        @Override
+        protected boolean preventRecursiveOptimizationOnRightChild() {
+            return true;
+        }
+
         @Override
         protected IQTree transformBySearchingFromScratch(IQTree tree) {
             return lookForDistinctTransformer.transform(tree);


### PR DESCRIPTION
This PR improves `CardinalityInsensitiveJoinTransferLJOptimizer` to make more robust self-left-joins nested on the right.

Once a self-left-join is optimized for a right child, the optimizer does try anymore to immediately optimize the parent left-join tree. Instead, it runs all the other join-like optimizations before coming back to the parent left-join tree in `CardinalityInsensitiveJoinTransferLJOptimizer`.

It also exploits the parent left-join condition to detect some variables as non-nullable when optimizing the right child.