### PR TITLE
Option to disable registering custom SPARQL aggregation functions

### DIFF
--- a/core/kg-query/src/main/java/it/unibz/inf/ontop/injection/OntopKGQuerySettings.java
+++ b/core/kg-query/src/main/java/it/unibz/inf/ontop/injection/OntopKGQuerySettings.java
@@ -9,5 +9,8 @@ public interface OntopKGQuerySettings extends OntopOBDASettings, OntopOptimizati
      */
     boolean isFixedObjectIncludedInDescribe();
 
+    boolean isCustomSPARQLFunctionRegistrationEnabled();
+
     String INCLUDE_FIXED_OBJECT_POSITION_IN_DESCRIBE = "ontop.includeFixedObjectPositionInDescribe";
+    String REGISTER_CUSTON_SPARQL_AGGREGATE_FUNCTIONS = "ontop.registerCustomSPARQLAggregateFunctions";
 }

--- a/core/kg-query/src/main/java/it/unibz/inf/ontop/injection/impl/OntopKGQuerySettingsImpl.java
+++ b/core/kg-query/src/main/java/it/unibz/inf/ontop/injection/impl/OntopKGQuerySettingsImpl.java
@@ -30,4 +30,9 @@ public class OntopKGQuerySettingsImpl extends OntopOBDASettingsImpl implements O
     public boolean isFixedObjectIncludedInDescribe() {
         return getRequiredBoolean(INCLUDE_FIXED_OBJECT_POSITION_IN_DESCRIBE);
     }
+
+    @Override
+    public boolean isCustomSPARQLFunctionRegistrationEnabled() {
+        return getRequiredBoolean(REGISTER_CUSTON_SPARQL_AGGREGATE_FUNCTIONS);
+    }
 }

--- a/core/kg-query/src/main/java/it/unibz/inf/ontop/query/translation/impl/RDF4JQueryTranslatorImpl.java
+++ b/core/kg-query/src/main/java/it/unibz/inf/ontop/query/translation/impl/RDF4JQueryTranslatorImpl.java
@@ -3,6 +3,7 @@ package it.unibz.inf.ontop.query.translation.impl;
 import com.google.common.collect.*;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import it.unibz.inf.ontop.injection.OntopKGQuerySettings;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
 import it.unibz.inf.ontop.model.atom.AtomPredicate;
 import it.unibz.inf.ontop.model.atom.DataAtom;
@@ -63,7 +64,7 @@ public class RDF4JQueryTranslatorImpl implements RDF4JQueryTranslator {
     public RDF4JQueryTranslatorImpl(CoreUtilsFactory coreUtilsFactory, TermFactory termFactory, SubstitutionFactory substitutionFactory,
                                     TypeFactory typeFactory, IntermediateQueryFactory iqFactory, AtomFactory atomFactory, RDF rdfFactory,
                                     FunctionSymbolFactory functionSymbolFactory,
-                                    InsertClauseNormalizer insertClauseNormalizer, IQTreeTools iqTreeTools) {
+                                    InsertClauseNormalizer insertClauseNormalizer, IQTreeTools iqTreeTools, OntopKGQuerySettings settings) {
         this.coreUtilsFactory = coreUtilsFactory;
         this.termFactory = termFactory;
         this.substitutionFactory = substitutionFactory;
@@ -74,13 +75,15 @@ public class RDF4JQueryTranslatorImpl implements RDF4JQueryTranslator {
         this.functionSymbolFactory = functionSymbolFactory;
         this.insertClauseNormalizer = insertClauseNormalizer;
         this.iqTreeTools = iqTreeTools;
-        CustomAggregateFunctionRegistry registry = CustomAggregateFunctionRegistry.getInstance();
-        registry.add(new VarianceSampAggregateFactory());
-        registry.add(new VariancePopAggregateFactory());
-        registry.add(new VarianceShortAggregateFactory());
-        registry.add(new StdevSampAggregateFactory());
-        registry.add(new StdevPopAggregateFactory());
-        registry.add(new StdevShortAggregateFactory());
+        if(settings.isCustomSPARQLFunctionRegistrationEnabled()) {
+            CustomAggregateFunctionRegistry registry = CustomAggregateFunctionRegistry.getInstance();
+            registry.add(new VarianceSampAggregateFactory());
+            registry.add(new VariancePopAggregateFactory());
+            registry.add(new VarianceShortAggregateFactory());
+            registry.add(new StdevSampAggregateFactory());
+            registry.add(new StdevPopAggregateFactory());
+            registry.add(new StdevShortAggregateFactory());
+        }
     }
 
     @Override

--- a/core/kg-query/src/main/resources/it/unibz/inf/ontop/injection/kg-query-default.properties
+++ b/core/kg-query/src/main/resources/it/unibz/inf/ontop/injection/kg-query-default.properties
@@ -1,3 +1,14 @@
+##########################################
+# GENERAL OPTIONS
+##########################################
+
+ontop.registerCustomSPARQLAggregateFunctions = true
+
+
+##########################################
+# Default implementations
+##########################################
+
 it.unibz.inf.ontop.query.unfolding.QueryUnfolder = it.unibz.inf.ontop.query.unfolding.impl.BasicQueryUnfolder
 it.unibz.inf.ontop.query.RDF4JQueryFactory = it.unibz.inf.ontop.query.impl.RDF4JQueryFactoryImpl
 it.unibz.inf.ontop.query.KGQueryFactory = it.unibz.inf.ontop.query.impl.KGQueryFactoryImpl

--- a/core/model/src/main/resources/property_description.json
+++ b/core/model/src/main/resources/property_description.json
@@ -163,6 +163,10 @@
     "type": "Boolean",
     "description": "Default value: `false`. If true, the pattern `?s ?p <to_describe>` is also considered when answering a DESCRIBE query."
   },
+  "ontop.registerCustomSPARQLAggregateFunctions": {
+    "type": "Boolean",
+    "description": "Default value: `true`. If true, Ontop's custom aggregate functions are registered in the RDF4J SPARQL parser's aggregate function registry."
+  },
   "ontop.query.defaultTimeout": {
     "type": "Integer",
     "description": "Query timeout (in seconds) assigned to the DB engine. Has no effect if negative or equal to 0."

--- a/core/obda/src/main/java/it/unibz/inf/ontop/injection/impl/OntopOBDASettingsImpl.java
+++ b/core/obda/src/main/java/it/unibz/inf/ontop/injection/impl/OntopOBDASettingsImpl.java
@@ -45,7 +45,6 @@ public class OntopOBDASettingsImpl extends OntopModelSettingsImpl implements Ont
         return getRequiredBoolean(IGNORE_INVALID_LENS_ENTRIES);
     }
 
-    @Override
     public boolean exposeSystemTables() {
         return getRequiredBoolean(EXPOSE_SYSTEM_TABLES);
     }

--- a/engine/system/sql/core/src/main/java/it/unibz/inf/ontop/injection/impl/OntopStandaloneSQLSettingsImpl.java
+++ b/engine/system/sql/core/src/main/java/it/unibz/inf/ontop/injection/impl/OntopStandaloneSQLSettingsImpl.java
@@ -84,6 +84,11 @@ public class OntopStandaloneSQLSettingsImpl extends OntopMappingSQLAllSettingsIm
     }
 
     @Override
+    public boolean isCustomSPARQLFunctionRegistrationEnabled() {
+        return getRequiredBoolean(REGISTER_CUSTON_SPARQL_AGGREGATE_FUNCTIONS);
+    }
+
+    @Override
     public long getQueryCacheMaxSize() {
         return getRequiredLong(QUERY_CACHE_MAX_SIZE);
     }


### PR DESCRIPTION
Option (`ontop.registerCustomSPARQLAggregateFunctions`) is included in `OntopKGQuerySettings` as it is accessed in `RDF4JQueryTranslatorImpl`.

When option is set to false (default true), custom aggregation functions (STDEV, VARIANCE...) will no longer be registered. This will make SPARQL queries using any of these functions fail during parsing.