### PR TITLE
Self-left-join elimination with nullable determinants of functional dependencies

### DIFF
--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/DefaultCompositeLeftJoinIQOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/DefaultCompositeLeftJoinIQOptimizer.java
@@ -20,14 +20,15 @@ public class DefaultCompositeLeftJoinIQOptimizer implements LeftJoinIQOptimizer 
             CardinalityInsensitiveJoinTransferLJOptimizer cardinalityInsensitiveJoinTransferLJOptimizer,
             LJWithNestingOnRightToInnerJoinOptimizer ljWithNestingOnRightToInnerJoinOptimizer,
             MergeLJOptimizer mergeLJOptimizer,
-            CardinalityInsensitiveLJPruningOptimizer cardinalityInsensitiveLJPruningOptimizer) {
+            CardinalityInsensitiveLJPruningOptimizer cardinalityInsensitiveLJPruningOptimizer,
+            NullableFDSelfLJOptimizer nullableFDOptimizer) {
         this.optimizers = ImmutableList.of(
                 cardinalitySensitiveJoinTransferLJOptimizer,
                 cardinalityInsensitiveJoinTransferLJOptimizer,
                 ljWithNestingOnRightToInnerJoinOptimizer,
                 mergeLJOptimizer,
-                cardinalityInsensitiveLJPruningOptimizer);
-
+                cardinalityInsensitiveLJPruningOptimizer,
+                nullableFDOptimizer);
     }
 
     @Override

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/NullableFDSelfLJOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/NullableFDSelfLJOptimizer.java
@@ -1,0 +1,192 @@
+package it.unibz.inf.ontop.iq.optimizer.impl.lj;
+
+import com.google.common.collect.*;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import it.unibz.inf.ontop.dbschema.Attribute;
+import it.unibz.inf.ontop.dbschema.FunctionalDependency;
+import it.unibz.inf.ontop.injection.CoreSingletons;
+import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
+import it.unibz.inf.ontop.iq.IQ;
+import it.unibz.inf.ontop.iq.IQTree;
+import it.unibz.inf.ontop.iq.node.*;
+import it.unibz.inf.ontop.iq.node.impl.JoinOrFilterVariableNullabilityTools;
+import it.unibz.inf.ontop.iq.node.normalization.impl.RightProvenanceNormalizer;
+import it.unibz.inf.ontop.iq.optimizer.LeftJoinIQOptimizer;
+import it.unibz.inf.ontop.iq.optimizer.impl.LookForDistinctOrLimit1TransformerImpl;
+import it.unibz.inf.ontop.iq.transform.IQTreeTransformer;
+import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
+import it.unibz.inf.ontop.model.term.ImmutableExpression;
+import it.unibz.inf.ontop.model.term.Variable;
+import it.unibz.inf.ontop.model.term.VariableOrGroundTerm;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+import it.unibz.inf.ontop.utils.VariableGenerator;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Is cardinality-insensitive.
+ * For self-left-joins on nullable determinants of FDs
+ *
+ */
+@Singleton
+public class NullableFDSelfLJOptimizer implements LeftJoinIQOptimizer {
+
+    private final RequiredExtensionalDataNodeExtractor requiredDataNodeExtractor;
+    private final RightProvenanceNormalizer rightProvenanceNormalizer;
+    private final JoinOrFilterVariableNullabilityTools variableNullabilityTools;
+    private final CoreSingletons coreSingletons;
+    private final IntermediateQueryFactory iqFactory;
+
+    @Inject
+    protected NullableFDSelfLJOptimizer(RequiredExtensionalDataNodeExtractor requiredDataNodeExtractor,
+                                        RightProvenanceNormalizer rightProvenanceNormalizer,
+                                        JoinOrFilterVariableNullabilityTools variableNullabilityTools,
+                                        CoreSingletons coreSingletons) {
+        this.requiredDataNodeExtractor = requiredDataNodeExtractor;
+        this.rightProvenanceNormalizer = rightProvenanceNormalizer;
+        this.variableNullabilityTools = variableNullabilityTools;
+        this.coreSingletons = coreSingletons;
+        this.iqFactory = coreSingletons.getIQFactory();
+    }
+
+    @Override
+    public IQ optimize(IQ query) {
+        IQTree initialTree = query.getTree();
+
+        IQTreeVisitingTransformer transformer = new LookForDistinctOrLimit1TransformerImpl(
+                (childTree, parentTransformer) -> new CardinalityInsensitiveTransformer(
+                        parentTransformer,
+                        childTree::getVariableNullability,
+                        query.getVariableGenerator(),
+                        requiredDataNodeExtractor,
+                        rightProvenanceNormalizer,
+                        variableNullabilityTools,
+                        coreSingletons),
+                coreSingletons);
+
+        IQTree newTree = initialTree.acceptTransformer(transformer);
+
+        return newTree.equals(initialTree)
+                ? query
+                : iqFactory.createIQ(query.getProjectionAtom(), newTree);
+    }
+
+    protected static class CardinalityInsensitiveTransformer extends AbstractLJTransformer {
+
+        private final IQTreeTransformer lookForDistinctTransformer;
+        private final RequiredExtensionalDataNodeExtractor requiredDataNodeExtractor;
+
+        protected CardinalityInsensitiveTransformer(IQTreeTransformer lookForDistinctTransformer,
+                                                    Supplier<VariableNullability> variableNullabilitySupplier,
+                                                    VariableGenerator variableGenerator, RequiredExtensionalDataNodeExtractor requiredDataNodeExtractor,
+                                                    RightProvenanceNormalizer rightProvenanceNormalizer,
+                                                    JoinOrFilterVariableNullabilityTools variableNullabilityTools,
+                                                    CoreSingletons coreSingletons) {
+            super(variableNullabilitySupplier, variableGenerator, rightProvenanceNormalizer,
+                    variableNullabilityTools, coreSingletons);
+            this.lookForDistinctTransformer = lookForDistinctTransformer;
+            this.requiredDataNodeExtractor = requiredDataNodeExtractor;
+        }
+
+        @Override
+        protected Optional<IQTree> furtherTransformLeftJoin(LeftJoinNode rootNode, IQTree leftChild, IQTree rightChild) {
+            if (!(rightChild instanceof ExtensionalDataNode))
+                return Optional.empty();
+
+            var rightNode = (ExtensionalDataNode) rightChild;
+            var rightArgumentMap = rightNode.getArgumentMap();
+
+            var nullableCoveringFDs = rightNode.getRelationDefinition().getOtherFunctionalDependencies().stream()
+                    .filter(fd -> fd.getDeterminants().stream().anyMatch(Attribute::isNullable))
+                    // Make sure all the terms are involved in the functional dependency
+                    .filter(fd -> Sets.union(fd.getDeterminants(), fd.getDependents()).stream()
+                            .map(a -> a.getIndex() - 1)
+                            .collect(ImmutableCollectors.toSet())
+                            .containsAll(rightArgumentMap.keySet()))
+                    .collect(ImmutableCollectors.toList());
+
+            if (nullableCoveringFDs.isEmpty())
+                return Optional.empty();
+
+            var transfer = requiredDataNodeExtractor.extractSomeRequiredNodes(leftChild, true)
+                    .flatMap(left -> tryToTransfer(left, rightNode, nullableCoveringFDs).stream())
+                    .findAny();
+
+            return transfer
+                    .map(t -> updateLeftTree(t, leftChild, rootNode.getOptionalFilterCondition()));
+        }
+
+        private Optional<Transfer> tryToTransfer(ExtensionalDataNode leftNode, ExtensionalDataNode rightNode,
+                                       ImmutableList<FunctionalDependency> coveringFDs) {
+            if (!leftNode.getRelationDefinition().equals(rightNode.getRelationDefinition()))
+                return Optional.empty();
+
+            var leftArgumentMap = leftNode.getArgumentMap();
+            var rightArgumentMap = rightNode.getArgumentMap();
+
+            var commonArgumentMap = Sets.intersection(leftArgumentMap.entrySet(),
+                            rightArgumentMap.entrySet()).stream()
+                            .collect(ImmutableCollectors.toMap());
+
+            if (commonArgumentMap.isEmpty())
+                return Optional.empty();
+
+            var selectedFD = coveringFDs.stream()
+                    .filter(fd -> fd.getDeterminants().stream().allMatch(a -> commonArgumentMap.containsKey(a.getIndex() - 1)))
+                    .findAny();
+
+            return selectedFD.map(fd -> {
+                var dependentIndexes = fd.getDependents().stream()
+                        .map(a -> a.getIndex() - 1)
+                        .collect(ImmutableCollectors.toSet());
+
+                var determinantVariables = fd.getDeterminants().stream()
+                        .map(a -> commonArgumentMap.get(a.getIndex() -1))
+                        .filter(t -> t instanceof Variable)
+                        .map(v -> (Variable) v)
+                        .collect(ImmutableCollectors.toSet());
+
+                return new Transfer(leftNode, determinantVariables, rightArgumentMap.entrySet().stream()
+                        .filter(e -> dependentIndexes.contains(e.getKey()))
+                        .collect(ImmutableCollectors.toMap()));
+            });
+        }
+
+        private IQTree updateLeftTree(Transfer t, IQTree leftChild, Optional<ImmutableExpression> optionalFilterCondition) {
+            throw new RuntimeException("TODO: implement transfer");
+        }
+
+        @Override
+        protected IQTree transformBySearchingFromScratch(IQTree tree) {
+            return lookForDistinctTransformer.transform(tree);
+        }
+
+        /**
+         * Recursive call on the right
+         */
+        @Override
+        protected IQTree preTransformLJRightChild(IQTree rightChild, Optional<ImmutableExpression> ljCondition,
+                                                  ImmutableSet<Variable> leftVariables) {
+            var newTransformer = new CardinalityInsensitiveTransformer(lookForDistinctTransformer,
+                    rightChild::getVariableNullability, variableGenerator, requiredDataNodeExtractor,
+                    rightProvenanceNormalizer, variableNullabilityTools, coreSingletons);
+            return rightChild.acceptTransformer(newTransformer);
+        }
+    }
+
+
+    private static class Transfer {
+        private final ExtensionalDataNode leftNode;
+        private final ImmutableSet<Variable> determinantVariables;
+        private final ImmutableMap<Integer, ? extends VariableOrGroundTerm> argumentsToTransfer;
+
+        protected Transfer(ExtensionalDataNode leftNode, ImmutableSet<Variable> determinantVariables,
+                           ImmutableMap<Integer, ? extends VariableOrGroundTerm> argumentsToTransfer) {
+            this.leftNode = leftNode;
+            this.determinantVariables = determinantVariables;
+            this.argumentsToTransfer = argumentsToTransfer;
+        }
+    }
+}

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/NullableFDSelfLJOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/NullableFDSelfLJOptimizer.java
@@ -33,7 +33,9 @@ import java.util.stream.Stream;
 
 /**
  * Is cardinality-insensitive.
- * For self-left-joins on nullable determinants of FDs
+ * For self-left-joins on nullable determinants of FDs.
+ * Because some determinants may be null on the left, we cannot perform a join transfer on the left
+ * (this would filter null values of determinants). Hence, the need for a new optimization.
  *
  */
 @Singleton
@@ -295,7 +297,8 @@ public class NullableFDSelfLJOptimizer implements LeftJoinIQOptimizer {
     }
 
     /**
-     * To be kept in sync with RequiredExtensionalDataNodeExtractor
+     * To be kept in sync with RequiredExtensionalDataNodeExtractor.
+     * Not safe to run in parallel
      */
     private static class DataNodeOnLeftReplacer extends DefaultNonRecursiveIQTreeTransformer {
 
@@ -317,7 +320,7 @@ public class NullableFDSelfLJOptimizer implements LeftJoinIQOptimizer {
         }
 
         @Override
-        public synchronized IQTree transformExtensionalData(ExtensionalDataNode dataNode) {
+        public IQTree transformExtensionalData(ExtensionalDataNode dataNode) {
             if ((!found) && dataNode.equals(nodeToBeReplaced)) {
                 found = true;
                 return replacingNode;

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/NullableFDSelfLJOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/NullableFDSelfLJOptimizer.java
@@ -5,6 +5,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import it.unibz.inf.ontop.dbschema.Attribute;
 import it.unibz.inf.ontop.dbschema.FunctionalDependency;
+import it.unibz.inf.ontop.exception.MinorOntopInternalBugException;
 import it.unibz.inf.ontop.injection.CoreSingletons;
 import it.unibz.inf.ontop.injection.IntermediateQueryFactory;
 import it.unibz.inf.ontop.iq.IQ;
@@ -17,13 +18,17 @@ import it.unibz.inf.ontop.iq.optimizer.impl.LookForDistinctOrLimit1TransformerIm
 import it.unibz.inf.ontop.iq.transform.IQTreeTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.model.term.ImmutableExpression;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
 import it.unibz.inf.ontop.model.term.Variable;
 import it.unibz.inf.ontop.model.term.VariableOrGroundTerm;
+import it.unibz.inf.ontop.substitution.Substitution;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import it.unibz.inf.ontop.utils.VariableGenerator;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
  * Is cardinality-insensitive.
@@ -154,8 +159,78 @@ public class NullableFDSelfLJOptimizer implements LeftJoinIQOptimizer {
             });
         }
 
-        private IQTree updateLeftTree(Transfer t, IQTree leftChild, Optional<ImmutableExpression> optionalFilterCondition) {
-            throw new RuntimeException("TODO: implement transfer");
+        private IQTree updateLeftTree(Transfer transfer, IQTree leftChild, Optional<ImmutableExpression> optionalFilterCondition) {
+            var newLeftNode = transfer.generateNewLeftNode(variableGenerator, iqFactory);
+            var leftVariables = leftChild.getVariables();
+            var condition = computeRightTermCondition(newLeftNode, leftVariables,
+                    transfer.determinantVariables, transfer.argumentsToTransfer, optionalFilterCondition);
+            var substitution = computeSubstitution(condition, leftVariables, transfer.argumentsToTransfer, newLeftNode);
+            var newLeftTree = replaceNodeOnLeft(leftChild, transfer.leftNode, newLeftNode);
+            return iqFactory.createUnaryIQTree(
+                    iqFactory.createConstructionNode(
+                            Sets.union(leftVariables, substitution.getDomain()).immutableCopy(),
+                            substitution),
+                    newLeftTree);
+        }
+
+        private ImmutableExpression computeRightTermCondition(ExtensionalDataNode newLeftNode,
+                                                              ImmutableSet<Variable> leftVariables,
+                                                              ImmutableSet<Variable> determinantVariables,
+                                                              ImmutableMap<Integer, ? extends VariableOrGroundTerm> argumentsToTransfer,
+                                                              Optional<ImmutableExpression> optionalFilterCondition) {
+
+            var leftArgumentMap = newLeftNode.getArgumentMap();
+
+            var groundTermsAndImplicitEqualitiesWithLeft = argumentsToTransfer.entrySet().stream()
+                    .filter(e -> e.getValue().isGround() || leftVariables.contains((Variable)e.getValue()))
+                    .map(e -> termFactory.getStrictEquality(leftArgumentMap.get(e.getKey()), e.getValue()));
+
+            var inverseVariableMap = argumentsToTransfer.entrySet().stream()
+                    .filter(e -> e.getValue() instanceof Variable)
+                    .collect(ImmutableCollectors.toMultimap(
+                            e -> (Variable)e.getValue(),
+                            Map.Entry::getKey))
+                    .asMap();
+
+
+            var coOccurrenceEqualities = inverseVariableMap.values().stream()
+                    .flatMap(indexes -> {
+                        var firstTerm = leftArgumentMap.get(indexes.iterator().next());
+                        return indexes.stream().skip(1)
+                                .map(i -> termFactory.getStrictEquality(firstTerm, leftArgumentMap.get(i)));
+                    });
+
+            return termFactory.getConjunction(optionalFilterCondition,
+                        Stream.concat(
+                                Stream.concat(
+                                    determinantVariables.stream()
+                                        .map(termFactory::getDBIsNotNull),
+                                    groundTermsAndImplicitEqualitiesWithLeft),
+                                coOccurrenceEqualities))
+                    .orElseThrow(() -> new MinorOntopInternalBugException("At least one determinant was expected"));
+        }
+
+        private Substitution<? extends ImmutableTerm> computeSubstitution(ImmutableExpression condition, ImmutableSet<Variable> leftVariables,
+                                                                          ImmutableMap<Integer, ? extends VariableOrGroundTerm> argumentsToTransfer,
+                                                                          ExtensionalDataNode newLeftNode) {
+            var leftArgumentMap = newLeftNode.getArgumentMap();
+
+            return argumentsToTransfer.asMultimap().inverse().asMap().entrySet().stream()
+                    .filter(e -> e.getKey() instanceof Variable)
+                    .filter(e -> !leftVariables.contains((Variable)e.getKey()))
+                    .collect(substitutionFactory.toSubstitution(
+                            e -> (Variable) e.getKey(),
+                            e -> termFactory.getIfElseNull(
+                                    condition,
+                                    // Picking the first index
+                                    leftArgumentMap.get(e.getValue().iterator().next())
+                            )));
+        }
+
+        private IQTree replaceNodeOnLeft(IQTree leftChild, ExtensionalDataNode leftNode, ExtensionalDataNode newLeftNode) {
+            if (leftChild.equals(leftNode))
+                return newLeftNode;
+            throw new RuntimeException("TODO: implement replacing node in non-trivial case");
         }
 
         @Override
@@ -187,6 +262,24 @@ public class NullableFDSelfLJOptimizer implements LeftJoinIQOptimizer {
             this.leftNode = leftNode;
             this.determinantVariables = determinantVariables;
             this.argumentsToTransfer = argumentsToTransfer;
+        }
+
+        /**
+         * Adds fresh variables for columns that will be "transferred" but are not already used by the left
+         */
+        public ExtensionalDataNode generateNewLeftNode(VariableGenerator variableGenerator, IntermediateQueryFactory iqFactory) {
+            var leftArgumentMap = leftNode.getArgumentMap();
+
+            var newArgumentMap = Sets.union(leftArgumentMap.keySet(), argumentsToTransfer.keySet()).stream()
+                    .collect(ImmutableCollectors.toMap(
+                            i -> i,
+                            i -> Optional.ofNullable((VariableOrGroundTerm) leftArgumentMap.get(i))
+                            .orElseGet(() -> Optional.ofNullable(argumentsToTransfer.get(i))
+                                    .filter(t -> t instanceof Variable)
+                                    .map(v -> variableGenerator.generateNewVariableFromVar((Variable) v))
+                                    .orElseGet(variableGenerator::generateNewVariable))));
+
+            return iqFactory.createExtensionalDataNode(leftNode.getRelationDefinition(), newArgumentMap);
         }
     }
 }

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/OptimizationTestingTools.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/OptimizationTestingTools.java
@@ -67,6 +67,7 @@ public class OptimizationTestingTools {
     public static final Variable B;
     public static final Variable BF0;
     public static final Variable BF1;
+    public static final Variable BF2;
     public static final Variable C;
     public static final Variable CF0;
     public static final Variable CF1;
@@ -153,6 +154,7 @@ public class OptimizationTestingTools {
         B = TERM_FACTORY.getVariable("b");
         BF0 = TERM_FACTORY.getVariable("bf0");
         BF1 = TERM_FACTORY.getVariable("bf1");
+        BF2 = TERM_FACTORY.getVariable("bf2");
         C = TERM_FACTORY.getVariable("c");
         CF0 = TERM_FACTORY.getVariable("cf0");
         CF1 = TERM_FACTORY.getVariable("cf1");

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -2306,6 +2306,38 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
+    @Test
+    public void testFDOnNullableDeterminant10() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A,2, C));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(2, C,3, D));
+
+        BinaryNonCommutativeIQTree leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                dataNode2);
+
+        DistinctNode distinctNode = IQ_FACTORY.createDistinctNode();
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(distinctNode, leftJoinTree));
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 2, C, 3, DF0));
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                                SUBSTITUTION_FACTORY.getSubstitution(D, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(C), DF0))),
+                        newDataNode));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
 
 
     /**

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -4407,7 +4407,6 @@ public class LeftJoinOptimizationTest {
      *   PK: 0, 1
      *   FD: 2 -> 3,4 (nullable)
      */
-    @Ignore("TODO: make self-left-join elimination based on FDs robust to nullable columns")
     @Test
     public void testProjectionAway12() {
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -43,9 +43,9 @@ public class LeftJoinOptimizationTest {
     private final static NamedRelationDefinition TABLE23;
 
     /**
-     *   TABLE_CLASSIFICATION(0:project, 1:action,2:objective,3:objective_name,4:axis)
+     *   TABLE_CLASSIFICATION(0:project, 1:action,2:objective,3:objective_name,4:axis,5:objective_extracolumn)
      *   PK: 0, 1
-     *   FD: 2 -> 3,4 (nullable)
+     *   FD: 2 -> 3,4,5 (nullable)
      */
     private final static NamedRelationDefinition TABLE_CLASSIFICATION;
 
@@ -222,7 +222,9 @@ public class LeftJoinOptimizationTest {
                 "action", integerDBType, true,
                 "objective", integerDBType, true,
                 "objective_name", stringDBType, true,
-                "axis", integerDBType, true);
+                "axis", integerDBType, true,
+                "objective_extracolumn", integerDBType, true
+                );
         UniqueConstraint.builder(TABLE_CLASSIFICATION, "uc1")
                 .addDeterminant(1)
                 .addDeterminant(2)
@@ -232,6 +234,7 @@ public class LeftJoinOptimizationTest {
                 .addDeterminant(3)
                 .addDependent(4)
                 .addDependent(5)
+                .addDependent(6)
                 .build();
     }
 
@@ -2047,6 +2050,256 @@ public class LeftJoinOptimizationTest {
                 IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
                         SUBSTITUTION_FACTORY.getSubstitution(D, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(C), DF0))),
                 newDataNode);
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testFDOnNullableDeterminant4() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, B, C));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(2, C,3, ONE));
+
+        BinaryNonCommutativeIQTree leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                dataNode2);
+
+        var filterNode = IQ_FACTORY.createFilterNode(
+                TERM_FACTORY.getConjunction(
+                        TERM_FACTORY.getDBIsNotNull(B)
+                ));
+
+        DistinctNode distinctNode = IQ_FACTORY.createDistinctNode();
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(
+                distinctNode,
+                IQ_FACTORY.createUnaryIQTree(filterNode, leftJoinTree)));
+
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom,
+                IQ_FACTORY.createUnaryIQTree(filterNode, dataNode1));
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testFDOnNullableDeterminant5() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(2, C,3, D, 4, ONE));
+
+        BinaryNonCommutativeIQTree leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                dataNode2);
+
+        var filterNode = IQ_FACTORY.createFilterNode(
+                TERM_FACTORY.getConjunction(
+                        TERM_FACTORY.getDBIsNotNull(B)
+                ));
+
+        DistinctNode distinctNode = IQ_FACTORY.createDistinctNode();
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(
+                distinctNode,
+                IQ_FACTORY.createUnaryIQTree(filterNode, leftJoinTree)));
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C, 3, DF0, 4, F1));
+
+        var condition = TERM_FACTORY.getConjunction(
+                TERM_FACTORY.getDBIsNotNull(C),
+                TERM_FACTORY.getStrictEquality(F1, ONE)
+                );
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(D, TERM_FACTORY.getIfElseNull(condition, DF0))),
+                IQ_FACTORY.createUnaryIQTree(filterNode, newDataNode));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testFDOnNullableDeterminant6() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(2, C,3, D, 4, D));
+
+        BinaryNonCommutativeIQTree leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                dataNode2);
+
+        var filterNode = IQ_FACTORY.createFilterNode(
+                TERM_FACTORY.getConjunction(
+                        TERM_FACTORY.getDBIsNotNull(B)
+                ));
+
+        DistinctNode distinctNode = IQ_FACTORY.createDistinctNode();
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(
+                distinctNode,
+                IQ_FACTORY.createUnaryIQTree(filterNode, leftJoinTree)));
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C, 3, DF0, 4, DF1));
+
+        var condition = TERM_FACTORY.getConjunction(
+                TERM_FACTORY.getDBIsNotNull(C),
+                TERM_FACTORY.getStrictEquality(DF0, DF1)
+        );
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(D, TERM_FACTORY.getIfElseNull(condition, DF0))),
+                IQ_FACTORY.createUnaryIQTree(filterNode, newDataNode));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testFDOnNullableDeterminant7() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(2, C,3, D, 4, B));
+
+        BinaryNonCommutativeIQTree leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                dataNode2);
+
+        var filterNode = IQ_FACTORY.createFilterNode(
+                TERM_FACTORY.getConjunction(
+                        TERM_FACTORY.getDBIsNotNull(B)
+                ));
+
+        DistinctNode distinctNode = IQ_FACTORY.createDistinctNode();
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(
+                distinctNode,
+                IQ_FACTORY.createUnaryIQTree(filterNode, leftJoinTree)));
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C, 3, DF0, 4, BF1));
+
+        var condition = TERM_FACTORY.getConjunction(
+                TERM_FACTORY.getDBIsNotNull(C),
+                TERM_FACTORY.getStrictEquality(BF1, B)
+        );
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(D, TERM_FACTORY.getIfElseNull(condition, DF0))),
+                IQ_FACTORY.createUnaryIQTree(filterNode, newDataNode));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testFDOnNullableDeterminant8() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(4), ImmutableList.of(A, B, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(2, C,3, D, 4, B, 5, B));
+
+        BinaryNonCommutativeIQTree leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                dataNode2);
+
+        var filterNode = IQ_FACTORY.createFilterNode(
+                TERM_FACTORY.getConjunction(
+                        TERM_FACTORY.getDBIsNotNull(B)
+                ));
+
+        DistinctNode distinctNode = IQ_FACTORY.createDistinctNode();
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(
+                distinctNode,
+                IQ_FACTORY.createUnaryIQTree(filterNode, leftJoinTree)));
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C, 3, DF0, 4, BF1, 5, BF2));
+
+        var condition = TERM_FACTORY.getConjunction(
+                TERM_FACTORY.getDBIsNotNull(C),
+                TERM_FACTORY.getStrictEquality(BF1, B),
+                TERM_FACTORY.getStrictEquality(BF2, B),
+                TERM_FACTORY.getStrictEquality(BF1, BF2)
+        );
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(D, TERM_FACTORY.getIfElseNull(condition, DF0))),
+                IQ_FACTORY.createUnaryIQTree(filterNode, newDataNode));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testFDOnNullableDeterminant9() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(5), ImmutableList.of(A, B, C, D, E));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A,1, E));
+        ExtensionalDataNode dataNode3 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(2, C,3, D));
+
+        var leftChild = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                dataNode2);
+
+        BinaryNonCommutativeIQTree topLeftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                leftChild,
+                dataNode3);
+
+        var filterNode = IQ_FACTORY.createFilterNode(
+                TERM_FACTORY.getConjunction(
+                        TERM_FACTORY.getDBIsNotNull(B)
+                ));
+
+        DistinctNode distinctNode = IQ_FACTORY.createDistinctNode();
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(
+                distinctNode,
+                IQ_FACTORY.createUnaryIQTree(filterNode, topLeftJoinTree)));
+
+        ExtensionalDataNode newDataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C, 3, DF0));
+
+        var newLeftJoin = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                newDataNode1,
+                dataNode2);
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(D, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(C), DF0))),
+                IQ_FACTORY.createUnaryIQTree(filterNode, newLeftJoin));
 
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -1951,7 +1951,6 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
-    @Ignore("TODO: make self-left-join elimination based on FDs robust to nullable columns")
     @Test
     public void testFDOnNullableDeterminant1() {
 
@@ -1977,7 +1976,7 @@ public class LeftJoinOptimizationTest {
                 distinctNode,
                 IQ_FACTORY.createUnaryIQTree(filterNode, leftJoinTree)));
 
-        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 2, B, 3, C, 4, DF0));
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C, 3, DF0));
 
         var newTree = IQ_FACTORY.createUnaryIQTree(
                         IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
@@ -1989,7 +1988,7 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, expectedIQ);
     }
 
-    @Ignore("TODO: make self-left-join elimination based on FDs robust to nullable columns")
+    @Ignore("TODO: be more rigorous with composite unique constraints and nullability")
     @Test
     public void testFDOnNullableDeterminant2() {
 
@@ -2008,7 +2007,7 @@ public class LeftJoinOptimizationTest {
 
         IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(distinctNode, leftJoinTree));
 
-        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 2, B, 3, C, 4, DF0));
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, B, 2, C, 3, DF0));
 
         var newTree = IQ_FACTORY.createUnaryIQTree(
                 IQ_FACTORY.createDistinctNode(),
@@ -2016,6 +2015,38 @@ public class LeftJoinOptimizationTest {
                         IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
                                 SUBSTITUTION_FACTORY.getSubstitution(D, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(C), DF0))),
                         newDataNode));
+
+        IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
+
+        optimizeAndCompare(initialIQ, expectedIQ);
+    }
+
+    @Test
+    public void testFDOnNullableDeterminant3() {
+
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, C, D));
+
+        ExtensionalDataNode dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, ONE, 2, C));
+        ExtensionalDataNode dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(2, C,3, D));
+
+        BinaryNonCommutativeIQTree leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                dataNode2);
+
+        DistinctNode distinctNode = IQ_FACTORY.createDistinctNode();
+
+        IQ initialIQ = IQ_FACTORY.createIQ(projectionAtom, IQ_FACTORY.createUnaryIQTree(
+                distinctNode,
+                leftJoinTree));
+
+        ExtensionalDataNode newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE_CLASSIFICATION, ImmutableMap.of(0, A, 1, ONE, 2, C, 3, DF0));
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(D, TERM_FACTORY.getIfElseNull(TERM_FACTORY.getDBIsNotNull(C), DF0))),
+                newDataNode);
 
         IQ expectedIQ = IQ_FACTORY.createIQ(projectionAtom, newTree);
 
@@ -5018,7 +5049,6 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, expectedTree));
     }
 
-    @Ignore("TODO: support self-LJ on nullable FDs")
     @Test
     public void testFDOnRight1() {
 
@@ -5052,8 +5082,7 @@ public class LeftJoinOptimizationTest {
 
         optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, expectedTree));
     }
-
-    @Ignore("TODO: support self-LJ on nullable FDs")
+    
     @Test
     public void testFDOnRight2() {
 
@@ -5117,7 +5146,6 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, IQ_FACTORY.createIQ(projectionAtom, newDataNode));
     }
 
-    @Ignore("TODO: support self-LJ on nullable FDs")
     @Test
     public void testFDOnRight4() {
 


### PR DESCRIPTION
This optimization technique eliminates self-left-joins on nullable determinants of functional dependencies.

Because some determinants may be null on the left, we cannot perform a join transfer on the left (this would filter null values of determinants).

This optimization is cardinality-insensitive.


Example:

```
DISTINCT
   LJ
      EXTENSIONAL CLASSIFICATION(0:a,2:c)
      EXTENSIONAL CLASSIFICATION(2:c,3:d)
```
where the third column of `CLASSIFICATION` is nullable and determines the value of the fourth column.

With this optimization, we obtain:

```
DISTINCT
   CONSTRUCT [a, c, d] [d/IF_ELSE_NULL(IS_NOT_NULL(c),df0)]
      EXTENSIONAL CLASSIFICATION(0:a,2:c,3:df0)
```