### PR TITLE
More non-nullability constraints extracted from the ancestors for transferring self-left-joins based on functional dependencies

### DIFF
--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/AbstractLJTransformer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/AbstractLJTransformer.java
@@ -51,7 +51,7 @@ public abstract class AbstractLJTransformer extends DefaultNonRecursiveIQTreeTra
     public IQTree transformLeftJoin(IQTree tree, LeftJoinNode rootNode, IQTree leftChild, IQTree rightChild) {
         IQTree transformedLeftChild = transform(leftChild);
         // Cannot reuse
-        IQTree transformedRightChild = preTransformLJRightChild(rightChild, rootNode.getOptionalFilterCondition());
+        IQTree transformedRightChild = preTransformLJRightChild(rightChild, rootNode.getOptionalFilterCondition(), leftChild.getVariables());
 
         if (preventRecursiveOptimizationOnRightChild()
                 && !transformedRightChild.equals(rightChild))
@@ -173,7 +173,8 @@ public abstract class AbstractLJTransformer extends DefaultNonRecursiveIQTreeTra
      * Can be overridden
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    abstract protected IQTree preTransformLJRightChild(IQTree rightChild, Optional<ImmutableExpression> ljCondition);
+    abstract protected IQTree preTransformLJRightChild(IQTree rightChild, Optional<ImmutableExpression> ljCondition,
+                                                       ImmutableSet<Variable> leftVariables);
 
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/AbstractLJTransformer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/AbstractLJTransformer.java
@@ -204,5 +204,25 @@ public abstract class AbstractLJTransformer extends DefaultNonRecursiveIQTreeTra
                 .orElse(nullabilityWithLJCondition);
     }
 
+    protected Supplier<VariableNullability> computeChildVariableNullabilityFromConstructionParent(IQTree tree,
+                                                                                                ConstructionNode rootNode, IQTree child) {
+        var childVariables = child.getVariables();
+        var inheritedVariableNullability = getInheritedVariableNullability();
+        var bottomUpVariableNullability = tree.getVariableNullability();
+
+        var isNotNullConditions = termFactory.getConjunction(childVariables.stream()
+                .filter(v -> !rootNode.getSubstitution().isDefining(v))
+                .filter(bottomUpVariableNullability::isPossiblyNullable)
+                .filter(v -> ! inheritedVariableNullability.isPossiblyNullable(v))
+                .map(termFactory::getDBIsNotNull));
+
+        return () -> isNotNullConditions
+                .map(c -> variableNullabilityTools.updateWithFilter(
+                        c,
+                        child.getVariableNullability().getNullableGroups(),
+                        childVariables))
+                .orElseGet(child::getVariableNullability);
+    }
+
 
 }

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalityInsensitiveJoinTransferLJOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalityInsensitiveJoinTransferLJOptimizer.java
@@ -1,9 +1,6 @@
 package it.unibz.inf.ontop.iq.optimizer.impl.lj;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.*;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import it.unibz.inf.ontop.dbschema.FunctionalDependency;
@@ -23,6 +20,7 @@ import it.unibz.inf.ontop.iq.optimizer.impl.LookForDistinctOrLimit1TransformerIm
 import it.unibz.inf.ontop.iq.transform.IQTreeTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.model.term.ImmutableExpression;
+import it.unibz.inf.ontop.model.term.Variable;
 import it.unibz.inf.ontop.model.term.VariableOrGroundTerm;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import it.unibz.inf.ontop.utils.VariableGenerator;
@@ -30,6 +28,7 @@ import it.unibz.inf.ontop.utils.VariableGenerator;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 @Singleton
 public class CardinalityInsensitiveJoinTransferLJOptimizer implements LeftJoinIQOptimizer {
@@ -148,10 +147,16 @@ public class CardinalityInsensitiveJoinTransferLJOptimizer implements LeftJoinIQ
         }
 
         @Override
-        protected IQTree preTransformLJRightChild(IQTree rightChild, Optional<ImmutableExpression> ljCondition) {
+        protected IQTree preTransformLJRightChild(IQTree rightChild, Optional<ImmutableExpression> ljCondition,
+                                                  ImmutableSet<Variable> leftVariables) {
+
+            var isNotNullFromImplicitEqualities = Sets.intersection(leftVariables, rightChild.getVariables()).stream()
+                    .map(termFactory::getDBIsNotNull);
+
+            var condition = termFactory.getConjunction(Stream.concat(ljCondition.stream(), isNotNullFromImplicitEqualities));
 
             return transformBySearchingFromScratchFromDistinctTree(rightChild,
-                    () -> ljCondition
+                    () -> condition
                             .map(c -> variableNullabilityTools.updateWithFilter(
                                             c,
                                             rightChild.getVariableNullability().getNullableGroups(),

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalityInsensitiveJoinTransferLJOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalityInsensitiveJoinTransferLJOptimizer.java
@@ -166,7 +166,10 @@ public class CardinalityInsensitiveJoinTransferLJOptimizer implements LeftJoinIQ
 
         @Override
         public IQTree transformConstruction(IQTree tree, ConstructionNode rootNode, IQTree child) {
-            return transformUnaryNode(tree, rootNode, child, this::transformBySearchingFromScratchFromDistinctTree);
+            var childVariableNullabilitySupplier = computeChildVariableNullabilityFromConstructionParent(tree, rootNode, child);
+
+            return transformUnaryNode(tree, rootNode, child,
+                    t -> transformBySearchingFromScratchFromDistinctTree(t, childVariableNullabilitySupplier));
         }
 
         @Override

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalitySensitiveJoinTransferLJOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalitySensitiveJoinTransferLJOptimizer.java
@@ -16,6 +16,7 @@ import it.unibz.inf.ontop.iq.node.normalization.impl.RightProvenanceNormalizer;
 import it.unibz.inf.ontop.iq.optimizer.LeftJoinIQOptimizer;
 import it.unibz.inf.ontop.model.term.ImmutableExpression;
 import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.term.Variable;
 import it.unibz.inf.ontop.model.term.VariableOrGroundTerm;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import it.unibz.inf.ontop.utils.VariableGenerator;
@@ -118,7 +119,7 @@ public class CardinalitySensitiveJoinTransferLJOptimizer implements LeftJoinIQOp
         }
 
         @Override
-        protected IQTree preTransformLJRightChild(IQTree rightChild, Optional<ImmutableExpression> ljCondition) {
+        protected IQTree preTransformLJRightChild(IQTree rightChild, Optional<ImmutableExpression> ljCondition, ImmutableSet<Variable> leftVariables) {
             Supplier<VariableNullability> variableNullabilitySupplier =
                     () -> computeRightChildVariableNullability(rightChild, ljCondition);
 

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/LJWithNestingOnRightToInnerJoinOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/LJWithNestingOnRightToInnerJoinOptimizer.java
@@ -112,7 +112,7 @@ public class LJWithNestingOnRightToInnerJoinOptimizer implements LeftJoinIQOptim
         }
 
         @Override
-        protected IQTree preTransformLJRightChild(IQTree rightChild, Optional<ImmutableExpression> ljCondition) {
+        protected IQTree preTransformLJRightChild(IQTree rightChild, Optional<ImmutableExpression> ljCondition, ImmutableSet<Variable> leftVariables) {
             Supplier<VariableNullability> variableNullabilitySupplier =
                     () -> computeRightChildVariableNullability(rightChild, ljCondition);
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -5133,6 +5133,73 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, expectedTree));
     }
 
+    @Test
+    public void testFDOnRight6() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(1, B, 2, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(1, B, 3, D));
+
+        IQTree rightLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode2, dataNode3);
+
+        IQTree topLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBIsNotNull(B)),
+                dataNode1, rightLjTree);
+
+        var initialTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                        topLjTree);
+
+        var initialIQ = IQ_FACTORY.createIQ(projectionAtom, initialTree);
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of( 1, B, 2, C, 3, D));
+
+        var expectedTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBIsNotNull(B)),
+                        dataNode1, newDataNode));
+
+        optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, expectedTree));
+    }
+
+    @Test
+    public void testFDOnRight7() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(5), ImmutableList.of(A, B, C, D, E));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(1, B, 2, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(1, B, 3, D));
+
+        var constructionNode = IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C, D, E),
+                SUBSTITUTION_FACTORY.getSubstitution(E, TERM_FACTORY.getProvenanceSpecialConstant()));
+
+        IQTree rightLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(), dataNode2, dataNode3);
+
+        IQTree topLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBIsNotNull(B)),
+                dataNode1, IQ_FACTORY.createUnaryIQTree(constructionNode, rightLjTree));
+
+        var initialTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                topLjTree);
+
+        var initialIQ = IQ_FACTORY.createIQ(projectionAtom, initialTree);
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of( 1, B, 2, C, 3, D));
+
+        var expectedTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBIsNotNull(B)),
+                        dataNode1,
+                        IQ_FACTORY.createUnaryIQTree(constructionNode, newDataNode)));
+
+        optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, expectedTree));
+    }
+
 
 
     private static void optimizeAndCompare(IQ initialIQ, IQ expectedIQ) {

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -40,6 +40,7 @@ public class LeftJoinOptimizationTest {
     private final static NamedRelationDefinition TABLE7;
     private final static NamedRelationDefinition TABLE21;
     private final static NamedRelationDefinition TABLE22;
+    private final static NamedRelationDefinition TABLE23;
 
     /**
      *   TABLE_CLASSIFICATION(0:project, 1:action,2:objective,3:objective_name,4:axis)
@@ -198,6 +199,19 @@ public class LeftJoinOptimizationTest {
                 "col5", integerDBType, true);
         UniqueConstraint.primaryKeyOf(TABLE22.getAttribute(1));
         FunctionalDependency.defaultBuilder(TABLE22)
+                .addDeterminant(2)
+                .addDependent(3)
+                .addDependent(4)
+                .build();
+
+        TABLE23 = builder.createDatabaseRelation("table23",
+                "col1", integerDBType, false,
+                "col2", integerDBType, false,
+                "col3", integerDBType, false,
+                "col4", integerDBType, false,
+                "col5", integerDBType, false);
+        UniqueConstraint.primaryKeyOf(TABLE23.getAttribute(1));
+        FunctionalDependency.defaultBuilder(TABLE23)
                 .addDeterminant(2)
                 .addDependent(3)
                 .addDependent(4)
@@ -4972,9 +4986,16 @@ public class LeftJoinOptimizationTest {
 
         var initialIQ = IQ_FACTORY.createIQ(projectionAtom, initialTree);
 
-        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(0, A, 1, B, 2, C, 3, D));
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(0, A, 1, B, 2, CF0, 3, DF1));
 
-        optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, newDataNode));
+        var expectedTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(
+                                C, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(B), CF0),
+                                D, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(B), DF1))),
+                newDataNode);
+
+        optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, expectedTree));
     }
 
     @Test
@@ -4999,9 +5020,114 @@ public class LeftJoinOptimizationTest {
 
         var initialIQ = IQ_FACTORY.createIQ(projectionAtom, initialTree);
 
-        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(0, A, 1, B, 2, C));
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(0, A, 1, B, 2, CF0));
+
+        var expectedTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(
+                                C, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(B), CF0))),
+                newDataNode);
+
+        optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, expectedTree));
+    }
+
+    /**
+     * Non-nullable columns
+     */
+    @Test
+    public void testFDOnRight3() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE23, ImmutableMap.of(0, A, 1, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE23, ImmutableMap.of(1, B, 2, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE23, ImmutableMap.of(1, B, 3, D));
+
+        IQTree rightLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode2, dataNode3);
+
+        IQTree topLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, rightLjTree);
+
+        var initialTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                topLjTree);
+
+        var initialIQ = IQ_FACTORY.createIQ(projectionAtom, initialTree);
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE23, ImmutableMap.of(0, A, 1, B, 2, C, 3, D));
 
         optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, newDataNode));
+    }
+
+    @Test
+    public void testFDOnRight4() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(0, A, 1, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(1, B, 2, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(1, B, 3, D));
+
+        IQTree rightLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode2, dataNode3);
+
+        IQTree topLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getDBIsNotNull(B)),
+                dataNode1, rightLjTree);
+
+        var initialTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                topLjTree);
+
+        var initialIQ = IQ_FACTORY.createIQ(projectionAtom, initialTree);
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(0, A, 1, B, 2, CF0, 3, DF1));
+
+        var expectedTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(
+                                C, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(B), CF0),
+                                D, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(B), DF1))),
+                newDataNode);
+
+        optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, expectedTree));
+    }
+
+    @Test
+    public void testFDOnRight5() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(0, A, 1, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(1, B, 2, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(1, B, 3, D));
+
+        IQTree rightLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode2, dataNode3);
+
+        IQTree topLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, rightLjTree);
+
+        FilterNode filterNode = IQ_FACTORY.createFilterNode(TERM_FACTORY.getDBIsNotNull(B));
+
+        var initialTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                IQ_FACTORY.createUnaryIQTree(
+                        filterNode,
+                        topLjTree));
+
+        var initialIQ = IQ_FACTORY.createIQ(projectionAtom, initialTree);
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(0, A, 1, B, 2, C, 3, D));
+
+        var expectedTree = IQ_FACTORY.createUnaryIQTree(
+                filterNode,
+                newDataNode);
+
+        optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, expectedTree));
     }
 
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -4950,6 +4950,61 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, expectedTree));
     }
 
+    @Test
+    public void testFDOnRight1() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(0, A, 1, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(1, B, 2, C));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(1, B, 3, D));
+
+        IQTree rightLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode2, dataNode3);
+
+        IQTree topLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, rightLjTree);
+
+        var initialTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                topLjTree);
+
+        var initialIQ = IQ_FACTORY.createIQ(projectionAtom, initialTree);
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(0, A, 1, B, 2, C, 3, D));
+
+        optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, newDataNode));
+    }
+
+    @Test
+    public void testFDOnRight2() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, B, C));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(0, A, 1, B));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(1, B));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(1, B, 2, C));
+
+        IQTree rightLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode2, dataNode3);
+
+        IQTree topLjTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(IQ_FACTORY.createLeftJoinNode(),
+                dataNode1, rightLjTree);
+
+        var initialTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                topLjTree);
+
+        var initialIQ = IQ_FACTORY.createIQ(projectionAtom, initialTree);
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE22, ImmutableMap.of(0, A, 1, B, 2, C));
+
+        optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, newDataNode));
+    }
+
+
 
     private static void optimizeAndCompare(IQ initialIQ, IQ expectedIQ) {
         LOGGER.debug("Initial query: "+ initialIQ);

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -4964,6 +4964,7 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, expectedTree));
     }
 
+    @Ignore("TODO: support self-LJ on nullable FDs")
     @Test
     public void testFDOnRight1() {
 
@@ -4998,6 +4999,7 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, expectedTree));
     }
 
+    @Ignore("TODO: support self-LJ on nullable FDs")
     @Test
     public void testFDOnRight2() {
 
@@ -5061,6 +5063,7 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, newDataNode));
     }
 
+    @Ignore("TODO: support self-LJ on nullable FDs")
     @Test
     public void testFDOnRight4() {
 


### PR DESCRIPTION
This PR helps better optimizing right children of left-joins based on functional dependencies by providing more non-nullability information coming in a top-down manner.

In particular, it has been made robust to `ConstructionNode`s introducing provenance variables.

Example:

```
DISTINCT
   LJ IS_NOT_NULL(b)
      EXTENSIONAL TABLE1(0:a)
      CONSTRUCT [b, c, d, e] [e/"ontop-provenance-constant"^^STRING]
         LJ
            EXTENSIONAL TABLE22(1:b,2:c)
            EXTENSIONAL TABLE22(1:b,3:d)
``` 
There is functional dependencies in `TABLE22` from the second to the third column, and from the second and the forth columns. These columns are nullable so the `IS_NOT_NULL(b)` constraint is key for optimizing.

After optimization:
```
DISTINCT
   LJ IS_NOT_NULL(b)
      EXTENSIONAL TABLE1(0:a)
      CONSTRUCT [b, c, d, e] [e/"ontop-provenance-constant"^^STRING]
         EXTENSIONAL TABLE22(1:b,2:c,3:d)
```