### PR TITLE
Distinct nodes: improve unique constraint and variable non requirement inference

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/DistinctNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/DistinctNodeImpl.java
@@ -139,12 +139,6 @@ public class DistinctNodeImpl extends QueryModifierNodeImpl implements DistinctN
                 .filter((v, conds) -> !requiredByDistinct.contains(v));
     }
 
-    private static ImmutableSet<Variable> getDependents(IQTree child) {
-        return child.inferFunctionalDependencies().stream()
-                .flatMap(e -> e.getValue().stream())
-                .collect(ImmutableCollectors.toSet());
-    }
-
     @Override
     public void acceptVisitor(QueryNodeVisitor visitor) {
         visitor.visit(this);

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ExtensionalDataNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/ExtensionalDataNodeImpl.java
@@ -238,7 +238,7 @@ public class ExtensionalDataNodeImpl extends LeafIQTreeImpl implements Extension
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(FunctionalDependencies.toFunctionalDependencies())
-                .concat(FunctionalDependencies.fromUniqueConstraints(inferUniqueConstraints(), variables));
+                .concat(FunctionalDependencies.fromUniqueConstraints(inferUniqueConstraints(), getLocalVariables()));
     }
 
     private Optional<Map.Entry<ImmutableSet<Variable>, ImmutableSet<Variable>>> convertFunctionalDependency(FunctionalDependency functionalDependency) {

--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/node/impl/LeftJoinNodeImpl.java
@@ -410,9 +410,28 @@ public class LeftJoinNodeImpl extends JoinLikeNodeImpl implements LeftJoinNode {
     }
 
     @Override
-    public FunctionalDependencies inferFunctionalDependencies(IQTree leftChild, IQTree rightChild, ImmutableSet<ImmutableSet<Variable>> uniqueConstraints, ImmutableSet<Variable> variables) {
-        //TODO: Infer functional dependencies for the right child (we have to filter those from the right to not impact the left child)
-        return leftChild.inferFunctionalDependencies();
+    public FunctionalDependencies inferFunctionalDependencies(IQTree leftChild, IQTree rightChild,
+                                                              ImmutableSet<ImmutableSet<Variable>> uniqueConstraints,
+                                                              ImmutableSet<Variable> variables) {
+        var rightFunctionalDependencies = rightChild.inferFunctionalDependencies();
+        if (rightFunctionalDependencies.isEmpty())
+            return leftChild.inferFunctionalDependencies();
+
+        var leftVariables = leftChild.getVariables();
+
+        // Makes sure the right child does not add FDs on left variables (as dependents)
+        var filterRightFunctionalDependencies = rightFunctionalDependencies.stream()
+                .map(e -> Maps.immutableEntry(
+                        e.getKey(),
+                        Sets.difference(e.getValue(), leftVariables).immutableCopy()))
+                .filter(e -> !e.getValue().isEmpty())
+                .collect(FunctionalDependencies.toFunctionalDependencies());
+
+        if (filterRightFunctionalDependencies.isEmpty())
+            return leftChild.inferFunctionalDependencies();
+
+        return leftChild.inferFunctionalDependencies()
+                .concat(filterRightFunctionalDependencies);
     }
 
     @Override

--- a/core/model/src/main/resources/property_description.json
+++ b/core/model/src/main/resources/property_description.json
@@ -193,6 +193,6 @@
   },
   "ontop.authorization": {
     "type": "Boolean",
-    "description": "Default value: `false`. If true, extracts user, group and role information from HTTP headers."
+    "description": "Since 5.2.0. Default value: `false`. If true, extracts user, group and role information from HTTP headers."
   }
 }

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/NormalizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/NormalizationTest.java
@@ -1353,10 +1353,11 @@ public class NormalizationTest {
 
         IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, tree);
 
-        UnaryIQTree expectedTree = IQ_FACTORY.createUnaryIQTree(constructionNode,
-                IQ_FACTORY.createUnaryIQTree(distinctNode,
+        ExtensionalDataNode newExtensionalDataNode1 = IQ_FACTORY.createExtensionalDataNode(PK_TABLE1_AR2, ImmutableMap.of(0, A));
+
+        UnaryIQTree expectedTree = IQ_FACTORY.createUnaryIQTree(distinctNode,
                         IQ_FACTORY.createBinaryNonCommutativeIQTree(leftJoinNode,
-                                extensionalDataNode1, extensionalDataNode2)));
+                                newExtensionalDataNode1, extensionalDataNode2));
 
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, expectedTree);
         normalizeAndCompare(initialIQ, expectedIQ);

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/FunctionalDependencyTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/FunctionalDependencyTest.java
@@ -11,6 +11,7 @@ import it.unibz.inf.ontop.model.atom.DistinctVariableOnlyDataAtom;
 import it.unibz.inf.ontop.model.atom.AtomPredicate;
 import it.unibz.inf.ontop.model.term.DBConstant;
 import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.model.term.functionsymbol.InequalityLabel;
 import it.unibz.inf.ontop.model.type.DBTermType;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -934,6 +935,70 @@ public class FunctionalDependencyTest {
 
         optimizeAndCompare(initialIQ, expectedIQ);
     }
+
+    @Test
+    public void testNonRequiredVariableDistinctProjection1() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ANS1_PREDICATE_AR_1, A);
+        ConstructionNode topConstructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE11, ImmutableMap.of( 1, A, 2, B, 4, C));
+
+        FilterNode filterNode = IQ_FACTORY.createFilterNode(
+                TERM_FACTORY.getConjunction(
+                        TERM_FACTORY.getDBIsNotNull(A),
+                        TERM_FACTORY.getDBNumericInequality(InequalityLabel.LTE, C, TWO)));
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom,
+                IQ_FACTORY.createUnaryIQTree(topConstructionNode,
+                        IQ_FACTORY.createUnaryIQTree(IQ_FACTORY.createDistinctNode(),
+                                IQ_FACTORY.createUnaryIQTree(
+                                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, B)),
+                                        IQ_FACTORY.createUnaryIQTree(
+                                                filterNode,
+                                                dataNode1)))));
+
+        ExtensionalDataNode newDataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE11, ImmutableMap.of( 1, A, 4, C));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom,
+                        IQ_FACTORY.createUnaryIQTree(IQ_FACTORY.createDistinctNode(),
+                                IQ_FACTORY.createUnaryIQTree(
+                                        topConstructionNode,
+                                        IQ_FACTORY.createUnaryIQTree(
+                                                filterNode,
+                                                newDataNode1))));
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testNonRequiredVariableDistinctProjection2() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(ANS1_PREDICATE_AR_2, A, C);
+        ConstructionNode topConstructionNode = IQ_FACTORY.createConstructionNode(projectionAtom.getVariables());
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE11, ImmutableMap.of( 1, A, 2, B, 4, C));
+
+        FilterNode filterNode = IQ_FACTORY.createFilterNode(TERM_FACTORY.getDBIsNotNull(A));
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom,
+                IQ_FACTORY.createUnaryIQTree(topConstructionNode,
+                        IQ_FACTORY.createUnaryIQTree(IQ_FACTORY.createDistinctNode(),
+                                IQ_FACTORY.createUnaryIQTree(
+                                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(A, B, C)),
+                                        IQ_FACTORY.createUnaryIQTree(
+                                                filterNode,
+                                                dataNode1)))));
+
+        ExtensionalDataNode newDataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE11, ImmutableMap.of( 1, A, 4, C));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom,
+                IQ_FACTORY.createUnaryIQTree(IQ_FACTORY.createDistinctNode(),
+                                IQ_FACTORY.createUnaryIQTree(
+                                        filterNode,
+                                        newDataNode1)));
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+
+
 
     private static void optimizeAndCompare(IQ initialIQ, IQ expectedIQ) {
         System.out.println("Initial query: "+ initialIQ);

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/FunctionalDependencyInferenceTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/FunctionalDependencyInferenceTest.java
@@ -251,44 +251,22 @@ public class FunctionalDependencyInferenceTest {
 
     @Test
     public void testLeftJoinFromChildren() {
-        ImmutableList<IQTree> children = ImmutableList.of(
-                IQ_FACTORY.createUnaryIQTree(
-                        IQ_FACTORY.createConstructionNode(
-                                ImmutableSet.of(A, B),
-                                SUBSTITUTION_FACTORY.getSubstitution()),
-                        DATA_NODE_1_WITH_ADDED_FD),
-                IQ_FACTORY.createUnaryIQTree(
-                        IQ_FACTORY.createConstructionNode(
-                                ImmutableSet.of(C, D),
-                                SUBSTITUTION_FACTORY.getSubstitution()),
-                        DATA_NODE_2_WITH_ADDED_FD));
         IQTree tree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
                 IQ_FACTORY.createLeftJoinNode(),
-                children.get(0),
-                children.get(1)
+                DATA_NODE_1_WITH_ADDED_FD,
+                DATA_NODE_2_WITH_ADDED_FD
         );
-        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(B)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(B), ImmutableSet.of(C), ImmutableSet.of(D)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
     }
 
     @Test
     public void testLeftJoinCrossInfer() {
-        ImmutableList<IQTree> children = ImmutableList.of(
-                IQ_FACTORY.createUnaryIQTree(
-                        IQ_FACTORY.createConstructionNode(
-                                ImmutableSet.of(A, B),
-                                SUBSTITUTION_FACTORY.getSubstitution()),
-                        DATA_NODE_1_WITH_ADDED_FD),
-                IQ_FACTORY.createUnaryIQTree(
-                        IQ_FACTORY.createConstructionNode(
-                                ImmutableSet.of(C, D),
-                                SUBSTITUTION_FACTORY.getSubstitution()),
-                        DATA_NODE_2_WITH_ADDED_FD));
         IQTree tree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
                 IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getStrictEquality(A, C)),
-                children.get(0),
-                children.get(1)
+                DATA_NODE_1_WITH_ADDED_FD,
+                DATA_NODE_2_WITH_ADDED_FD
         );
-        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(B), ImmutableSet.of(D, A), ImmutableSet.of(C)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A), ImmutableSet.of(B, D, C)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
     }
 
     @Test


### PR DESCRIPTION
The improvements introduced by this PR allow to better detect non required variables and further prune the query tree.
They take advantage of functional dependencies.

This PR also improves functional dependency inference for left-joins: it now consider functional dependencies coming from the right child.