### PR TITLE
Include user info in the query log

### DIFF
--- a/binding/rdf4j/src/main/java/it/unibz/inf/ontop/rdf4j/predefined/OntopRDF4JPredefinedQueryEngine.java
+++ b/binding/rdf4j/src/main/java/it/unibz/inf/ontop/rdf4j/predefined/OntopRDF4JPredefinedQueryEngine.java
@@ -2,7 +2,6 @@ package it.unibz.inf.ontop.rdf4j.predefined;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import org.eclipse.rdf4j.query.GraphQueryResult;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 
@@ -27,7 +26,7 @@ public interface OntopRDF4JPredefinedQueryEngine {
     void evaluate(String queryId,
                   ImmutableMap<String, String> bindings,
                   ImmutableList<String> acceptMediaTypes,
-                  ImmutableMultimap<String, String> httpHeaders,
+                  ImmutableMap<String, String> httpHeaders,
                   Consumer<Integer> httpStatusSetter,
                   BiConsumer<String, String> httpHeaderSetter,
                   OutputStream outputStream) throws LateEvaluationOrConversionException;
@@ -38,7 +37,7 @@ public interface OntopRDF4JPredefinedQueryEngine {
     String evaluate(String queryId,
                   ImmutableMap<String, String> bindings,
                   ImmutableList<String> acceptMediaTypes,
-                  ImmutableMultimap<String, String> httpHeaders,
+                  ImmutableMap<String, String> httpHeaders,
                   Consumer<Integer> httpStatusSetter,
                   BiConsumer<String, String> httpHeaderSetter);
 

--- a/binding/rdf4j/src/main/java/it/unibz/inf/ontop/rdf4j/predefined/impl/FakeOntopRDF4JPredefinedQueryEngine.java
+++ b/binding/rdf4j/src/main/java/it/unibz/inf/ontop/rdf4j/predefined/impl/FakeOntopRDF4JPredefinedQueryEngine.java
@@ -2,7 +2,6 @@ package it.unibz.inf.ontop.rdf4j.predefined.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import it.unibz.inf.ontop.rdf4j.predefined.OntopRDF4JPredefinedQueryEngine;
 import org.eclipse.rdf4j.query.GraphQueryResult;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -16,7 +15,7 @@ public class FakeOntopRDF4JPredefinedQueryEngine implements OntopRDF4JPredefined
 
     @Override
     public void evaluate(String queryId, ImmutableMap<String, String> bindings, ImmutableList<String> acceptMediaTypes,
-                         ImmutableMultimap<String, String> httpHeaders, Consumer<Integer> httpStatusSetter,
+                         ImmutableMap<String, String> httpHeaders, Consumer<Integer> httpStatusSetter,
                          BiConsumer<String, String> httpHeaderSetter, OutputStream outputStream)
             throws QueryEvaluationException, RDFHandlerException {
         // Not-recognized query id
@@ -25,7 +24,7 @@ public class FakeOntopRDF4JPredefinedQueryEngine implements OntopRDF4JPredefined
 
     @Override
     public String evaluate(String queryId, ImmutableMap<String, String> bindings, ImmutableList<String> acceptMediaTypes,
-                           ImmutableMultimap<String, String> httpHeaders, Consumer<Integer> httpStatusSetter,
+                           ImmutableMap<String, String> httpHeaders, Consumer<Integer> httpStatusSetter,
                            BiConsumer<String, String> httpHeaderSetter) {
         // Not-recognized query id
         httpStatusSetter.accept(404);

--- a/binding/rdf4j/src/main/java/it/unibz/inf/ontop/rdf4j/predefined/impl/OntopRDF4JPredefinedQueryEngineImpl.java
+++ b/binding/rdf4j/src/main/java/it/unibz/inf/ontop/rdf4j/predefined/impl/OntopRDF4JPredefinedQueryEngineImpl.java
@@ -8,7 +8,6 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.inject.Injector;
 import it.unibz.inf.ontop.answering.OntopQueryEngine;
 import it.unibz.inf.ontop.answering.connection.OntopConnection;
@@ -102,7 +101,7 @@ public class OntopRDF4JPredefinedQueryEngineImpl implements OntopRDF4JPredefined
     @Override
     public void evaluate(String queryId, ImmutableMap<String, String> bindings,
                          ImmutableList<String> acceptMediaTypes,
-                         ImmutableMultimap<String, String> httpHeaders,
+                         ImmutableMap<String, String> httpHeaders,
                          Consumer<Integer> httpStatusSetter,
                          BiConsumer<String, String> httpHeaderSetter,
                          OutputStream outputStream) throws LateEvaluationOrConversionException {
@@ -130,7 +129,7 @@ public class OntopRDF4JPredefinedQueryEngineImpl implements OntopRDF4JPredefined
 
     @Override
     public String evaluate(String queryId, ImmutableMap<String, String> bindings, ImmutableList<String> acceptMediaTypes,
-                           ImmutableMultimap<String, String> httpHeaders, Consumer<Integer> httpStatusSetter,
+                           ImmutableMap<String, String> httpHeaders, Consumer<Integer> httpStatusSetter,
                            BiConsumer<String, String> httpHeaderSetter) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try {
@@ -158,7 +157,7 @@ public class OntopRDF4JPredefinedQueryEngineImpl implements OntopRDF4JPredefined
     }
 
     private void evaluateGraphWithHandler(PredefinedGraphQuery predefinedQuery, ImmutableMap<String, String> bindings, ImmutableList<String> acceptMediaTypes,
-                                          ImmutableMultimap<String, String> httpHeaders, BiConsumer<String, String> httpHeaderSetter,
+                                          ImmutableMap<String, String> httpHeaders, BiConsumer<String, String> httpHeaderSetter,
                                           Consumer<Integer> httpStatusSetter, OutputStream outputStream) throws LateEvaluationOrConversionException {
 
         RDFWriterRegistry registry = RDFWriterRegistry.getInstance();
@@ -268,7 +267,7 @@ public class OntopRDF4JPredefinedQueryEngineImpl implements OntopRDF4JPredefined
         PredefinedGraphQuery predefinedQuery = Optional.ofNullable(graphQueries.get(queryId))
                 .orElseThrow(() -> new IllegalArgumentException("The query" + queryId + " is not defined as a graph query"));
         ConstructTemplate constructTemplate = predefinedQuery.getConstructTemplate();
-        QueryLogger queryLogger = createQueryLogger(predefinedQuery, bindings, ImmutableMultimap.of());
+        QueryLogger queryLogger = createQueryLogger(predefinedQuery, bindings, ImmutableMap.of());
         try {
             IQ executableQuery = createExecutableQuery(predefinedQuery, bindings, queryLogger);
             return executeConstructQuery(constructTemplate, executableQuery, queryLogger);
@@ -308,7 +307,7 @@ public class OntopRDF4JPredefinedQueryEngineImpl implements OntopRDF4JPredefined
                 .newBindings(bindingSet);
 
         // TODO: shall we consider some HTTP headers?
-        QueryLogger tmpQueryLogger = queryLoggerFactory.create(ImmutableMultimap.of());
+        QueryLogger tmpQueryLogger = queryLoggerFactory.create(ImmutableMap.of());
         QueryContext emptyQueryContext = queryContextFactory.create(ImmutableMap.of());
 
         LOGGER.debug("Generating the reference query for {} with ref parameters {}",
@@ -319,7 +318,7 @@ public class OntopRDF4JPredefinedQueryEngineImpl implements OntopRDF4JPredefined
     }
 
     private QueryLogger createQueryLogger(PredefinedQuery<?> predefinedQuery, ImmutableMap<String, String> bindings,
-                                          ImmutableMultimap<String, String> httpHeaders) {
+                                          ImmutableMap<String, String> httpHeaders) {
         QueryLogger queryLogger = queryLoggerFactory.create(httpHeaders);
         queryLogger.setPredefinedQuery(predefinedQuery.getId(), bindings);
         return queryLogger;
@@ -354,8 +353,8 @@ public class OntopRDF4JPredefinedQueryEngineImpl implements OntopRDF4JPredefined
     }
 
     private void evaluateTupleWithHandler(String queryId, ImmutableMap<String, String> bindings, ImmutableList<String> acceptMediaTypes,
-                                          ImmutableMultimap<String, String> httpHeaders, BiConsumer<String, String> httpHeaderSetter,
+                                          ImmutableMap<String, String> httpHeaders, BiConsumer<String, String> httpHeaderSetter,
                                           Consumer<Integer> httpStatusSetter, OutputStream outputStream) {
-        throw new RuntimeException("TODO: support SELECT queries");
+        throw new RuntimeException("TODO: support SELECT queries");
     }
 }

--- a/client/endpoint-core/src/main/java/it/unibz/inf/ontop/endpoint/processor/SparqlQueryExecutor.java
+++ b/client/endpoint-core/src/main/java/it/unibz/inf/ontop/endpoint/processor/SparqlQueryExecutor.java
@@ -46,10 +46,7 @@ public class SparqlQueryExecutor {
     public void executeQuery(HttpServletRequest request, String accept, String query,
                              String[] defaultGraphUri, String[] namedGraphUri, HttpServletResponse response) {
 
-        ImmutableMultimap<String, String> httpHeaders = Collections.list(request.getHeaderNames()).stream()
-                .flatMap(k -> Collections.list(request.getHeaders(k)).stream()
-                        .map(v -> Maps.immutableEntry(k, v)))
-                .collect(ImmutableCollectors.toMultimap());
+        ImmutableMultimap<String, String> httpHeaders = extractHttpHeaders(request);
 
         try (OntopRepositoryConnection connection = repository.getConnection()) {
             Query q = connection.prepareQuery(QueryLanguage.SPARQL, query, httpHeaders);
@@ -136,6 +133,13 @@ public class SparqlQueryExecutor {
         catch (IOException ex) {
             throw new Error(ex);
         }
+    }
+
+    public static ImmutableMultimap<String, String> extractHttpHeaders(HttpServletRequest request) {
+        return Collections.list(request.getHeaderNames()).stream()
+                .flatMap(k -> Collections.list(request.getHeaders(k)).stream()
+                        .map(v -> Maps.immutableEntry(k, v)))
+                .collect(ImmutableCollectors.toMultimap());
     }
 
     private void evaluateSelectQuery(TupleQuery selectQuery, TupleQueryResultWriter writer, HttpServletResponse response) {

--- a/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/controllers/PredefinedQueryController.java
+++ b/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/controllers/PredefinedQueryController.java
@@ -2,8 +2,8 @@ package it.unibz.inf.ontop.endpoint.controllers;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Maps;
+import it.unibz.inf.ontop.answering.connection.impl.QuestStatement;
 import it.unibz.inf.ontop.rdf4j.predefined.LateEvaluationOrConversionException;
 import it.unibz.inf.ontop.rdf4j.predefined.OntopRDF4JPredefinedQueryEngine;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
@@ -51,10 +51,10 @@ public class PredefinedQueryController {
                 .map(m -> m.getType() + "/" + m.getSubtype())
                 .collect(ImmutableCollectors.toList());
 
-        ImmutableMultimap<String, String> httpHeaders = Collections.list(request.getHeaderNames()).stream()
+        ImmutableMap<String, String> httpHeaders = QuestStatement.normalizeHttpHeaders(Collections.list(request.getHeaderNames()).stream()
                 .flatMap(k -> Collections.list(request.getHeaders(k)).stream()
                         .map(v -> Maps.immutableEntry(k, v)))
-                .collect(ImmutableCollectors.toMultimap());
+                .collect(ImmutableCollectors.toMultimap()));
 
         ImmutableMap<String, String> requestParams = ImmutableMap.copyOf(allRequestParams);
         ServletOutputStream responseOutputStream = response.getOutputStream();

--- a/core/model/src/main/resources/property_description.json
+++ b/core/model/src/main/resources/property_description.json
@@ -143,6 +143,10 @@
     "type": "Boolean",
     "description": "Includes DB tables/views into the query log."
   },
+  "ontop.queryLogging.includeUserInfo": {
+    "type": "Boolean",
+    "description": "Since 5.2.0. Default value: `false`. If `true`, includes the user ID, his/her groups and roles."
+  },
   "ontop.queryLogging.includeHttpHeader.HEADER_NAME": {
     "type": "Boolean",
     "description": "If true, includes a specific HTTP header (please replace `HEADER_NAME` by the desired one) into the query log."

--- a/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/answering/logging/QueryLogger.java
+++ b/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/answering/logging/QueryLogger.java
@@ -1,7 +1,6 @@
 package it.unibz.inf.ontop.answering.logging;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import it.unibz.inf.ontop.exception.OntopReformulationException;
 import it.unibz.inf.ontop.iq.IQ;
 import it.unibz.inf.ontop.spec.ontology.InconsistentOntologyException;
@@ -34,6 +33,6 @@ public interface QueryLogger {
     void setPredefinedQuery(String queryId, ImmutableMap<String, String> bindings);
 
     interface Factory {
-        QueryLogger create(ImmutableMultimap<String, String> httpHeaders);
+        QueryLogger create(ImmutableMap<String, String> httpHeaders);
     }
 }

--- a/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/injection/OntopReformulationSettings.java
+++ b/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/injection/OntopReformulationSettings.java
@@ -21,6 +21,8 @@ public interface OntopReformulationSettings extends OntopKGQuerySettings {
     boolean isReformulatedQueryIncludedIntoQueryLog();
     boolean areClassesAndPropertiesIncludedIntoQueryLog();
     boolean areTablesIncludedIntoQueryLog();
+    boolean isUserInfoIncludedIntoQueryLog();
+
     boolean isQueryLoggingDecompositionEnabled();
     boolean areQueryLoggingDecompositionAndMergingMutuallyExclusive();
 
@@ -53,6 +55,7 @@ public interface OntopReformulationSettings extends OntopKGQuerySettings {
     String CLASSES_INCLUDED_QUERY_LOGGING = "ontop.queryLogging.includeClassesAndProperties";
     // Includes DB tables/views into the query log
     String TABLES_INCLUDED_QUERY_LOGGING = "ontop.queryLogging.includeTables";
+    String USER_INFO_INCLUDED_QUERY_LOGGING = "ontop.queryLogging.includeUserInfo";
     String HTTP_HEADER_INCLUDED_QUERY_LOGGING_PREFIX = "ontop.queryLogging.includeHttpHeader.";
     String QUERY_TEMPLATE_EXTRACTION = "ontop.queryLogging.extractQueryTemplate";
     String QUERY_LOGGING_DECOMPOSITION = "ontop.queryLogging.decomposition";

--- a/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/injection/impl/OntopReformulationSettingsImpl.java
+++ b/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/injection/impl/OntopReformulationSettingsImpl.java
@@ -84,6 +84,11 @@ public class OntopReformulationSettingsImpl extends OntopKGQuerySettingsImpl imp
     }
 
     @Override
+    public boolean isUserInfoIncludedIntoQueryLog() {
+        return getRequiredBoolean(USER_INFO_INCLUDED_QUERY_LOGGING);
+    }
+
+    @Override
     public boolean isQueryLoggingDecompositionEnabled() {
         return getRequiredBoolean(QUERY_LOGGING_DECOMPOSITION);
     }

--- a/engine/reformulation/core/src/main/resources/it/unibz/inf/ontop/injection/reformulation-default.properties
+++ b/engine/reformulation/core/src/main/resources/it/unibz/inf/ontop/injection/reformulation-default.properties
@@ -29,6 +29,8 @@ ontop.queryLogging.includeReformulatedQuery=false
 ontop.queryLogging.includeClassesAndProperties=true
 # Includes DB tables/views into the query log
 ontop.queryLogging.includeTables=true
+# Includes the user ID, his/her groups and roles
+ontop.queryLogging.includeUserInfo=false
 # Provides separated message at different phases (after reformulation, result set unblocked, last result fetched)
 ontop.queryLogging.decomposition=false
 # Sets that merged messages are only inserted when decomposition is disabled

--- a/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/connection/impl/QuestStatement.java
+++ b/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/connection/impl/QuestStatement.java
@@ -230,8 +230,7 @@ public abstract class QuestStatement implements OntopStatement {
 
 		ImmutableMap<String, String> normalizedHttpHeaders = normalizeHttpHeaders(httpHeaders);
 
-		// TODO: use normalizedHttpHeaders
-		QueryLogger queryLogger = queryLoggerFactory.create(httpHeaders);
+		QueryLogger queryLogger = queryLoggerFactory.create(normalizedHttpHeaders);
 		queryLogger.setSparqlQuery(inputQuery.getOriginalString());
 
 		QueryContext queryContext = queryContextFactory.create(normalizedHttpHeaders);
@@ -276,7 +275,7 @@ public abstract class QuestStatement implements OntopStatement {
 	 * without changing the semantics of the message, by appending each subsequent field-value to the first,
 	 * each separated by a comma.
 	 */
-	private ImmutableMap<String, String> normalizeHttpHeaders(ImmutableMultimap<String, String> httpHeaders) {
+	public static ImmutableMap<String, String> normalizeHttpHeaders(ImmutableMultimap<String, String> httpHeaders) {
 		return httpHeaders.asMap().entrySet().stream()
 				.collect(ImmutableCollectors.toMap(
 						e -> e.getKey().toLowerCase(),
@@ -308,8 +307,9 @@ public abstract class QuestStatement implements OntopStatement {
 
 	@Override
 	public  <R extends OBDAResultSet>  IQ getExecutableQuery(KGQuery<R> inputQuery, ImmutableMultimap<String, String> httpHeaders) throws OntopReformulationException {
-		return engine.reformulateIntoNativeQuery(inputQuery, queryContextFactory.create(normalizeHttpHeaders(httpHeaders)),
-				queryLoggerFactory.create(ImmutableMultimap.of()));
+		ImmutableMap<String, String> normalizedHttpHeaders = normalizeHttpHeaders(httpHeaders);
+		return engine.reformulateIntoNativeQuery(inputQuery, queryContextFactory.create(normalizedHttpHeaders),
+				queryLoggerFactory.create(normalizedHttpHeaders));
 	}
 
 }

--- a/engine/system/core/src/main/java/it/unibz/inf/ontop/query/resultset/impl/DefaultDescribeGraphResultSet.java
+++ b/engine/system/core/src/main/java/it/unibz/inf/ontop/query/resultset/impl/DefaultDescribeGraphResultSet.java
@@ -42,7 +42,7 @@ public class DefaultDescribeGraphResultSet implements GraphResultSet {
                                                               Evaluator<TupleResultSet, SelectQuery> selectQueryEvaluator)
             throws OntopQueryEvaluationException, OntopConnectionException,
             OntopReformulationException, OntopResultConversionException {
-        QueryLogger selectQueryLogger = queryLoggerFactory.create(ImmutableMultimap.of());
+        QueryLogger selectQueryLogger = queryLoggerFactory.create(ImmutableMap.of());
         try (TupleResultSet resultSet = selectQueryEvaluator.evaluate(inputQuery.getSelectQuery(), queryContext, selectQueryLogger)) {
             queryLogger.declareResultSetUnblockedAndSerialize();
 
@@ -118,7 +118,7 @@ public class DefaultDescribeGraphResultSet implements GraphResultSet {
             do {
                 if (currentGraphResultSetIterator == null) {
                     if (constructQueryIterator.hasNext()) {
-                        QueryLogger constructQueryLogger = queryLoggerFactory.create(ImmutableMultimap.of());
+                        QueryLogger constructQueryLogger = queryLoggerFactory.create(ImmutableMap.of());
                         try {
                             GraphResultSet graphResultSet = constructQueryEvaluator.evaluate(constructQueryIterator.next(),
                                     queryContext, constructQueryLogger);

--- a/engine/system/sql/core/src/main/java/it/unibz/inf/ontop/injection/impl/OntopStandaloneSQLSettingsImpl.java
+++ b/engine/system/sql/core/src/main/java/it/unibz/inf/ontop/injection/impl/OntopStandaloneSQLSettingsImpl.java
@@ -69,6 +69,11 @@ public class OntopStandaloneSQLSettingsImpl extends OntopMappingSQLAllSettingsIm
     }
 
     @Override
+    public boolean isUserInfoIncludedIntoQueryLog() {
+        return getRequiredBoolean(USER_INFO_INCLUDED_QUERY_LOGGING);
+    }
+
+    @Override
     public boolean isQueryLoggingDecompositionEnabled() {
         return getRequiredBoolean(QUERY_LOGGING_DECOMPOSITION);
     }

--- a/engine/system/sql/core/src/test/java/it/unibz/inf/ontop/answering/reformulation/OfflineOnlineMarriageTest.java
+++ b/engine/system/sql/core/src/test/java/it/unibz/inf/ontop/answering/reformulation/OfflineOnlineMarriageTest.java
@@ -87,7 +87,7 @@ public class OfflineOnlineMarriageTest {
 
         IQ executableQuery = queryReformulator.reformulateIntoNativeQuery(query,
                 queryReformulator.getQueryContextFactory().create(ImmutableMap.of()),
-                queryReformulator.getQueryLoggerFactory().create(ImmutableMultimap.of()));
+                queryReformulator.getQueryLoggerFactory().create(ImmutableMap.of()));
         String sqlQuery = Optional.of(executableQuery.getTree())
                 .filter(t -> t instanceof UnaryIQTree)
                 .map(t -> ((UnaryIQTree) t).getChild().getRootNode())


### PR DESCRIPTION
The option `ontop.queryLogging.includeUserInfo` needs to be set to `true` (`false` by default).

3 fields are added to the query log: `user`, `groups` and `roles`.

Small change: selected HTTP headers are now normalized before being logged: their keys are lower-cased and multiple values are joined together (before only the first value was logged).