### PR TITLE
Fixed `<expression> = true` issue for SQLServer and Oracle

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/AvoidEqualsBoolNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/AvoidEqualsBoolNormalizer.java
@@ -1,0 +1,85 @@
+package it.unibz.inf.ontop.generation.normalization.impl;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import it.unibz.inf.ontop.generation.normalization.DialectExtraNormalizer;
+import it.unibz.inf.ontop.injection.CoreSingletons;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.transform.impl.DefaultRecursiveIQTreeExtendedTransformer;
+import it.unibz.inf.ontop.iq.type.SingleTermTypeExtractor;
+import it.unibz.inf.ontop.iq.type.impl.AbstractExpressionTransformer;
+import it.unibz.inf.ontop.model.term.*;
+import it.unibz.inf.ontop.model.term.functionsymbol.BooleanFunctionSymbol;
+import it.unibz.inf.ontop.model.term.functionsymbol.FunctionSymbol;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.impl.AbstractDBNonStrictEqOperator;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.impl.DefaultDBStrictEqFunctionSymbol;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+/**
+ * Some dialects like SQLServer and Oracle don't support expressions like `<expression> = true`, but they may appear in
+ * the generated queries under certain conditions. This normalizer searches such cases and replaces them by just `<expression>`.
+ * `<expression> = false` is handled similarly.
+ */
+public class AvoidEqualsBoolNormalizer extends DefaultRecursiveIQTreeExtendedTransformer<VariableGenerator>
+        implements DialectExtraNormalizer {
+
+    private final IntermediateQueryFactory iqFactory;
+    private final TermFactory termFactory;
+    private final SingleTermTypeExtractor typeExtractor;
+
+    @Inject
+    protected AvoidEqualsBoolNormalizer(IntermediateQueryFactory iqFactory, SingleTermTypeExtractor typeExtractor,
+                                        TermFactory termFactory, CoreSingletons coreSingletons) {
+        super(coreSingletons);
+        this.iqFactory = iqFactory;
+        this.termFactory = termFactory;
+        this.typeExtractor = typeExtractor;
+    }
+
+    @Override
+    public IQTree transform(IQTree tree, VariableGenerator variableGenerator) {
+        return new AvoidEqualsBoolExpressionTransformer(iqFactory, typeExtractor, termFactory).transform(tree);
+    }
+
+    private static class AvoidEqualsBoolExpressionTransformer extends AbstractExpressionTransformer {
+
+        protected AvoidEqualsBoolExpressionTransformer(IntermediateQueryFactory iqFactory, SingleTermTypeExtractor typeExtractor, TermFactory termFactory) {
+            super(iqFactory, typeExtractor, termFactory);
+        }
+
+        @Override
+        protected boolean isFunctionSymbolToReplace(FunctionSymbol functionSymbol) {
+            return (functionSymbol instanceof AbstractDBNonStrictEqOperator) || (functionSymbol instanceof DefaultDBStrictEqFunctionSymbol);
+        }
+
+        @Override
+        protected ImmutableFunctionalTerm replaceFunctionSymbol(FunctionSymbol functionSymbol, ImmutableList<ImmutableTerm> newTerms, IQTree tree) {
+            if(newTerms.size() != 2)
+                return noReplace(functionSymbol, newTerms);
+
+            var otherTerm = newTerms.stream()
+                    .filter(t -> t instanceof ImmutableExpression)
+                    .map(t -> (ImmutableExpression) t)
+                    .findFirst();
+            var constantTerm = newTerms.stream()
+                    .filter(t -> t instanceof Constant)
+                    .map(t -> (Constant) t)
+                    .filter(t -> t.equals(termFactory.getDBBooleanConstant(true)) || t.equals(termFactory.getDBBooleanConstant(false)))
+                    .findFirst();
+
+            if(otherTerm.isEmpty() || constantTerm.isEmpty())
+                return noReplace(functionSymbol, newTerms);
+
+            var requiresTrue = constantTerm.get().equals(termFactory.getDBBooleanConstant(true));
+
+            if(requiresTrue)
+                return otherTerm.get();
+            return otherTerm.get().negate(termFactory);
+        }
+
+        private ImmutableFunctionalTerm noReplace(FunctionSymbol functionSymbol, ImmutableList<ImmutableTerm> newTerms) {
+            return termFactory.getImmutableExpression((BooleanFunctionSymbol) functionSymbol, newTerms);
+        }
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/OracleExtraNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/OracleExtraNormalizer.java
@@ -14,26 +14,31 @@ public class OracleExtraNormalizer implements DialectExtraNormalizer {
     private final DialectExtraNormalizer expressionWrapper;
     private final ConvertValuesToUnionNormalizer toUnionNormalizer;
     private final UnquoteFlattenResultsNormalizer unquoteFlattenResultsNormalizer;
+    private final DialectExtraNormalizer avoidEqualsBoolNormalizer;
 
     @Inject
     protected OracleExtraNormalizer(OnlyInPresenceOfDistinctProjectOrderByTermsNormalizer orderByNormalizer,
                                     WrapProjectedOrOrderByExpressionNormalizer expressionWrapper,
                                     ConvertValuesToUnionNormalizer toUnionNormalizer,
-                                    UnquoteFlattenResultsNormalizer unquoteFlattenResultsNormalizer) {
+                                    UnquoteFlattenResultsNormalizer unquoteFlattenResultsNormalizer,
+                                    AvoidEqualsBoolNormalizer avoidEqualsBoolNormalizer) {
         this.orderByNormalizer = orderByNormalizer;
         this.expressionWrapper = expressionWrapper;
         this.toUnionNormalizer = toUnionNormalizer;
         this.unquoteFlattenResultsNormalizer = unquoteFlattenResultsNormalizer;
+        this.avoidEqualsBoolNormalizer = avoidEqualsBoolNormalizer;
     }
 
     @Override
     public IQTree transform(IQTree tree, VariableGenerator variableGenerator) {
-        return unquoteFlattenResultsNormalizer.transform(
+        return avoidEqualsBoolNormalizer.transform(
+            unquoteFlattenResultsNormalizer.transform(
                 toUnionNormalizer.transform(
                     orderByNormalizer.transform(
                             expressionWrapper.transform(tree, variableGenerator),
                             variableGenerator),
                     variableGenerator),
-                variableGenerator);
+                variableGenerator),
+            variableGenerator);
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SQLServerExtraNormalizer.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/generation/normalization/impl/SQLServerExtraNormalizer.java
@@ -14,25 +14,30 @@ public class SQLServerExtraNormalizer implements DialectExtraNormalizer {
     private final DialectExtraNormalizer projectionWrapper;
     private final DialectExtraNormalizer limitOffsetOldVersionNormalizer;
     private final DialectExtraNormalizer insertOrderByInSlizeNormalizer;
+    private final DialectExtraNormalizer avoidEqualsBoolNormalizer;
 
     @Inject
     protected SQLServerExtraNormalizer(AlwaysProjectOrderByTermsNormalizer projectOrderByTermsNormalizer,
                                        WrapProjectedOrOrderByExpressionNormalizer projectionWrapper,
                                        SQLServerLimitOffsetOldVersionNormalizer limitOffsetOldVersionNormalizer,
-                                       SQLServerInsertOrderByInSliceNormalizer insertOrderByInSlizeNormalizer) {
+                                       SQLServerInsertOrderByInSliceNormalizer insertOrderByInSlizeNormalizer,
+                                       AvoidEqualsBoolNormalizer avoidEqualsBoolNormalizer) {
         this.projectOrderByTermsNormalizer = projectOrderByTermsNormalizer;
         this.projectionWrapper = projectionWrapper;
         this.limitOffsetOldVersionNormalizer = limitOffsetOldVersionNormalizer;
         this.insertOrderByInSlizeNormalizer = insertOrderByInSlizeNormalizer;
+        this.avoidEqualsBoolNormalizer = avoidEqualsBoolNormalizer;
     }
 
     @Override
     public IQTree transform(IQTree tree, VariableGenerator variableGenerator) {
-        return insertOrderByInSlizeNormalizer.transform(
+        return avoidEqualsBoolNormalizer.transform(
+            insertOrderByInSlizeNormalizer.transform(
                 limitOffsetOldVersionNormalizer.transform(
                     projectOrderByTermsNormalizer.transform(
                         projectionWrapper.transform(tree, variableGenerator),
                     variableGenerator), variableGenerator),
-                variableGenerator);
+                variableGenerator),
+            variableGenerator);
     }
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mssql/BindWithFunctionsSQLServerTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mssql/BindWithFunctionsSQLServerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Disabled;
 public class BindWithFunctionsSQLServerTest extends AbstractBindTestWithFunctions {
 
     private static final String PROPERTIES_FILE = "/books/mssql/books-mssql.properties";
+    private static final String OBDA_FILE = "/books/mssql/books.obda";
 
     @BeforeAll
     public static void before() {
@@ -82,5 +83,14 @@ public class BindWithFunctionsSQLServerTest extends AbstractBindTestWithFunction
     @Override
     protected ImmutableSet<String> getStatisticalAttributesExpectedResults() {
         return ImmutableSet.of("\"215.340000\"^^xsd:decimal");
+    }
+
+    @Test
+    /**
+     * Tests the `CASE <EXPRESSION> WHEN ...` operator for SQLServer.
+     */
+    public void testSwitchCaseSuccessful() {
+        String query = "PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\nSELECT ?v WHERE { dc:switchCaseResult dc:value ?v } ";
+        executeAndCompareValues(query, ImmutableSet.of("\"2\"^^xsd:integer", "\"1\"^^xsd:integer"));
     }
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/oracle/BindWithFunctionsOracleTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/oracle/BindWithFunctionsOracleTest.java
@@ -126,4 +126,13 @@ public class BindWithFunctionsOracleTest extends AbstractBindTestWithFunctions {
     protected ImmutableSet<String> getSimpleDateTrunkExpectedValues() {
         return ImmutableSet.of("\"1970-01-01T00:00:00.000000+01:00\"^^xsd:dateTime", "\"2011-01-01T00:00:00.000000+01:00\"^^xsd:dateTime", "\"2014-01-01T00:00:00.000000+01:00\"^^xsd:dateTime", "\"2015-01-01T00:00:00.000000+01:00\"^^xsd:dateTime");
     }
+
+    @Test
+    /**
+     * Tests the `CASE <EXPRESSION> WHEN ...` operator for SQLServer.
+     */
+    public void testSwitchCaseSuccessful() {
+        String query = "PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\nSELECT ?v WHERE { dc:switchCaseResult dc:value ?v } ";
+        executeAndCompareValues(query, ImmutableSet.of("\"2\"^^xsd:integer", "\"1\"^^xsd:integer"));
+    }
 }

--- a/test/lightweight-tests/src/test/resources/books/mssql/books.obda
+++ b/test/lightweight-tests/src/test/resources/books/mssql/books.obda
@@ -7,13 +7,13 @@ ns:  http://example.org/ns#
 [MappingDeclaration] @collection [[
 mappingId	mapping1
 target	:{id} a :Book ; dc:title {title}@en ; ns:price {price} ; ns:discount {discount} ; ns:pubYear {publication_date} ; dc:description {description}@en .
-source	SELECT id, title, price, discount, publication_date, description, lang FROM books.books WHERE lang = 'en'
+source	SELECT id, title, price, discount, publication_date, description, lang FROM books WHERE lang = 'en'
 
 mappingId	divisionTest
-target	dc:divisionResult dc:value {value} .
-source	SELECT (10 / 3) as value FROM dual
+target	dc:divisionResult dc:value {value} ; dc:result {res} .
+source	SELECT (10 / 3) as value, CASE price = 4 WHEN true THEN 'hello' ELSE null END as res FROM books
 
 mappingId switchCaseTest
 target dc:switchCaseResult dc:value {value} .
-source SELECT CASE id = 4 WHEN true THEN 1 ELSE 2 END AS value FROM books.books
+source SELECT CASE id = 4 WHEN true THEN 1 ELSE 2 END AS value FROM books
 ]]


### PR DESCRIPTION
Some dialects like SQLServer and Oracle don't support expressions like `<expression> = true`, but they may appear in the generated queries under certain conditions. 

The newly implemented `AvoidEqualsBooleanNormalizer` handles such cases (as well as the `= false` alternatives) and replaces them by just `<expression>` (or its negated form).