### PR TITLE
Propagate foreign keys from basic lenses to parents

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/LensMetadataProviderImpl.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/LensMetadataProviderImpl.java
@@ -182,9 +182,9 @@ public class LensMetadataProviderImpl implements LensMetadataProvider {
                 jsonLens.insertIntegrityConstraints((Lens) relation, baseRelations, metadataLookupForFK,
                         getDBParameters());
 
-                /* Propagate UCs to the parent relation.
-                If at least one UC was sent up this way, repeat this process from the parent.
-                Keep going until either no UC could be propagated up or the root element is reached.
+                /* Propagate UCs and KFs to the parent relation.
+                If at least one UC or FK was sent up this way, repeat this process from the parent.
+                Keep going until either no UC/FK could be propagated up or the root element is reached.
                  */
                 Queue<NamedRelationDefinition> lensesForPropagation = new ArrayDeque<>();
                 lensesForPropagation.add(relation);
@@ -193,6 +193,11 @@ public class LensMetadataProviderImpl implements LensMetadataProvider {
                     JsonLens currentPropagationJsonLens = jsonMap.get(currentPropagationLens.getID());
                     ImmutableList<NamedRelationDefinition> currentPropagationParents = dependencyCacheMetadataLookup.getBaseRelations(currentPropagationLens.getID());
                     if(currentPropagationJsonLens.propagateUniqueConstraintsUp((Lens)currentPropagationLens, currentPropagationParents, getQuotedIDFactory())) {
+                        lensesForPropagation.addAll(currentPropagationParents.stream()
+                                .filter(l -> l instanceof Lens)
+                                .collect(Collectors.toList()));
+                    }
+                    if(currentPropagationJsonLens.propagateForeignKeyConstraintsUp((Lens)currentPropagationLens, currentPropagationParents, getQuotedIDFactory())) {
                         lensesForPropagation.addAll(currentPropagationParents.stream()
                                 .filter(l -> l instanceof Lens)
                                 .collect(Collectors.toList()));

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
@@ -87,6 +87,14 @@ public abstract class JsonLens extends JsonOpenObject {
     }
 
     /**
+     * Propagates foreign key constraints of this lens to its parents, if possible. Returns true if at least one constraint was propagated.
+     */
+    public boolean propagateForeignKeyConstraintsUp(Lens relation, ImmutableList<NamedRelationDefinition> parents, QuotedIDFactory idFactory) throws MetadataExtractionException {
+        //Does nothing by default, but is implemented by JsonBasicLens. May also be implemented by other lenses under certain conditions.
+        return false;
+    }
+
+    /**
      * May be incomplete, but must not produce any false positive.
      *
      * Returns the attributes for which it can be proved that the projection over them includes the results

--- a/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/BasicLensPropagateFKUpTest.java
+++ b/db/rdb/src/test/java/it/unibz/inf/ontop/dbschema/BasicLensPropagateFKUpTest.java
@@ -1,0 +1,177 @@
+package it.unibz.inf.ontop.dbschema;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+public class BasicLensPropagateFKUpTest {
+    private static final String LENS_FILE = "src/test/resources/propagate-fk-up/lenses.json";
+    private static final String DBMETADATA_FILE = "src/test/resources/propagate-fk-up/metadata.db-extract.json";
+
+    private final ImmutableSet<NamedRelationDefinition> relationDefinitions = LensParsingTest.loadLensesAndTablesH2(LENS_FILE, DBMETADATA_FILE);
+    private final ImmutableMap<String, Lens> lensMap;
+    private final ImmutableMap<String, NamedRelationDefinition> tableMap;
+
+    public BasicLensPropagateFKUpTest() throws Exception {
+        lensMap = relationDefinitions.stream()
+                .filter(l -> l instanceof Lens)
+                .map(l -> (Lens)l)
+                .collect(ImmutableCollectors.<Lens, String, Lens>toMap(
+                    l -> String.join(".", l.getID().getComponents().reverse().stream()
+                            .map(c -> c.getName())
+                            .collect(Collectors.toList())),
+                    l -> l
+        ));
+        tableMap = relationDefinitions.stream()
+                .filter(t -> !(t instanceof Lens))
+                .collect(ImmutableCollectors.<NamedRelationDefinition, String, NamedRelationDefinition>toMap(
+                        t -> String.join(".", t.getID().getComponents().reverse()
+                                .stream().map(c -> c.getName())
+                                .collect(Collectors.toList())),
+                        t -> t
+                ));
+    }
+
+    @Test
+    public void testLeafFK() {
+        assertHasFKs(lensMap.get("lenses.l4"), ImmutableSet.of(
+                new ForeignKey("\"A\"", "id_A", "id"),
+                new ForeignKey("\"B\"", "id_B_1", "id_1", "id_B_2", "id_2")
+        ));
+    }
+
+    @Test
+    public void testDirectPropagation() {
+        assertHasFKs(lensMap.get("lenses.l3"), ImmutableSet.of(
+                new ForeignKey("\"A\"", "id_A", "id"),
+                new ForeignKey("\"B\"", "id_B_1", "id_1", "id_B_2", "id_2")
+        ));
+    }
+
+    @Test
+    public void testTwoLevelPropagation() {
+        assertHasFKs(lensMap.get("lenses.l2"), ImmutableSet.of(
+                new ForeignKey("\"A\"", "id_A", "id"),
+                new ForeignKey("\"B\"", "id_B_1", "id_1", "id_B_2", "id_2")
+        ));
+    }
+
+    @Test
+    public void testMultilevelPropagation() {
+        assertHasFKs(lensMap.get("lenses.l1"), ImmutableSet.of(
+                new ForeignKey("\"A\"", "id_A", "id"),
+                new ForeignKey("\"B\"", "id_B_1", "id_1", "id_B_2", "id_2")
+        ));
+    }
+
+    @Test
+    public void testSourceTablePropagation() {
+        assertHasFKs(tableMap.get("base_table"), ImmutableSet.of(
+                new ForeignKey("\"A\"", "id_A", "id"),
+                new ForeignKey("\"B\"", "id_B_1", "id_1", "id_B_2", "id_2")
+        ));
+    }
+
+    //The 'x' lenses are loaded in opposite order (starting with the one that defines the FK first. This way, recursive propagation should happen more often.
+    @Test
+    public void testOppositeOrderPropagation() {
+        assertHasFKs(lensMap.get("lenses.x1"), ImmutableSet.of(
+                new ForeignKey("\"A\"", "id_A", "id"),
+                new ForeignKey("\"B\"", "id_B_1", "id_1", "id_B_2", "id_2")
+        ));
+    }
+
+    @Test
+    public void testNoPropagationIsParent() {
+        assertHasFKs(tableMap.get("A"), ImmutableSet.of());
+    }
+
+    @Test
+    public void testNoPropagationOverride() {
+        assertHasFKs(tableMap.get("base_table_3"), ImmutableSet.of());
+    }
+
+    @Test
+    public void testSomeVariablesOverridden() {
+        assertHasFKs(tableMap.get("base_table_4"), ImmutableSet.of(
+                new ForeignKey("\"A\"", "id_A", "id"),
+                new ForeignKey("\"B\"", "id_B_1", "id_1", "id_B_2", "id_2")
+        ));
+    }
+
+    @Test
+    public void testUCsStillInferred() {
+        assertHasUCs(tableMap.get("base_table"), ImmutableSet.of(ImmutableSet.of("id_A", "id_B_1", "id_B_2")));
+    }
+
+    private void assertHasUCs(NamedRelationDefinition relation, ImmutableSet<ImmutableSet<String>> expected) {
+        assertEquals(expected, relation.getUniqueConstraints().stream()
+                .map(uc -> uc.getDeterminants().stream()
+                        .map(det -> det.getID().getName())
+                        .collect(Collectors.toSet()))
+                .collect(Collectors.toSet()));
+        assertEquals(expected.size(), relation.getUniqueConstraints().size());
+    }
+
+    private void assertHasFKs(NamedRelationDefinition relation, ImmutableSet<ForeignKey> expected) {
+        var actual = relation.getForeignKeys().stream()
+                .map(ForeignKey::new)
+                .collect(ImmutableCollectors.toSet());
+        assertEquals(expected, actual);
+    }
+
+    private static class ForeignKey {
+        private final String targetRelation;
+        private final ImmutableMap<String, String> mappedColumns;
+
+        protected ForeignKey(ForeignKeyConstraint fk) {
+            this.targetRelation = fk.getReferencedRelation().getID().getSQLRendering();
+            this.mappedColumns = fk.getComponents().stream()
+                    .collect(ImmutableCollectors.toMap(
+                            c -> c.getAttribute().getID().getName(),
+                            c -> c.getReferencedAttribute().getID().getName()
+                    ));
+        }
+
+        protected ForeignKey(String targetRelation, String... mapping) {
+            this.targetRelation = targetRelation;
+            this.mappedColumns = IntStream.range(0, mapping.length / 2)
+                    .mapToObj(i -> Maps.immutableEntry(mapping[i * 2], mapping[i * 2 + 1]))
+                    .collect(ImmutableCollectors.toMap());
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if(!(obj instanceof ForeignKey))
+                return false;
+            var fk = (ForeignKey) obj;
+            return fk.targetRelation.equals(targetRelation) && fk.mappedColumns.equals(mappedColumns);
+        }
+
+        @Override
+        public String toString() {
+            var keys = ImmutableList.copyOf(mappedColumns.keySet());
+            return String.format("FK --> %s:\n[%s] --> [%s]",
+                    targetRelation,
+                    String.join(", ", keys),
+                    keys.stream()
+                            .map(mappedColumns::get)
+                            .collect(Collectors.joining(", ")));
+        }
+
+        @Override
+        public int hashCode() {
+            return ImmutableSet.of(targetRelation.hashCode(), mappedColumns.hashCode()).hashCode();
+        }
+    }
+
+
+}

--- a/db/rdb/src/test/resources/propagate-fk-up/lenses.json
+++ b/db/rdb/src/test/resources/propagate-fk-up/lenses.json
@@ -1,0 +1,218 @@
+{
+  "relations": [
+    {
+      "name": ["\"lenses\"", "\"l1\""],
+      "baseRelation": ["\"base_table\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"l2\""],
+      "baseRelation": ["\"lenses\"", "\"l1\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"l3\""],
+      "baseRelation": ["\"lenses\"", "\"l2\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"l4\""],
+      "baseRelation": ["\"lenses\"", "\"l3\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "uniqueConstraints": {
+        "added": [
+          {
+            "name": "uc",
+            "determinants": [
+              "\"id_A\"",
+              "\"id_B_1\"",
+              "\"id_B_2\""
+            ],
+            "isPrimaryKey": false
+          }
+        ]
+      },
+      "foreignKeys": {
+        "added": [
+          {
+            "name": "fk_1",
+            "from": ["\"id_A\""],
+            "to": {
+              "relation": ["\"A\""],
+              "columns": ["\"id\""]
+            }
+          },
+          {
+            "name": "fk_2",
+            "from": ["\"id_B_1\"", "\"id_B_2\""],
+            "to": {
+              "relation": ["\"B\""],
+              "columns": ["\"id_1\"", "\"id_2\""]
+            }
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"x1\""],
+      "baseRelation": ["\"lenses\"", "\"x2\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "foreignKeys": {
+        "added": [
+          {
+            "name": "fk_1",
+            "from": ["\"id_A\""],
+            "to": {
+              "relation": ["\"A\""],
+              "columns": ["\"id\""]
+            }
+          },
+          {
+            "name": "fk_2",
+            "from": ["\"id_B_1\"", "\"id_B_2\""],
+            "to": {
+              "relation": ["\"B\""],
+              "columns": ["\"id_1\"", "\"id_2\""]
+            }
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"x2\""],
+      "baseRelation": ["\"lenses\"", "\"x3\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"x3\""],
+      "baseRelation": ["\"base_table_2\""],
+      "columns": {
+        "added": [],
+        "hidden": []
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"noIsParent\""],
+      "baseRelation": ["\"A\""],
+      "columns": {
+        "added": [
+          {
+            "name": "\"id\"",
+            "expression": "\"id\" + \"y\""
+          }
+        ],
+        "hidden": []
+      },
+      "foreignKeys": {
+        "added": [
+          {
+            "name": "fk_1",
+            "from": ["\"y\""],
+            "to": {
+              "relation": ["\"A\""],
+              "columns": ["\"y\""]
+            }
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"modified\""],
+      "baseRelation": ["\"base_table_3\""],
+      "columns": {
+        "added": [
+          {
+            "name": "\"id_B_1\"",
+            "expression": "\"id_B_1\" + \"id_B_2\""
+          },
+          {
+            "name": "\"id_A\"",
+            "expression": "\"id_A\""
+          }
+        ],
+        "hidden": []
+      },
+      "foreignKeys": {
+        "added": [
+          {
+            "name": "fk_1",
+            "from": ["\"id_A\""],
+            "to": {
+              "relation": ["\"A\""],
+              "columns": ["\"id\""]
+            }
+          },
+          {
+            "name": "fk_2",
+            "from": ["\"id_B_1\"", "\"id_B_2\""],
+            "to": {
+              "relation": ["\"B\""],
+              "columns": ["\"id_1\"", "\"id_2\""]
+            }
+          }
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"other_change\""],
+      "baseRelation": ["\"base_table_4\""],
+      "columns": {
+        "added": [
+          {
+            "name": "\"x\"",
+            "expression": "\"x\" + \"x\""
+          }
+        ],
+        "hidden": []
+      },
+      "foreignKeys": {
+        "added": [
+          {
+            "name": "fk_1",
+            "from": ["\"id_A\""],
+            "to": {
+              "relation": ["\"A\""],
+              "columns": ["\"id\""]
+            }
+          },
+          {
+            "name": "fk_2",
+            "from": ["\"id_B_1\"", "\"id_B_2\""],
+            "to": {
+              "relation": ["\"B\""],
+              "columns": ["\"id_1\"", "\"id_2\""]
+            }
+          }
+        ]
+      },
+      "type": "BasicLens"
+    }
+  ]
+}

--- a/db/rdb/src/test/resources/propagate-fk-up/metadata.db-extract.json
+++ b/db/rdb/src/test/resources/propagate-fk-up/metadata.db-extract.json
@@ -1,0 +1,197 @@
+{
+  "relations": [
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_A\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_B_1\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_B_2\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"x\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"base_table\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"y\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"A\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id_1\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_2\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"z\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"B\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_A\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_B_1\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_B_2\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"x\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"base_table_2\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_A\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_B_1\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_B_2\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"x\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"base_table_3\""
+      ]
+    },
+    {
+      "uniqueConstraints": [],
+      "otherFunctionalDependencies": [],
+      "foreignKeys": [],
+      "columns": [
+        {
+          "name": "\"id\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_A\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_B_1\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"id_B_2\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        },
+        {
+          "name": "\"x\"",
+          "datatype": "INTEGER",
+          "isNullable": false
+        }
+      ],
+      "name": [
+        "\"base_table_4\""
+      ]
+    }
+  ],
+  "metadata": {
+    "dbmsProductName": "H2",
+    "dbmsVersion": "1.4.199 (2019-03-13)",
+    "driverName": "H2 JDBC Driver",
+    "driverVersion": "1.4.199 (2019-03-13)",
+    "quotationString": "\"",
+    "extractionTime": "2020-11-12T17:24:30"
+  }
+}


### PR DESCRIPTION
Under certain conditions, foreign key constraints explicitly stated for basic lenses can be propagated to the lens' parent relation.

These conditions are:
- The referencing column is not modified by the lens.
- The foreign key does not point to the parent relation itself.

Also includes a set of test cases to test the feature together with UC propagation.