### PR TITLE
Implemented option to expose system tables

### DIFF
--- a/core/model/src/main/resources/property_description.json
+++ b/core/model/src/main/resources/property_description.json
@@ -71,6 +71,10 @@
     "type": "Boolean",
     "description": "Since 5.1.0. Default value: `false`. If `true`, lens entries that result in an error will be created as empty instead of failing the initialization procedure. Expected to be used together with `ontop.ignoreInvalidMappingEntries`."
   },
+  "ontop.exposeSystemTables": {
+    "type": "Boolean",
+    "description": "Since 5.1.0. Default value: `false`. If `true`, system tables of the database system will be made accessible for Ontop."
+  },
   "ontop.enableValuesNode": {
     "type": "Boolean",
     "description": "Since 4.2.0. Default value: `true`. If false Union Nodes are used instead of Values Nodes for facts."

--- a/core/obda/src/main/java/it/unibz/inf/ontop/injection/OntopOBDASettings.java
+++ b/core/obda/src/main/java/it/unibz/inf/ontop/injection/OntopOBDASettings.java
@@ -17,6 +17,11 @@ public interface OntopOBDASettings extends OntopModelSettings {
     boolean ignoreInvalidMappingEntries();
     boolean ignoreInvalidLensEntries();
 
+    /**
+     * If true, system tables will also be accessible by ontop.
+     */
+    boolean exposeSystemTables();
+
     //--------------------------
     // Keys
     //--------------------------
@@ -25,4 +30,5 @@ public interface OntopOBDASettings extends OntopModelSettings {
     String ALLOW_RETRIEVING_BLACK_BOX_VIEW_METADATA_FROM_DB = "ontop.allowRetrievingBlackBoxViewMetadataFromDB";
     String IGNORE_INVALID_MAPPING_ENTRIES = "ontop.ignoreInvalidMappingEntries";
     String IGNORE_INVALID_LENS_ENTRIES = "ontop.ignoreInvalidLensEntries";
+    String EXPOSE_SYSTEM_TABLES = "ontop.exposeSystemTables";
 }

--- a/core/obda/src/main/java/it/unibz/inf/ontop/injection/impl/OntopOBDASettingsImpl.java
+++ b/core/obda/src/main/java/it/unibz/inf/ontop/injection/impl/OntopOBDASettingsImpl.java
@@ -44,4 +44,9 @@ public class OntopOBDASettingsImpl extends OntopModelSettingsImpl implements Ont
     public boolean ignoreInvalidLensEntries() {
         return getRequiredBoolean(IGNORE_INVALID_LENS_ENTRIES);
     }
+
+    @Override
+    public boolean exposeSystemTables() {
+        return getRequiredBoolean(EXPOSE_SYSTEM_TABLES);
+    }
 }

--- a/core/obda/src/main/resources/it/unibz/inf/ontop/injection/obda-default.properties
+++ b/core/obda/src/main/resources/it/unibz/inf/ontop/injection/obda-default.properties
@@ -10,6 +10,7 @@ ontop.sameAs=false
 ontop.allowRetrievingBlackBoxViewMetadataFromDB = false
 ontop.ignoreInvalidMappingEntries = false
 ontop.ignoreInvalidLensEntries = false
+ontop.exposeSystemTables = false
 
 
 ##########################################

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AbstractDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AbstractDBMetadataProvider.java
@@ -117,7 +117,7 @@ public abstract class AbstractDBMetadataProvider implements DBMetadataProvider {
             ImmutableList.Builder<RelationID> builder = ImmutableList.builder();
             while (rs.next()) {
                 RelationID id = getRelationID(rs, "TABLE_CAT", "TABLE_SCHEM","TABLE_NAME");
-                if (!isRelationExcluded(id))
+                if (!isRelationExcluded(id) || settings.exposeSystemTables())
                     builder.add(id);
             }
             return builder.build();

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AbstractDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AbstractDBMetadataProvider.java
@@ -104,6 +104,10 @@ public abstract class AbstractDBMetadataProvider implements DBMetadataProvider {
         // Does nothing
     }
 
+    protected OntopOBDASettings getSettings() {
+        return settings;
+    }
+
 
     protected boolean isRelationExcluded(RelationID id) { return false; }
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AthenaDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AthenaDBMetadataProvider.java
@@ -2,12 +2,14 @@ package it.unibz.inf.ontop.dbschema.impl;
 
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import it.unibz.inf.ontop.dbschema.RelationID;
 import it.unibz.inf.ontop.exception.MetadataExtractionException;
 import it.unibz.inf.ontop.injection.CoreSingletons;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 public class AthenaDBMetadataProvider extends TrinoDBMetadataProvider {
 
@@ -17,10 +19,20 @@ public class AthenaDBMetadataProvider extends TrinoDBMetadataProvider {
     }
 
     /**
-     * No filter on type (by default tables in Athena appears as "EXTERNAL_TABLE")
+     * System tables are only listed when querying information_schema
+     * @return
+     * @throws SQLException
      */
     @Override
     protected ResultSet getRelationIDsResultSet() throws SQLException {
-        return metadata.getTables(null, null, null, null);
+        Statement stmt = connection.createStatement();
+        stmt.closeOnCompletion();
+        return stmt.executeQuery("SELECT TABLE_CATALOG AS TABLE_CAT, TABLE_SCHEMA AS TABLE_SCHEM, TABLE_NAME " +
+                "FROM INFORMATION_SCHEMA.TABLES");
+    }
+
+    @Override
+    protected boolean isRelationExcluded(RelationID id) {
+        return getRelationSchema(id).equals("information_schema");
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DremioDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DremioDBMetadataProvider.java
@@ -99,4 +99,12 @@ public class DremioDBMetadataProvider extends AbstractDBMetadataProvider {
         return id.getComponents().get(TABLE_INDEX).getName();
     }
 
+    @Override
+    protected ResultSet getRelationIDsResultSet() throws SQLException {
+        return metadata.getTables(null, null, null, getSettings().exposeSystemTables()
+                ? new String[] { "TABLE", "VIEW", "MATERIALIZED VIEW", "SYSTEM_TABLE", "SYSTEM_VIEW" }
+                : new String[] { "TABLE", "VIEW", "MATERIALIZED VIEW"});
+
+    }
+
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/OracleDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/OracleDBMetadataProvider.java
@@ -134,6 +134,11 @@ public class OracleDBMetadataProvider extends DefaultSchemaDBMetadataProvider {
 
     @Override
     protected boolean isRelationExcluded(RelationID id) {
+        /*
+        We lose the information of whether a relation is a table or a view that was accessible
+        while checking for these conditions in the original query. Therefore, we exclude ALL
+        relations names that correspond to either system tables OR system views.
+         */
         String schema = getRelationSchema(id);
         String table = getRelationName(id);
         return IGNORED_VIEW_SCHEMAS.contains(schema)

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/PostgreSQLDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/PostgreSQLDBMetadataProvider.java
@@ -26,7 +26,10 @@ public class PostgreSQLDBMetadataProvider extends DefaultSchemaDBMetadataProvide
 
     @Override
     protected ResultSet getRelationIDsResultSet() throws SQLException {
-        return metadata.getTables(null, null, null, new String[] { "TABLE", "VIEW", "MATERIALIZED VIEW" });
+        return metadata.getTables(null, null, null, getSettings().exposeSystemTables()
+                ? new String[] { "TABLE", "VIEW", "MATERIALIZED VIEW", "SYSTEM TABLE", "SYSTEM VIEW", "TEMPORARY TABLE" }
+                : new String[] { "TABLE", "VIEW", "MATERIALIZED VIEW"});
+
     }
 
     private static final ImmutableList<String> IGNORED_SCHEMAS = ImmutableList.of( "_timescaledb_cache", "_timescaledb_catalog",


### PR DESCRIPTION
This makes it so that system tables will be included in the list of relations accessible by Ontop, when the option `ontop.exposeSystemTables` is set to `true`.

Currently, system tables are marked as hidden by the method `isRelationExcluded` in the corresponding metadata provider. Now, in addition to checking the output of this method, Ontop will also require that the `exposeSystemTables` option is set to false before hiding a table.

Hiding system tables is currently not supported for:
- BigQuery
- DuckDB
