### PR TITLE
Implemented transitive closure for lens FDs

### DIFF
--- a/binding/rdf4j/src/test/resources/project-denormalized/lenses.json
+++ b/binding/rdf4j/src/test/resources/project-denormalized/lenses.json
@@ -16,10 +16,7 @@
             ],
             "dependents": [
               "\"mun_label\"",
-              "\"province_id\"",
-              "\"province_label\"",
-              "\"region_id\"",
-              "\"region_label\""
+              "\"province_id\""
             ]
           },
           {
@@ -28,8 +25,7 @@
             ],
             "dependents": [
               "\"province_label\"",
-              "\"region_id\"",
-              "\"region_label\""
+              "\"region_id\""
             ]
           },
           {

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/FunctionalDependenciesImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/impl/FunctionalDependenciesImpl.java
@@ -93,7 +93,14 @@ public class FunctionalDependenciesImpl implements FunctionalDependencies {
      */
     protected FunctionalDependencies complete() {
         var dependencyPairs = stream().collect(ImmutableCollectors.toSet());
-        var collectedDependencies = Streams.concat(dependencyPairs.stream(), inferTransitiveDependencies(dependencyPairs))
+        var withTransitive = dependencyPairs;
+        var lastSize = 0;
+        while(lastSize != withTransitive.size()) {
+            lastSize = withTransitive.size();
+            withTransitive = Streams.concat(dependencyPairs.stream(), inferTransitiveDependencies(withTransitive))
+                    .collect(ImmutableCollectors.toSet());
+        }
+        var collectedDependencies = withTransitive.stream()
                 .collect(Collectors.groupingBy(Map.Entry::getKey))
                 .entrySet().stream()
                 .map(e -> new FunctionalDependency(e.getKey(), ImmutableSet.copyOf(e.getValue().stream()

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonBasicOrJoinLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonBasicOrJoinLens.java
@@ -111,7 +111,7 @@ public abstract class JsonBasicOrJoinLens extends JsonBasicOrJoinOrNestedLens {
 
         insertFunctionalDependencies(relation, idFactory, hiddenColumns, addedColumns,
                 (otherFunctionalDependencies != null) ? otherFunctionalDependencies.added : ImmutableList.of(),
-                ImmutableList.of(), baseRelations);
+                ImmutableList.of(), baseRelations, coreSingletons);
 
         insertForeignKeys(relation, metadataLookupForFK,
                 (foreignKeys != null) ? foreignKeys.added : ImmutableList.of(),

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonFlattenLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonFlattenLens.java
@@ -263,7 +263,8 @@ public class JsonFlattenLens extends JsonBasicOrJoinOrNestedLens {
                 addedColumns,
                 Optional.ofNullable(otherFunctionalDependencies).map(d -> d.added).orElseGet(ImmutableList::of),
                 inferFDsFromParentUCs(keptColumns, baseRelation),
-                baseRelations);
+                baseRelations,
+                dbParameters.getCoreSingletons());
 
         insertForeignKeys(relation, metadataLookupForFK,
                 Stream.concat(

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
@@ -174,7 +174,7 @@ public abstract class JsonLens extends JsonOpenObject {
                 .normalizeForOptimization(variableGenerator);
     }
 
-    protected void insertTransitiveFunctionalDependencies(ImmutableSet<FunctionalDependencyConstruct> previousDependencies, NamedRelationDefinition relation, CoreSingletons coreSingletons) throws AttributeNotFoundException {
+    protected void insertTransitiveFunctionalDependencies(ImmutableSet<FunctionalDependencyConstruct> previousDependencies, NamedRelationDefinition relation, CoreSingletons coreSingletons) throws AttributeNotFoundException, MetadataExtractionException {
         var uselessVariableGenerator = new VariableGeneratorImpl(ImmutableSet.of(), coreSingletons.getTermFactory());
         var var2Attr = relation.getAttributes().stream()
                 .collect(ImmutableCollectors.toMap(
@@ -186,6 +186,15 @@ public abstract class JsonLens extends JsonOpenObject {
                         entry -> entry.getValue().getID(),
                         Map.Entry::getKey)
                 );
+        if(previousDependencies.stream()
+                .anyMatch(fd ->
+                                fd.getDeterminants().stream()
+                                        .anyMatch(id -> !id2Var.containsKey(id))
+                                || fd.getDeterminants().stream()
+                                        .anyMatch(id -> !id2Var.containsKey(id))
+                        ))
+            throw new MetadataExtractionException(String.format(
+                    "Cannot find attribute for Functional Dependency of %s.", relation.getID()));
         FunctionalDependencies allDependencies = previousDependencies.stream()
                 .map(fd -> Maps.immutableEntry(
                         fd.getDeterminants().stream()

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
@@ -8,9 +8,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.*;
 import it.unibz.inf.ontop.dbschema.*;
 import it.unibz.inf.ontop.dbschema.impl.AbstractRelationDefinition;
 import it.unibz.inf.ontop.dbschema.impl.RawQuotedIDFactory;
@@ -20,6 +18,7 @@ import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.IQ;
 import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.node.ConstructionNode;
+import it.unibz.inf.ontop.iq.request.FunctionalDependencies;
 import it.unibz.inf.ontop.iq.type.SingleTermTypeExtractor;
 import it.unibz.inf.ontop.model.atom.impl.AtomPredicateImpl;
 import it.unibz.inf.ontop.model.term.ImmutableTerm;
@@ -33,13 +32,12 @@ import it.unibz.inf.ontop.substitution.Substitution;
 import it.unibz.inf.ontop.substitution.SubstitutionFactory;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import it.unibz.inf.ontop.utils.VariableGenerator;
+import it.unibz.inf.ontop.utils.impl.VariableGeneratorImpl;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 @JsonDeserialize(using = JsonLens.JSONLensDeserializer.class)
 public abstract class JsonLens extends JsonOpenObject {
@@ -174,6 +172,49 @@ public abstract class JsonLens extends JsonOpenObject {
                 newConstructionNode,
                 iqTreeBeforeIRISafeConstraints.applyFreshRenaming(renaming))
                 .normalizeForOptimization(variableGenerator);
+    }
+
+    protected void insertTransitiveFunctionalDependencies(ImmutableSet<FunctionalDependencyConstruct> previousDependencies, NamedRelationDefinition relation, CoreSingletons coreSingletons) throws AttributeNotFoundException {
+        var uselessVariableGenerator = new VariableGeneratorImpl(ImmutableSet.of(), coreSingletons.getTermFactory());
+        var var2Attr = relation.getAttributes().stream()
+                .collect(ImmutableCollectors.toMap(
+                        attr -> uselessVariableGenerator.generateNewVariable(attr.getID().getName()),
+                        attr -> attr
+                ));
+        var id2Var = var2Attr.entrySet().stream()
+                .collect(ImmutableCollectors.toMap(
+                        entry -> entry.getValue().getID(),
+                        Map.Entry::getKey)
+                );
+        FunctionalDependencies allDependencies = previousDependencies.stream()
+                .map(fd -> Maps.immutableEntry(
+                        fd.getDeterminants().stream()
+                                .map(id2Var::get).collect(ImmutableCollectors.toSet()),
+                        fd.getDependents().stream()
+                                .map(id2Var::get).collect(ImmutableCollectors.toSet())
+                ))
+                .collect(FunctionalDependencies.toFunctionalDependencies());
+        for(var entry : allDependencies.stream().collect(ImmutableCollectors.toList())) {
+            addTransitiveDependency(
+                    relation,
+                    entry.getKey().stream()
+                            .map(var2Attr::get)
+                            .collect(ImmutableCollectors.toSet()),
+                    entry.getValue().stream()
+                            .map(var2Attr::get)
+                            .collect(ImmutableCollectors.toSet()));
+        }
+    }
+
+    private void addTransitiveDependency(NamedRelationDefinition relation, ImmutableSet<Attribute> determinants, Set<Attribute> dependents) throws AttributeNotFoundException {
+        var builder = FunctionalDependency.defaultBuilder(relation);
+        for (Attribute determinant : determinants) {
+            builder.addDeterminant(determinant.getID());
+        }
+        for (Attribute attribute : dependents) {
+            builder.addDependent(attribute.getID());
+        }
+        builder.build();
     }
 
 


### PR DESCRIPTION
Lenses now also use the utility interface `FunctionalDependencies` to infer transitive FDs and merge multiple related FDs into one. 