### PR TITLE
No default schema in MS SQL Server for Ontop 5.1

### DIFF
--- a/core/model/src/main/java/it/unibz/inf/ontop/dbschema/QuotedIDFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/dbschema/QuotedIDFactory.java
@@ -23,6 +23,7 @@ package it.unibz.inf.ontop.dbschema;
 import com.google.common.collect.ImmutableMap;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
+import javax.annotation.Nullable;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -77,7 +78,7 @@ public interface QuotedIDFactory {
      *                   from the catalog to the table name
      * @return relation ID
      */
-    RelationID createRelationID(String... components);
+    RelationID createRelationID(@Nullable String... components);
 
     /**
      * Returns the quotation string used in the SQL rendering.

--- a/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLStandardQuotedIDFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLStandardQuotedIDFactory.java
@@ -29,6 +29,7 @@ import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
 import it.unibz.inf.ontop.dbschema.RelationID;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
 
@@ -82,7 +83,7 @@ public class SQLStandardQuotedIDFactory implements QuotedIDFactory {
 	}
 
 	@Override
-	public RelationID createRelationID(String... components) {
+	public RelationID createRelationID(@Nullable String... components) {
 		Objects.requireNonNull(components[components.length - 1]);
 		ImmutableList.Builder<QuotedID> builder = ImmutableList.builder();
 		for (int i = components.length - 1; i >= 0; i--)

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AbstractDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AbstractDBMetadataProvider.java
@@ -548,7 +548,7 @@ public abstract class AbstractDBMetadataProvider implements DBMetadataProvider {
         return e.getCause().toString();
     }
 
-    protected abstract RelationID getCanonicalRelationId(RelationID id);
+    protected abstract RelationID getCanonicalRelationId(RelationID id) throws MetadataExtractionException;
 
     protected abstract ImmutableList<RelationID> getAllIDs(RelationID id);
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DefaultSchemaCatalogDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DefaultSchemaCatalogDBMetadataProvider.java
@@ -46,10 +46,10 @@ public abstract class DefaultSchemaCatalogDBMetadataProvider extends AbstractDBM
         super(connection, idFactoryProvider, coreSingletons);
         try {
             String[] defaultRelationComponents = defaultsFactory.getDefaultRelationIdComponents(connection);
-            if (defaultRelationComponents == null || defaultRelationComponents.length < CATALOG_INDEX + 1
-                    || defaultRelationComponents[SCHEMA_INDEX] == null)
+            if (defaultRelationComponents == null || defaultRelationComponents.length < 3
+                    || defaultRelationComponents[1] == null)
                 throw new MetadataExtractionException("Unable to obtain the default schema: make sure the connection URL is complete " + Arrays.toString(defaultRelationComponents));
-            if (defaultRelationComponents[CATALOG_INDEX] == null)
+            if (defaultRelationComponents[0] == null)
                 throw new MetadataExtractionException("Unable to obtain the default catalog: make sure the connection URL is complete " + Arrays.toString(defaultRelationComponents));
 
             RelationID id = rawIdFactory.createRelationID(defaultRelationComponents);

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DefaultSchemaDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DefaultSchemaDBMetadataProvider.java
@@ -38,8 +38,8 @@ public abstract class DefaultSchemaDBMetadataProvider extends AbstractDBMetadata
         super(connection, idFactoryProvider, coreSingletons);
         try {
             String[] defaultRelationComponents = defaultsFactory.getDefaultRelationIdComponents(connection);
-            if (defaultRelationComponents == null || defaultRelationComponents.length < SCHEMA_INDEX + 1
-                    || defaultRelationComponents[SCHEMA_INDEX] == null)
+            if (defaultRelationComponents == null || defaultRelationComponents.length < 2
+                    || defaultRelationComponents[0] == null)
                 throw new MetadataExtractionException("Unable to obtain the default schema: make sure the connection URL is complete " + Arrays.toString(defaultRelationComponents));
 
             RelationID id = rawIdFactory.createRelationID(defaultRelationComponents);

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DremioQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DremioQuotedIDFactory.java
@@ -6,6 +6,7 @@ import it.unibz.inf.ontop.dbschema.QuotedIDFactory.IDFactoryType;
 import it.unibz.inf.ontop.dbschema.RelationID;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -21,12 +22,12 @@ public class DremioQuotedIDFactory extends SQLStandardQuotedIDFactory {
     }
 
     @Override
-    public RelationID createRelationID(String... components) {
+    public RelationID createRelationID(@Nullable String... components) {
         Objects.requireNonNull(components[components.length - 1]);
 
         Stream<String> stream = components.length <= 2
-                ? Arrays.stream(components)
-                : Stream.of(Arrays.stream(components)
+                ? Arrays.stream(components).filter(Objects::nonNull)
+                : Stream.of(Arrays.stream(components).filter(Objects::nonNull)
                         .limit(components.length - 1) // first (N-1) components are the schema
                         .map(name -> name.replace("\"", "")) // remove quotes in-between
                         .collect(Collectors.joining(".")),

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLServerDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLServerDBMetadataProvider.java
@@ -1,21 +1,50 @@
 package it.unibz.inf.ontop.dbschema.impl;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import it.unibz.inf.ontop.dbschema.QuotedID;
 import it.unibz.inf.ontop.dbschema.RelationID;
 import it.unibz.inf.ontop.exception.MetadataExtractionException;
 import it.unibz.inf.ontop.injection.CoreSingletons;
 
 import javax.annotation.Nullable;
 import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
 
-public class SQLServerDBMetadataProvider extends DefaultSchemaCatalogDBMetadataProvider {
+import static it.unibz.inf.ontop.dbschema.RelationID.TABLE_INDEX;
+
+public class SQLServerDBMetadataProvider extends AbstractDBMetadataProvider {
+
+    protected static final int SCHEMA_INDEX = 1;
+    protected static final int CATALOG_INDEX = 2;
+
+    private final QuotedID defaultCatalog;
+    private final Optional<QuotedID> defaultSchema;
 
     @AssistedInject
     SQLServerDBMetadataProvider(@Assisted Connection connection, CoreSingletons coreSingletons) throws MetadataExtractionException {
         super(connection, metadata -> new SQLServerQuotedIDFactory(), coreSingletons);
+        try {
+            String defaultCatalogString = connection.getCatalog();
+            String defaultSchemaString = connection.getSchema(); // can be null
+
+            if (defaultCatalogString == null)
+                throw new MetadataExtractionException("Unable to obtain the default catalog: make sure the connection URL is complete: " + defaultCatalogString + " " + defaultSchemaString);
+
+            RelationID id = rawIdFactory.createRelationID(defaultCatalogString, defaultSchemaString, "DUMMY");
+            defaultCatalog = id.getComponents().get(defaultSchemaString == null ? SCHEMA_INDEX : CATALOG_INDEX);
+            defaultSchema = defaultSchemaString == null ? Optional.empty() : Optional.of(id.getComponents().get(SCHEMA_INDEX));
+        }
+        catch (SQLException e) {
+            throw new MetadataExtractionException(e);
+        }
     }
+
+
 
     private static final ImmutableSet<String> IGNORED_SCHEMAS = ImmutableSet.of("sys", "INFORMATION_SCHEMA");
 
@@ -32,6 +61,50 @@ public class SQLServerDBMetadataProvider extends DefaultSchemaCatalogDBMetadataP
     @Override
     protected String makeQueryMinimizeResultSet(String query) {
         return String.format("SELECT * FROM (%s) subQ ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY", query);
+    }
+
+
+    @Override
+    protected RelationID getCanonicalRelationId(RelationID id) throws MetadataExtractionException {
+        switch (id.getComponents().size()) {
+            case CATALOG_INDEX:
+                return new RelationIDImpl(ImmutableList.of(
+                        id.getComponents().get(TABLE_INDEX),
+                        id.getComponents().get(SCHEMA_INDEX),
+                        defaultCatalog));
+            case SCHEMA_INDEX:
+                return new RelationIDImpl(ImmutableList.of(
+                        id.getComponents().get(TABLE_INDEX),
+                        defaultSchema.orElseThrow(() -> new MetadataExtractionException("There is no default schema for " + id)),
+                        defaultCatalog));
+            default:
+                return id;
+        }
+    }
+
+    @Override
+    protected ImmutableList<RelationID> getAllIDs(RelationID id) {
+        if (defaultCatalog.equals(id.getComponents().get(CATALOG_INDEX))) {
+            RelationID schemaTableId = new RelationIDImpl(id.getComponents().subList(TABLE_INDEX, CATALOG_INDEX));
+            if (defaultSchema.filter(d -> d.equals(id.getComponents().get(SCHEMA_INDEX))).isPresent())
+                return ImmutableList.of(id.getTableOnlyID(), schemaTableId, id);
+            return ImmutableList.of(schemaTableId, id);
+        }
+        return ImmutableList.of(id);
+    }
+
+    @Override
+    protected String getRelationCatalog(RelationID id) { return id.getComponents().get(CATALOG_INDEX).getName(); }
+
+    @Override
+    protected String getRelationSchema(RelationID id) { return id.getComponents().get(SCHEMA_INDEX).getName(); }
+
+    @Override
+    protected String getRelationName(RelationID id) { return id.getComponents().get(TABLE_INDEX).getName(); }
+
+    @Override
+    protected RelationID getRelationID(ResultSet rs, String catalogNameColumn, String schemaNameColumn, String tableNameColumn) throws SQLException {
+        return rawIdFactory.createRelationID(rs.getString(catalogNameColumn), rs.getString(schemaNameColumn), rs.getString(tableNameColumn));
     }
 
     /*


### PR DESCRIPTION
The JDBC driver for MS SQL Server in certain settings returns `null` instead of the default schema name. A special implementation of metadata extraction is provided to account for this case.