### PR TITLE
Encode to utf8 the mysql datetime conversion

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
@@ -208,7 +208,7 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
                                            ImmutableList<? extends ImmutableTerm> terms,
                                            Function<ImmutableTerm, String> termConverter) {
 
-        String dateTimeStringWithoutTz = String.format("REPLACE(CAST(%s AS CHAR(30)),' ', 'T')",
+        String dateTimeStringWithoutTz = String.format("REPLACE(CAST(%s AS CHAR(30) CHARACTER SET utf8),' ', 'T')",
                 termConverter.apply(terms.get(0)));
 
         return dbDateTimestampType.getName().equals(TIMESTAMP_STR)


### PR DESCRIPTION
Mysql datetime conversion requires a cast with character set utf8 to avoid collation error.
All strings in MySQL are already cast to utf8 as visible here:
https://github.com/ontop/ontop/blob/2606d30b83fb01269525d1342947e13bc503a04c/db/rdb/src/main/java/it/unibz/inf/ontop/model/type/impl/MySQLDBTypeFactory.java#L49