### PR TITLE
fix for issue #743

### DIFF
--- a/test/docker-tests/src/test/java/it/unibz/inf/ontop/docker/BootstrapSelfJoinTest.java
+++ b/test/docker-tests/src/test/java/it/unibz/inf/ontop/docker/BootstrapSelfJoinTest.java
@@ -1,0 +1,34 @@
+package it.unibz.inf.ontop.docker;
+
+import it.unibz.inf.ontop.owlapi.connection.OWLStatement;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BootstrapSelfJoinTest extends AbstractBootstrapTest {
+    private static final String baseIRI = "http://h2-bootstrap-test";
+    private static final String owlOutputFile = "src/test/resources/h2/bootstrap-self-join/output.owl";
+    private static final String obdaOutputFile = "src/test/resources/h2/bootstrap-self-join/output.obda";
+
+    private final String propertyFile = this.getClass().getResource("/h2/bootstrap-self-join/bootstrap.properties").toString();
+    private static final String sqlCreateFile = "src/test/resources/h2/bootstrap-self-join/create.sql";
+    private static final String sqlDropFile = "src/test/resources//h2/bootstrap-self-join/drop.sql";
+
+    @Before
+    public void setUp() throws Exception {
+        createTables(sqlCreateFile, "jdbc:h2:mem:questjunitdb", "sa", "");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        dropTables(sqlDropFile);
+    }
+
+    @Test
+    public void testBootstrap() throws Exception {
+        bootstrap(propertyFile, baseIRI, owlOutputFile, obdaOutputFile);
+        try (OWLStatement st = loadGeneratedFiles(owlOutputFile, obdaOutputFile, propertyFile)) {
+            st.executeSelectQuery("SELECT * WHERE { ?x <http://h2-bootstrap-test/course-registration#ref-COURSE_ID> ?y }");
+        }
+    }
+}

--- a/test/docker-tests/src/test/resources/h2/bootstrap-self-join/bootstrap.properties
+++ b/test/docker-tests/src/test/resources/h2/bootstrap-self-join/bootstrap.properties
@@ -1,0 +1,4 @@
+jdbc.url = jdbc:h2:mem:questjunitdb
+jdbc.user = sa
+jdbc.password =
+jdbc.driver = org.h2.Driver

--- a/test/docker-tests/src/test/resources/h2/bootstrap-self-join/create.sql
+++ b/test/docker-tests/src/test/resources/h2/bootstrap-self-join/create.sql
@@ -1,0 +1,9 @@
+create table "course" (
+id integer not null primary key
+);
+
+create table "course-registration" (
+  id integer not null primary key,
+  course_id integer not null references "course"(id),
+  course_prerequisite integer null references "course-registration" (id)
+);

--- a/test/docker-tests/src/test/resources/h2/bootstrap-self-join/drop.sql
+++ b/test/docker-tests/src/test/resources/h2/bootstrap-self-join/drop.sql
@@ -1,0 +1,2 @@
+drop table "course-registration";
+drop table "course";


### PR DESCRIPTION
In bootstrapper, the case of a foreign key referencing the same table was handled incorrectly, resulting in an SQL query having two occurrences of the same table without any aliases (reported in issue #743). This fix introduces table aliases for this specific case.