### PR TITLE
Updated "EqualsTrue" function symbol

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/EqualsTrueDBIsTrueFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/EqualsTrueDBIsTrueFunctionSymbolImpl.java
@@ -17,6 +17,9 @@ public class EqualsTrueDBIsTrueFunctionSymbolImpl extends DefaultDBIsTrueFunctio
     @Override
     public String getNativeDBString(ImmutableList<? extends ImmutableTerm> terms,
                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
+        if(terms.get(0) instanceof ImmutableExpression) {
+            return inBrackets(termConverter.apply(terms.get(0)));
+        }
         ImmutableExpression newTerm = termFactory.getStrictEquality(terms.get(0), termFactory.getDBBooleanConstant(true));
         return inBrackets(termConverter.apply(newTerm));
     }


### PR DESCRIPTION
For SQLServer, the expression
`<boolean-expression> = 1` is not valid. Updated the implementation to first check if the provided term is already a boolean expression. In that case, we just return the expression itself.