### PR TITLE
Bugfix/plugin connection test for trino and H2

### DIFF
--- a/protege/plugin/src/main/java/it/unibz/inf/ontop/protege/connection/DataSource.java
+++ b/protege/plugin/src/main/java/it/unibz/inf/ontop/protege/connection/DataSource.java
@@ -126,7 +126,7 @@ public class DataSource {
 	public Connection getConnection() throws SQLException {
 		if (connection == null || connection.isClosed()) {
 			// H2: https://www.h2database.com/html/features.html#database_only_if_exists
-			String effectiveUrl = url.startsWith("jdbc:h2") && !url.contains("IFEXISTS=TRUE")
+			String effectiveUrl = url.startsWith("jdbc:h2") && !url.contains("IFEXISTS=")
 					? url + ";IFEXISTS=TRUE"
 					: url;
 

--- a/protege/plugin/src/main/java/it/unibz/inf/ontop/protege/connection/DataSource.java
+++ b/protege/plugin/src/main/java/it/unibz/inf/ontop/protege/connection/DataSource.java
@@ -126,7 +126,7 @@ public class DataSource {
 	public Connection getConnection() throws SQLException {
 		if (connection == null || connection.isClosed()) {
 			// H2: https://www.h2database.com/html/features.html#database_only_if_exists
-			String effectiveUrl = url.startsWith("jdbc:h2") && !url.contains("IFEXISTS=")
+			String effectiveUrl = url.startsWith("jdbc:h2:") && !url.contains("IFEXISTS=")
 					? url + ";IFEXISTS=TRUE"
 					: url;
 

--- a/protege/plugin/src/main/java/it/unibz/inf/ontop/protege/connection/DataSource.java
+++ b/protege/plugin/src/main/java/it/unibz/inf/ontop/protege/connection/DataSource.java
@@ -124,8 +124,14 @@ public class DataSource {
 	 * If the connection doesn't exist or is dead, it will create a new connection.
 	 */
 	public Connection getConnection() throws SQLException {
-		if (connection == null || connection.isClosed())
-			connection = DriverManager.getConnection(url, username, password);
+		if (connection == null || connection.isClosed()) {
+			// H2: https://www.h2database.com/html/features.html#database_only_if_exists
+			String effectiveUrl = url.startsWith("jdbc:h2") && !url.contains("IFEXISTS=TRUE")
+					? url + ";IFEXISTS=TRUE"
+					: url;
+
+			connection = DriverManager.getConnection(effectiveUrl, username, password);
+		}
 
 		return connection;
 	}

--- a/protege/plugin/src/main/java/it/unibz/inf/ontop/protege/connection/DataSource.java
+++ b/protege/plugin/src/main/java/it/unibz/inf/ontop/protege/connection/DataSource.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.*;
-import java.net.URI;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -61,26 +60,6 @@ public class DataSource {
 			JDBC_RESULTSETCONCUR, ResultSet.CONCUR_READ_ONLY
 			JDBC_RESULTSETTYPE, ResultSet.TYPE_FORWARD_ONLY
 		 */
-
-
-	public DataSource() {
-		URI id = URI.create(UUID.randomUUID().toString());
-	}
-
-	/**
-	 * Closes the connection quietly
-	 */
-	public void dispose() {
-		try {
-			if (connection != null) {
-				connection.close();
-				connection = null;
-			}
-		}
-		catch (Exception e) {
-			LOGGER.error(e.getMessage());
-		}
-	}
 
 
 	@Nonnull
@@ -118,10 +97,27 @@ public class DataSource {
 		this.driver = driver;
 
 		if (changed) {
-			dispose();
+			closeConnection();
 			listeners.fire(l -> l.changed(this));
 		}
 	}
+
+	public void dispose() {
+		closeConnection();
+	}
+
+	private void closeConnection() {
+		try {
+			if (connection != null) {
+				connection.close();
+				connection = null;
+			}
+		}
+		catch (Exception e) {
+			LOGGER.error(e.getMessage());
+		}
+	}
+
 
 	/**
 	 * Retrieves the connection object.
@@ -156,7 +152,7 @@ public class DataSource {
 		url = "";
 		username = "";
 		password = "";
-		connection = null;
+		closeConnection();
 	}
 
 	public ImmutableSet<String> getPropertyKeys() {

--- a/protege/plugin/src/main/java/it/unibz/inf/ontop/protege/connection/DataSourcePanel.java
+++ b/protege/plugin/src/main/java/it/unibz/inf/ontop/protege/connection/DataSourcePanel.java
@@ -159,10 +159,6 @@ public class DataSourcePanel extends JPanel implements OBDAModelManagerListener 
                             // In Trino, non-null connection object does not mean that a connection has been established.
                             // This username request forces the Trino driver to execute an SQL query (so, a connection will be opened).
                             conn.getMetaData().getUserName();
-                            // A workaround for H2
-                            //noinspection EmptyTryBlock
-                            try (ResultSet rs = conn.getMetaData().getTableTypes()) {
-                            }
                             return null;
                         }
                         catch (SQLException e) {

--- a/protege/plugin/src/main/java/it/unibz/inf/ontop/protege/connection/DataSourcePanel.java
+++ b/protege/plugin/src/main/java/it/unibz/inf/ontop/protege/connection/DataSourcePanel.java
@@ -37,6 +37,7 @@ import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
@@ -158,6 +159,10 @@ public class DataSourcePanel extends JPanel implements OBDAModelManagerListener 
                             // In Trino, non-null connection object does not mean that a connection has been established.
                             // This username request forces the Trino driver to execute an SQL query (so, a connection will be opened).
                             conn.getMetaData().getUserName();
+                            // A workaround for H2
+                            //noinspection EmptyTryBlock
+                            try (ResultSet rs = conn.getMetaData().getTableTypes()) {
+                            }
                             return null;
                         }
                         catch (SQLException e) {


### PR DESCRIPTION
Fixed the following two issues with JDBC drivers:
  - Trino does not actually open a connection until a query is issued;
  - H2 creates an empty DB if it does not exist (the IFEXISTS=TRUE flag is needed in the connection URL to prevent that).