### PR TITLE
Fixed implementation of Functional Dependency inference for Unions

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/iq/request/FunctionalDependencies.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/iq/request/FunctionalDependencies.java
@@ -24,6 +24,12 @@ public interface FunctionalDependencies {
     FunctionalDependencies rename(InjectiveSubstitution<Variable> renamingSubstitution, SubstitutionFactory substitutionFactory);
     FunctionalDependencies concat(FunctionalDependencies other);
 
+    /**
+     * "Merges" two sets of determinants in the sense of a union: The dependents become the intersection of any
+     * two dependent sets of the two FD sets that are not empty, while the determinants become their union.
+     */
+    FunctionalDependencies merge(FunctionalDependencies other);
+
     boolean contains(ImmutableSet<Variable> determinants, ImmutableSet<Variable> dependents);
 
     ImmutableSet<ImmutableSet<Variable>> getDeterminantsOf(Variable variable);

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/DependencyTestDBMetadata.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/DependencyTestDBMetadata.java
@@ -1,5 +1,6 @@
 package it.unibz.inf.ontop;
 
+import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.dbschema.RelationDefinition;
 
 import static it.unibz.inf.ontop.OptimizationTestingTools.createMetadataProviderBuilder;
@@ -30,6 +31,7 @@ public class DependencyTestDBMetadata {
 
     public static final RelationDefinition FD_TABLE1_AR2;
     public static final RelationDefinition FD_TABLE2_AR2;
+    public static final RelationDefinition FD_TABLE1_AR5;
 
     static {
         OptimizationTestingTools.OfflineMetadataProviderBuilder3 builder = createMetadataProviderBuilder();
@@ -57,5 +59,7 @@ public class DependencyTestDBMetadata {
 
         FD_TABLE1_AR2 = builder.createRelationWithFD(1, 2, false);
         FD_TABLE2_AR2 = builder.createRelationWithFD(2, 2, false);
+        FD_TABLE1_AR5 = builder.createRelationWithCompositeFD(1, 5, false,
+                ImmutableSet.of(1, 2), ImmutableSet.of(3, 4));
     }
 }

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/OptimizationTestingTools.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/OptimizationTestingTools.java
@@ -246,6 +246,20 @@ public class OptimizationTestingTools {
             return tableDef;
         }
 
+        public NamedRelationDefinition createRelationWithCompositeFD(int tableNumber, int arity, boolean canNull,
+                                                                     ImmutableSet<Integer> determinants,
+                                                                     ImmutableSet<Integer> dependents) {
+            DBTermType stringDBType = getDBTypeFactory().getDBStringType();
+            NamedRelationDefinition tableDef = createRelation(tableNumber, arity, stringDBType, "FD_", canNull);
+            FunctionalDependency.Builder builder = FunctionalDependency.defaultBuilder(tableDef);
+            determinants.stream()
+                    .forEach(builder::addDeterminant);
+            dependents.stream()
+                    .forEach(builder::addDependent);
+            builder.build();
+            return tableDef;
+        }
+
         public RelationDefinition createRelationWithStringAttributes(int tableNumber, int arity, boolean canBeNull) {
             return createRelation(tableNumber, arity, getDBTypeFactory().getDBStringType(), "STR_", canBeNull);
         }

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/FunctionalDependencyInferenceTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/optimizer/FunctionalDependencyInferenceTest.java
@@ -28,6 +28,7 @@ public class FunctionalDependencyInferenceTest {
     private final ExtensionalDataNode DATA_NODE_1_WITH_ADDED_FD = createExtensionalDataNode(FD_TABLE1_AR2 , ImmutableList.of(A, B));
     private final ExtensionalDataNode DATA_NODE_2_WITH_ADDED_FD = createExtensionalDataNode(FD_TABLE2_AR2 , ImmutableList.of(C, D));
     private final ExtensionalDataNode DATA_NODE_2 = createExtensionalDataNode(PK_TABLE1_AR3, ImmutableList.of(A, B, C));
+    private final ExtensionalDataNode DATA_NODE_3_WITH_ADDED_FD = createExtensionalDataNode(FD_TABLE1_AR5 , ImmutableList.of(A, B, C, D, E));
 
     private static final NamedRelationDefinition COMPOSITE_PK_REL;
 
@@ -247,6 +248,37 @@ public class FunctionalDependencyInferenceTest {
                 IQ_FACTORY.createUnionNode(ImmutableSet.of(A, B, X)),
                 children);
         assertEquals(FunctionalDependencies.of(ImmutableSet.of(X), ImmutableSet.of(B, A)), tree.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree.getKnownVariables())).inferFunctionalDependencies());
+    }
+
+    @Test
+    public void testUnionWithSmallerDependentSet() {
+        IQTree leftChild = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(A, B, C, D, E, X),
+                        SUBSTITUTION_FACTORY.getSubstitution(X, TERM_FACTORY.getDBConstant("1", TYPE_FACTORY.getDBTypeFactory().getDBStringType()))),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(
+                                ImmutableSet.of(A, B, C, D, E),
+                                SUBSTITUTION_FACTORY.getSubstitution(D, TERM_FACTORY.getDBRand(UUID.randomUUID()))),
+                        DATA_NODE_3_WITH_ADDED_FD
+                )
+        );
+        IQTree rightChild = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(
+                        ImmutableSet.of(A, B, C, D, E, X),
+                        SUBSTITUTION_FACTORY.getSubstitution(X, TERM_FACTORY.getDBConstant("2", TYPE_FACTORY.getDBTypeFactory().getDBStringType()))),
+                DATA_NODE_3_WITH_ADDED_FD
+        );
+
+        IQTree tree1 = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createUnionNode(ImmutableSet.of(A, B, C, D, E, X)),
+                ImmutableList.of(leftChild, rightChild));
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A, B, X), ImmutableSet.of(C)), tree1.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree1.getKnownVariables())).inferFunctionalDependencies());
+
+        IQTree tree2 = IQ_FACTORY.createNaryIQTree(
+                IQ_FACTORY.createUnionNode(ImmutableSet.of(A, B, C, D, E, X)),
+                ImmutableList.of(rightChild, leftChild));
+        assertEquals(FunctionalDependencies.of(ImmutableSet.of(A, B, X), ImmutableSet.of(C)), tree2.normalizeForOptimization(CORE_UTILS_FACTORY.createVariableGenerator(tree2.getKnownVariables())).inferFunctionalDependencies());
     }
 
     @Test


### PR DESCRIPTION
We now use a different strategy to infer FDs of unions. This now works even if the set of dependents or determinants are not equal.

For instance, if `relation1` and `relation2` have the following dependencies, respectively:
`(a, b) -> (x, y)`, `(a, b, c) -> (x)`

Then we can infer the FD of the union (assuming at least one column is disjoint):
`(a, b, c) -> (x)`