### PR TITLE
Remove redundant MySQL version checks for XSD cast

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -261,7 +261,7 @@ jobs:
       - name: Run CI for SQLServer docker tests
         run: cd test/lightweight-tests && ../../mvnw install -Dgroups="mssqllighttests" -DskipTests=false --fail-at-end
 
-  run-mysql:
+  run-mysql-v8:
     needs: [run-mssql]
     runs-on: ubuntu-latest
     strategy:
@@ -282,13 +282,43 @@ jobs:
         run: set MAVEN_OPTS="-Xms6000m -Xmx8000m"
       - name: Set up docker
         run: cd test/lightweight-tests/lightweight-db-test-images &&
-          docker-compose -f "docker-compose.lightweight.yml" up -d mysql
+          docker-compose -f "docker-compose.lightweight.yml" up -d mysql-v8
       # Runs all tests specific to a db engine
       - name: Run CI for MySQL docker tests
         run: cd test/lightweight-tests && ../../mvnw install -Dgroups="mysqllighttests" -DskipTests=false --fail-at-end
 
+  run-mysql-v5:
+    needs: [ run-mssql ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jdk: [ 11 ]
+
+    steps:
+      # Checks-out ontop repository under $GITHUB_WORKSPACE
+      - uses: actions/checkout@v3
+      # Set up the java versions
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: ${{ matrix.jdk }}
+          cache: maven
+      - name: Set maven opts
+        run: set MAVEN_OPTS="-Xms6000m -Xmx8000m"
+      - name: Set up docker
+        run: cd test/lightweight-tests/lightweight-db-test-images &&
+          docker-compose -f "docker-compose.lightweight.yml" up -d mysql-v5
+      # Runs all tests specific to a db engine
+      - name: Set Environment Variable for MySQL 5 # Needed to skip tests
+        run: echo "MYSQL_VERSION=5" >> $GITHUB_ENV
+      - name: Run CI for MySQL v5.x docker tests
+        run: cd test/lightweight-tests && ../../mvnw install -Dgroups="mysqllighttests" -DskipTests=false --fail-at-end
+        env:
+          MYSQL_VERSION: ${{ env.MYSQL_VERSION }}
+
   run-mariadb:
-    needs: [run-mysql]
+    needs: [run-mysql-v8]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
@@ -318,42 +318,20 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     /**
      * XSD CAST functions
      */
-
-    // Cast and regex differ in MySQL version 8 and above vs. previous versions
-    private boolean isMySQLVersion8OrAbove() {
-        return databaseInfoSupplier.getDatabaseVersion().isPresent() &&
-                databaseInfoSupplier.getDatabaseVersion()
-                        .map(s -> Integer.parseInt(s.substring(0, s.indexOf("."))))
-                        .filter(s -> s > 7 ).isPresent();
-    }
-
     @Override
     protected String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        if (isMySQLVersion8OrAbove()) {
-            return String.format("CASE WHEN %1$s NOT REGEXP" + numericPattern +
-                            " THEN NULL ELSE CAST(%1$s + 0.0 AS DOUBLE) END",
-                    term); }
-        else {
-            return String.format("CASE WHEN %1$s NOT REGEXP BINARY" + numericPattern +
-                            " THEN NULL ELSE %1$s + 0.0 END",
-                    term); }
+        return String.format("CASE WHEN %1$s NOT REGEXP" + numericPattern +
+                " THEN NULL ELSE CAST(%1$s + 0.0 AS DOUBLE) END", term);
     }
 
     @Override
     protected String serializeCheckAndConvertFloat(ImmutableList<? extends ImmutableTerm> terms,
                                                    Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        if (isMySQLVersion8OrAbove()) {
-            return String.format("CASE WHEN %1$s NOT REGEXP " + numericPattern +
-                            " THEN NULL ELSE CAST(%1$s + 0.0 AS FLOAT) END",
-                    term);
-        } else {
-            return String.format("CASE WHEN %1$s NOT REGEXP BINARY " + numericPattern +
-                            " THEN NULL ELSE %1$s + 0.0 END",
-                    term);
-        }
+        return String.format("CASE WHEN %1$s NOT REGEXP " + numericPattern +
+                " THEN NULL ELSE CAST(%1$s + 0.0 AS FLOAT) END", term);
     }
 
     @Override
@@ -370,15 +348,8 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     protected String serializeCheckAndConvertDecimal(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        if (isMySQLVersion8OrAbove()) {
-            return String.format("CASE WHEN %1$s NOT REGEXP " + numericNonFPPattern +
-                            " THEN NULL ELSE CAST(%1$s AS DECIMAL(60,30)) END",
-                    term);
-        } else {
-            return String.format("CASE WHEN %1$s NOT REGEXP BINARY " + numericNonFPPattern +
-                            " THEN NULL ELSE CAST(%1$s AS DECIMAL(60,30)) END",
-                    term);
-        }
+        return String.format("CASE WHEN %1$s NOT REGEXP " + numericNonFPPattern +
+                " THEN NULL ELSE CAST(%1$s AS DECIMAL(60,30)) END", term);
     }
 
     // SIGNED as a datatype cast truncates scale. This workaround addresses the issue.
@@ -386,15 +357,9 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     protected String serializeCheckAndConvertInteger(ImmutableList<? extends ImmutableTerm> terms,
                                                      Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        if (isMySQLVersion8OrAbove()) {
-            return String.format("IF(%1$s REGEXP '[^0-9]+$', NULL , " +
+        return String.format("IF(%1$s REGEXP '[^0-9]+$', NULL , " +
                             "FLOOR(ABS(CAST(%1$s AS DECIMAL(60,30))))  * SIGN(CAST(%1$s AS DECIMAL(60,30)))) ",
                     term);
-        } else {
-            return String.format("IF(%1$s REGEXP '[^0-9]+$', %1$s RLIKE(if(1=1,')','a')) , " +
-                            "FLOOR(ABS(CAST(%1$s AS DECIMAL(60,30)))) * SIGN(CAST(%1$s AS DECIMAL(60,30)))) ",
-                    term);
-        }
     }
 
     @Override
@@ -443,21 +408,12 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     protected String serializeCheckAndConvertDateFromString(ImmutableList<? extends ImmutableTerm> terms,
                                                             Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        if (isMySQLVersion8OrAbove()) {
-            return String.format("CASE WHEN (%1$s NOT REGEXP " + datePattern1 + " AND " +
-                            "%1$s NOT REGEXP " + datePattern2 +" AND " +
-                            "%1$s NOT REGEXP " + datePattern3 +" AND " +
-                            "%1$s NOT REGEXP " + datePattern4 +" ) " +
-                            " THEN NULL ELSE CAST(%1$s AS DATE) END",
-                    term);
-        } else {
-            return String.format("CASE WHEN (%1$s NOT REGEXP BINARY " + datePattern1 + " AND " +
-                            "%1$s NOT REGEXP BINARY " + datePattern2 +" AND " +
-                            "%1$s NOT REGEXP BINARY " + datePattern3 +" AND " +
-                            "%1$s NOT REGEXP BINARY " + datePattern4 +" ) " +
-                            " THEN NULL ELSE CAST(%1$s AS DATE) END",
-                    term);
-        }
+        return String.format("CASE WHEN (%1$s NOT REGEXP " + datePattern1 + " AND " +
+                        "%1$s NOT REGEXP " + datePattern2 +" AND " +
+                        "%1$s NOT REGEXP " + datePattern3 +" AND " +
+                        "%1$s NOT REGEXP " + datePattern4 +" ) " +
+                        " THEN NULL ELSE CAST(%1$s AS DATE) END",
+                term);
     }
 
     @Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
@@ -322,7 +322,7 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
     protected String serializeCheckAndConvertDouble(ImmutableList<? extends ImmutableTerm> terms,
                                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         String term = termConverter.apply(terms.get(0));
-        return String.format("CASE WHEN %1$s NOT REGEXP" + numericPattern +
+        return String.format("CASE WHEN %1$s NOT REGEXP " + numericPattern +
                 " THEN NULL ELSE CAST(%1$s + 0.0 AS DOUBLE) END", term);
     }
 

--- a/test/lightweight-tests/lightweight-db-test-images/docker-compose.lightweight.yml
+++ b/test/lightweight-tests/lightweight-db-test-images/docker-compose.lightweight.yml
@@ -50,8 +50,22 @@ services:
       - ACCEPT_EULA=Y
       - MSSQL_PID=Express
 
-  mysql:
-    build: ./mysql
+  mysql-v8:
+    build:
+      context: ./mysql
+      args:
+        MYSQL_VERSION: 8.0.29
+    env_file: .env
+    ports:
+      - "3694:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+
+  mysql-v5:
+    build:
+      context: ./mysql
+      args:
+        MYSQL_VERSION: 5.7.44
     env_file: .env
     ports:
       - "3694:3306"

--- a/test/lightweight-tests/lightweight-db-test-images/mysql/Dockerfile
+++ b/test/lightweight-tests/lightweight-db-test-images/mysql/Dockerfile
@@ -1,4 +1,5 @@
-FROM mysql:8.0.29
+ARG MYSQL_VERSION
+FROM mysql:${MYSQL_VERSION}
 
 # copying all SQL files to this folder will automatically put them in the default DB
 COPY /sql/*.sql /docker-entrypoint-initdb.d/

--- a/test/lightweight-tests/lightweight-db-test-images/mysql/sql/books-mysql.sql
+++ b/test/lightweight-tests/lightweight-db-test-images/mysql/sql/books-mysql.sql
@@ -12,7 +12,7 @@ CREATE TABLE `books` (
   `lang` varchar(100) DEFAULT NULL,
   -- TIMESTAMP has a range of '1970-01-01 00:00:01' UTC to '2038-01-19 03:14:07' UTC.
   -- DATETIME should be used outside of this range
-  `publication_date` timestamp DEFAULT NULL,
+  `publication_date` timestamp,
   PRIMARY KEY (`id`)
 );
 

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mysql/BindWithFunctionsMySQLTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mysql/BindWithFunctionsMySQLTest.java
@@ -5,10 +5,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.docker.lightweight.AbstractBindTestWithFunctions;
 import it.unibz.inf.ontop.docker.lightweight.MySQLLightweightTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 /**
  * Class to test if functions on Strings and Numerics in SPARQL are working properly.
@@ -100,5 +98,37 @@ public class BindWithFunctionsMySQLTest extends AbstractBindTestWithFunctions {
     @Override
     protected ImmutableSet<String> getStatisticalAttributesExpectedResults() {
         return ImmutableSet.of("\"215.3400\"^^xsd:decimal");
+    }
+
+    /**
+     * MySQL scenarios not fully supported for MySQL v5.x
+     * Method level tag restricts test to MySQL v8.x
+     */
+    @DisabledIfEnvironmentVariable(named = "MYSQL_VERSION", matches = "5")
+    @Override
+    @Test
+    public void testBNODE0() {
+        super.testBNODE0();
+    }
+
+    @DisabledIfEnvironmentVariable(named = "MYSQL_VERSION", matches = "5")
+    @Override
+    @Test
+    public void testBNODE1() {
+        super.testBNODE0();
+    }
+
+    @DisabledIfEnvironmentVariable(named = "MYSQL_VERSION", matches = "5")
+    @Override
+    @Test
+    public void testREPLACE() {
+        super.testREPLACE();
+    }
+
+    @DisabledIfEnvironmentVariable(named = "MYSQL_VERSION", matches = "5")
+    @Override
+    @Test
+    public void testStatisticalAggregates() {
+        super.testStatisticalAggregates();;
     }
 }

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mysql/NestedDataMySQLTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/mysql/NestedDataMySQLTest.java
@@ -5,10 +5,12 @@ import it.unibz.inf.ontop.docker.lightweight.AbstractNestedDataTest;
 import it.unibz.inf.ontop.docker.lightweight.MySQLLightweightTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import java.io.IOException;
 import java.sql.SQLException;
 
+@DisabledIfEnvironmentVariable(named = "MYSQL_VERSION", matches = "5")
 @MySQLLightweightTest
 public class NestedDataMySQLTest extends AbstractNestedDataTest {
 


### PR DESCRIPTION
XSD cast functions in MySQL contain some unnecessary regex case sensitivity checks for older versions of MySQL (<8) even when the condition reviewed is simply to ascertain the value is non-numeric. The provision of a MySQL version specific (i.e. version above or below 8) checker is therefore also unnecessary. 

This PR modifies the MySQLDBFunctionSymbolFactory:
- Removes redundant code for casts in older versions of MySQL.
- Removes the MySQL version checker which was also redirecting in some cases MariaDB xsd casts to incorrect older MySQL serializations.