### PR TITLE
Optimization to StrStartsWith function 

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/StrStartsFunctionTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/StrStartsFunctionTest.java
@@ -29,11 +29,10 @@ public class StrStartsFunctionTest extends AbstractRDF4JTest{
 
     @Test
     public void testStrStartsConstants() {
-        String query = "PREFIX schema: <http://www.schema.org/>\n" +
-                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
+        String query = "PREFIX ex: <http://www.example.org/>\n" +
                 "SELECT ?s\n" +
                 "WHERE {\n" +
-                "?s a schema:Result.\n" +
+                "?s a ex:Result.\n" +
                 "FILTER (STRSTARTS(\"name\", \"x\"))\n"+
                 "}";
         ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
@@ -42,13 +41,12 @@ public class StrStartsFunctionTest extends AbstractRDF4JTest{
 
     @Test
     public void testStrStartsPredicate() {
-        String query = "PREFIX schema: <http://www.schema.org/>\n" +
-                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
-                "SELECT DISTINCT ?s\n" +
+        String query = "PREFIX ex: <http://www.example.org/>\n" +
+                "SELECT ?s\n" +
                 "WHERE {\n" +
                 " ?s ?p ?o. \n" +
-                " ?s a schema:Person. \n" +
-                " FILTER (STRSTARTS(str(?p), \"http://www.schema.org/givenName\"))\n"+
+                " ?s a ex:Person. \n" +
+                " FILTER (STRSTARTS(str(?p), \"http://www.example.org/givenName\"))\n"+
                 "}";
         // predicates are constants so they can be optimized
         String reformulatedQuery = reformulateIntoNativeQuery(query).toLowerCase();
@@ -56,20 +54,19 @@ public class StrStartsFunctionTest extends AbstractRDF4JTest{
 
         ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
         assertEquals(result, ImmutableList.of(
-                ImmutableMap.of("s", "http://www.schema.org/Person/1"),
-                ImmutableMap.of("s", "http://www.schema.org/Person/2"),
-                ImmutableMap.of("s", "http://www.schema.org/Person/4")
-        ));
+                ImmutableMap.of("s", "http://www.example.org/Person/1"),
+                ImmutableMap.of("s", "http://www.example.org/Person/2"),
+                ImmutableMap.of("s", "http://www.example.org/Person/4")
+                ));
     }
 
     @Test
     public void testStrStartsIRI() {
-        String query = "PREFIX schema: <http://www.schema.org/>\n" +
-                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
+        String query = "PREFIX ex: <http://www.example.org/>\n" +
                 "SELECT DISTINCT ?s\n" +
                 "WHERE {\n" +
                 "?s ?p ?o.\n" +
-                " FILTER (STRSTARTS(STR(?s), \"http://www.w3\"))\n"+
+                " FILTER (STRSTARTS(STR(?s), \"http://www.example.org/Re\"))\n"+
                 "}";
 
         String reformulatedQuery = reformulateIntoNativeQuery(query).toLowerCase();
@@ -77,18 +74,17 @@ public class StrStartsFunctionTest extends AbstractRDF4JTest{
 
         ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
         assertEquals(result, ImmutableList.of(
-                ImmutableMap.of("s", "http://www.w3.org/ns/sosa/Result/1"),
-                ImmutableMap.of("s", "http://www.w3.org/ns/sosa/Result/2")));
+                ImmutableMap.of("s", "http://www.example.org/Result/1"),
+                ImmutableMap.of("s", "http://www.example.org/Result/2")));
     }
 
     @Test
     public void testStrStartsObject() {
-        String query = "PREFIX schema: <http://www.schema.org/>\n" +
-                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
-                "SELECT DISTINCT ?s\n" +
+        String query = "PREFIX ex: <http://www.example.org/>\n" +
+                "SELECT ?s\n" +
                 "WHERE {\n" +
                 "?s ?p ?o.\n" +
-                "?s a sosa:Result. \n" +
+                "?s a ex:Result. \n" +
                 " FILTER (STRSTARTS(STR(?o), \"2024\"))\n"+
                 "}";
         String reformulatedQuery = reformulateIntoNativeQuery(query).toLowerCase();
@@ -98,12 +94,11 @@ public class StrStartsFunctionTest extends AbstractRDF4JTest{
 
     @Test
     public void testStrStartsComplex() {
-        String query = "PREFIX schema: <http://www.schema.org/>\n" +
-                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
+        String query = "PREFIX ex: <http://www.example.org/>\n" +
                 "SELECT DISTINCT ?o\n" +
                 "WHERE {\n" +
                 "?s ?p ?o.\n" +
-                " FILTER (STRSTARTS(STR(?o), \"http://www.schema.org\"))\n"+
+                " FILTER (STRSTARTS(STR(?o), \"http://www.example.org\"))\n"+
                 "}";
         String reformulatedQuery = reformulateIntoNativeQuery(query).toLowerCase();
         // some of the objects are iri templates while others aren't
@@ -111,24 +106,24 @@ public class StrStartsFunctionTest extends AbstractRDF4JTest{
 
         ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
         assertEquals(result, ImmutableList.of(
-                ImmutableMap.of("o", "http://www.schema.org/House"),
-                ImmutableMap.of("o", "http://www.schema.org/Person"),
-                ImmutableMap.of("o", "http://www.schema.org/Person/1"),
-                ImmutableMap.of("o", "http://www.schema.org/Person/2")
-        ));
+                ImmutableMap.of("o", "http://www.example.org/House"),
+                ImmutableMap.of("o", "http://www.example.org/Person"),
+                ImmutableMap.of("o", "http://www.example.org/Person/1"),
+                ImmutableMap.of("o", "http://www.example.org/Person/2"),
+                ImmutableMap.of("o", "http://www.example.org/Result")
+                ));
     }
 
     @Test
     public void testStrStartsNull() {
-        String query = "PREFIX schema: <http://www.schema.org/>\n" +
-                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
+        String query = "PREFIX ex: <http://www.example.org/>\n" +
                 "SELECT ?res\n" +
                 "WHERE {\n" +
-                " ?s a schema:House.\n" +
+                " ?s a ex:House.\n" +
                 " OPTIONAL { \n"+
-                "  ?s schema:belongs ?person. \n" +
+                "  ?s ex:belongs ?person. \n" +
                 " } \n" +
-                " BIND( COALESCE(STRSTARTS(STR(?person), \"http://www.schema.org\"), \"default\") AS ?res) \n"+
+                " BIND( COALESCE(STRSTARTS(STR(?person), \"http://www.example.org\"), \"default\") AS ?res) \n"+
                 "}";
 
         ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
@@ -138,49 +133,46 @@ public class StrStartsFunctionTest extends AbstractRDF4JTest{
     @Test
     @Ignore("Optimization missing for concat function")
     public void testStrStartsConcat() {
-        String query = "PREFIX schema: <http://www.schema.org/>\n" +
-                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
-                "SELECT DISTINCT ?s \n" +
+        String query = "PREFIX ex: <http://www.example.org/>\n" +
+                "SELECT ?s \n" +
                 "WHERE {\n" +
-                "?s ?p ?o. \n" +
-                "?s a schema:Person. \n" +
-                " FILTER (STRSTARTS(CONCAT(STR(?s), \"a\"), \"http://www.schema.org\"))\n"+
+                "?s a ex:Person. \n" +
+                " FILTER (STRSTARTS(CONCAT(STR(?s), \"a\"), \"http://www.example.org\"))\n"+
                 "}";
         String reformulatedQuery = reformulateIntoNativeQuery(query).toLowerCase();
         assertFalse(reformulatedQuery.contains("substring"));
 
         ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
         assertEquals(result, ImmutableList.of(
-                ImmutableMap.of("s", "http://www.schema.org/Person/1"),
-                ImmutableMap.of("s", "http://www.schema.org/Person/2"),
-                ImmutableMap.of("s", "http://www.schema.org/Person/3"),
-                ImmutableMap.of("s", "http://www.schema.org/Person/4"))
+                ImmutableMap.of("s", "http://www.example.org/Person/1"),
+                ImmutableMap.of("s", "http://www.example.org/Person/2"),
+                ImmutableMap.of("s", "http://www.example.org/Person/3"),
+                ImmutableMap.of("s", "http://www.example.org/Person/4"))
         );
     }
 
     @Test
     @Ignore("Optimization missing for concat function")
     public void testStrStartsConcatNull() {
-        String query = "PREFIX schema: <http://www.schema.org/>\n" +
-                "PREFIX sosa: <http://www.w3.org/ns/sosa#>\n" +
+        String query = "PREFIX ex: <http://www.example.org/>\n" +
                 "SELECT ?person ?res \n" +
                 "WHERE {\n" +
-                " ?person a schema:Person.\n" +
+                " ?person a ex:Person.\n" +
                 " OPTIONAL {"+
-                "  ?person schema:givenName ?name.\n" +
+                "  ?person ex:givenName ?name.\n" +
                 "}" +
                 " BIND( COALESCE(STRSTARTS(" +
                 "                STR(CONCAT(?name, \"a\")), " +
-                "                \"http://www.schema.org\"), " +
+                "                \"http://www.example.org\"), " +
                 "       \"default\") " +
                 " AS ?res) \n"+
                 "}";
         ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
         assertEquals(result, ImmutableList.of(
-                ImmutableMap.of("person", "http://www.schema.org/Person/3", "res", "default"),
-                ImmutableMap.of("person", "http://www.schema.org/Person/4", "res", "false"),
-                ImmutableMap.of("person", "http://www.schema.org/Person/2", "res", "false"),
-                ImmutableMap.of("person", "http://www.schema.org/Person/1", "res", "false"))
+                ImmutableMap.of("person", "http://www.example.org/Person/1", "res", "false"),
+                ImmutableMap.of("person", "http://www.example.org/Person/2", "res", "false"),
+                ImmutableMap.of("person", "http://www.example.org/Person/3", "res", "default"),
+                ImmutableMap.of("person", "http://www.example.org/Person/4", "res", "false"))
         );
     }
 

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/StrStartsFunctionTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/StrStartsFunctionTest.java
@@ -1,0 +1,175 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Objects;
+
+import static org.junit.Assert.*;
+
+public class StrStartsFunctionTest extends AbstractRDF4JTest{
+    private static final String CREATE_DB_FILE = "/strstarts-function/sparql-strstarts.sql";
+    private static final String OBDA_FILE = "/strstarts-function/sparql-strstarts.obda";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(CREATE_DB_FILE, OBDA_FILE);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void testStrStartsConstants() {
+        String query = "PREFIX schema: <http://www.schema.org/>\n" +
+                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
+                "SELECT ?s\n" +
+                "WHERE {\n" +
+                "?s a schema:Result.\n" +
+                "FILTER (STRSTARTS(\"name\", \"x\"))\n"+
+                "}";
+        ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
+        assertEquals(result, ImmutableList.of());
+    }
+
+    @Test
+    public void testStrStartsPredicate() {
+        String query = "PREFIX schema: <http://www.schema.org/>\n" +
+                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
+                "SELECT DISTINCT ?s\n" +
+                "WHERE {\n" +
+                " ?s ?p ?o. \n" +
+                " ?s a schema:Person. \n" +
+                " FILTER (STRSTARTS(str(?p), \"http://www.schema.org/givenName\"))\n"+
+                "}";
+        // predicates are constants so they can be optimized
+        String reformulatedQuery = reformulateIntoNativeQuery(query).toLowerCase();
+        assertFalse(reformulatedQuery.contains("substring"));
+
+        ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
+        assertEquals(result, ImmutableList.of(
+                ImmutableMap.of("s", "http://www.schema.org/Person/1"),
+                ImmutableMap.of("s", "http://www.schema.org/Person/2"),
+                ImmutableMap.of("s", "http://www.schema.org/Person/4")
+        ));
+    }
+
+    @Test
+    public void testStrStartsIRI() {
+        String query = "PREFIX schema: <http://www.schema.org/>\n" +
+                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
+                "SELECT DISTINCT ?s\n" +
+                "WHERE {\n" +
+                "?s ?p ?o.\n" +
+                " FILTER (STRSTARTS(STR(?s), \"http://www.w3\"))\n"+
+                "}";
+
+        String reformulatedQuery = reformulateIntoNativeQuery(query).toLowerCase();
+        assertFalse(reformulatedQuery.contains("substring"));
+
+        ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
+        assertEquals(result, ImmutableList.of(
+                ImmutableMap.of("s", "http://www.w3.org/ns/sosa/Result/1"),
+                ImmutableMap.of("s", "http://www.w3.org/ns/sosa/Result/2")));
+    }
+
+    @Test
+    public void testStrStartsObject() {
+        String query = "PREFIX schema: <http://www.schema.org/>\n" +
+                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
+                "SELECT DISTINCT ?s\n" +
+                "WHERE {\n" +
+                "?s ?p ?o.\n" +
+                "?s a sosa:Result. \n" +
+                " FILTER (STRSTARTS(STR(?o), \"2024\"))\n"+
+                "}";
+        String reformulatedQuery = reformulateIntoNativeQuery(query).toLowerCase();
+        // objects aren't iri templates or a constants so the query can't be optimized
+        assertTrue(reformulatedQuery.contains("substring"));
+    }
+
+    @Test
+    public void testStrStartsComplex() {
+        String query = "PREFIX schema: <http://www.schema.org/>\n" +
+                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
+                "SELECT DISTINCT ?o\n" +
+                "WHERE {\n" +
+                "?s ?p ?o.\n" +
+                " FILTER (STRSTARTS(STR(?o), \"http://www.schema.org\"))\n"+
+                "}";
+        String reformulatedQuery = reformulateIntoNativeQuery(query).toLowerCase();
+        // some of the objects are iri templates while others aren't
+        assertTrue(reformulatedQuery.contains("substring"));
+
+        ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
+        assertEquals(result, ImmutableList.of(
+                ImmutableMap.of("o", "http://www.schema.org/House"),
+                ImmutableMap.of("o", "http://www.schema.org/Person"),
+                ImmutableMap.of("o", "http://www.schema.org/Person/1"),
+                ImmutableMap.of("o", "http://www.schema.org/Person/2")
+        ));
+    }
+
+    @Test
+    public void testStrStartsNull() {
+        String query = "PREFIX schema: <http://www.schema.org/>\n" +
+                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
+                "SELECT ?res\n" +
+                "WHERE {\n" +
+                " ?s a schema:House.\n" +
+                " OPTIONAL { \n"+
+                "  ?s schema:belongs ?person. \n" +
+                " } \n" +
+                " BIND( COALESCE(STRSTARTS(STR(?person), \"http://www.schema.org\"), \"null\") AS ?res) \n"+
+                "}";
+
+        ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
+        assertTrue(result.stream().anyMatch(r -> Objects.equals(r.get("res"), "null")));
+    }
+
+    @Test
+    @Ignore("No optimization done for concat function")
+    public void testStrStartsConcat() {
+        String query = "PREFIX schema: <http://www.schema.org/>\n" +
+                "PREFIX sosa: <http://www.w3.org/ns/sosa/>\n" +
+                "SELECT DISTINCT ?s \n" +
+                "WHERE {\n" +
+                "?s ?p ?o" +
+                " FILTER (STRSTARTS(CONCAT(STR(?o), \"a\"), \"http://www.schema.org\"))\n"+
+                "}";
+        ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
+        assertEquals(result, ImmutableList.of());
+    }
+
+    @Test
+    @Ignore("No optimization done for concat function")
+    public void testStrStartsConcatNull() {
+        String query = "PREFIX schema: <http://www.schema.org/>\n" +
+                "PREFIX sosa: <http://www.w3.org/ns/sosa#>\n" +
+                "SELECT ?person ?name \n" +
+                "WHERE {\n" +
+                " ?person a schema:Person.\n" +
+                " OPTIONAL {"+
+                "  ?person schema:givenName ?name.\n" +
+                "  FILTER (STRSTARTS(CONCAT(?name, \"a\"), \"Ma\"))\n"+
+                "}}";
+        ImmutableList<ImmutableMap<String, String>> result = executeQuery(query);
+        assertEquals(result, ImmutableList.of(
+                ImmutableMap.of("person", "http://www.schema.org/Person/2"),
+                ImmutableMap.of("person", "http://www.schema.org/Person/3"),
+                ImmutableMap.of("person", "http://www.schema.org/Person/4"),
+                ImmutableMap.of("person", "http://www.schema.org/Person/1", "name", "Mary"))
+        );
+    }
+
+
+
+}

--- a/binding/rdf4j/src/test/resources/strstarts-function/sparql-strstarts.obda
+++ b/binding/rdf4j/src/test/resources/strstarts-function/sparql-strstarts.obda
@@ -1,22 +1,17 @@
 [PrefixDeclaration]
-owl: http://www.w3.org/2002/07/owl#
-rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
-xml: http://www.w3.org/XML/1998/namespace
 xsd: http://www.w3.org/2001/XMLSchema#
-rdfs: http://www.w3.org/2000/01/rdf-schema#
-schema: http://www.schema.org#
-sosa: http://www.w3.org/ns/sosa#
+ex: http://www.example.org/
 
 [MappingDeclaration] @collection [[
 mappingId   mapping1
-target	    <http://www.schema.org/Person/{person_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.schema.org/Person>. <http://www.schema.org/Person/{person_id}> <http://www.schema.org/givenName> {first_name}.
+target	    ex:Person/{person_id} a ex:Person; ex:givenName {first_name}.
 source	    SELECT * FROM person
 
 mappingId   mapping2
-target	    <http://www.schema.org/House/{house_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.schema.org/House>. <http://www.schema.org/House/{house_id}> <http://www.schema.org/address> {address}. <http://www.schema.org/House/{house_id}> <http://www.schema.org/belongs>  <http://www.schema.org/Person/{owner}> .
+target	    ex:House/{house_id} a ex:House; ex:address {address}; ex:belongs ex:Person/{owner} .
 source      SELECT * FROM house
 
 mappingId   mapping3
-target	    <http://www.w3.org/ns/sosa/Result/{sensor_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/sosa/Result> .  <http://www.w3.org/ns/sosa/Result/{sensor_id}> <http://www.w3.org/ns/sosa/hasSimpleResult> {timestamp}^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+target	    ex:Result/{sensor_id} a ex:Result; ex:hasTimestamp {timestamp}^^xsd:dateTime .
 source	    SELECT * FROM sensor
 ]]

--- a/binding/rdf4j/src/test/resources/strstarts-function/sparql-strstarts.obda
+++ b/binding/rdf4j/src/test/resources/strstarts-function/sparql-strstarts.obda
@@ -1,0 +1,22 @@
+[PrefixDeclaration]
+owl: http://www.w3.org/2002/07/owl#
+rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+xml: http://www.w3.org/XML/1998/namespace
+xsd: http://www.w3.org/2001/XMLSchema#
+rdfs: http://www.w3.org/2000/01/rdf-schema#
+schema: http://www.schema.org#
+sosa: http://www.w3.org/ns/sosa#
+
+[MappingDeclaration] @collection [[
+mappingId   mapping1
+target	    <http://www.schema.org/Person/{person_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.schema.org/Person>. <http://www.schema.org/Person/{person_id}> <http://www.schema.org/givenName> {first_name}.
+source	    SELECT * FROM person
+
+mappingId   mapping2
+target	    <http://www.schema.org/House/{house_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.schema.org/House>. <http://www.schema.org/House/{house_id}> <http://www.schema.org/address> {address}. <http://www.schema.org/House/{house_id}> <http://www.schema.org/belongs>  <http://www.schema.org/Person/{owner}> .
+source      SELECT * FROM house
+
+mappingId   mapping3
+target	    <http://www.w3.org/ns/sosa/Result/{sensor_id}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/sosa/Result> .  <http://www.w3.org/ns/sosa/Result/{sensor_id}> <http://www.w3.org/ns/sosa/hasSimpleResult> {timestamp}^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+source	    SELECT * FROM sensor
+]]

--- a/binding/rdf4j/src/test/resources/strstarts-function/sparql-strstarts.sql
+++ b/binding/rdf4j/src/test/resources/strstarts-function/sparql-strstarts.sql
@@ -1,0 +1,27 @@
+CREATE TABLE person (
+    person_id integer NOT NULL,
+    first_name text
+);
+INSERT INTO person VALUES (1, 'Mary');
+INSERT INTO person VALUES (2, 'John');
+INSERT INTO person VALUES (3, NULL);
+INSERT INTO person VALUES (4, 'James');
+
+CREATE TABLE house (
+    house_id integer NOT NULL,
+    address text NOT NULL,
+    owner integer
+);
+INSERT INTO house VALUES (100, 'Via Roma, 14', 1);
+INSERT INTO house VALUES (200, 'Piazza Verdi, 1', 1);
+INSERT INTO house VALUES (300, 'Via Manci, 31', 2);
+INSERT INTO house VALUES (400, 'Via Venezia, 27', NULL);
+
+CREATE TABLE sensor (
+    sensor_id integer NOT NULL,
+    timestamp text NOT NULL
+);
+
+
+INSERT INTO sensor VALUES (1, '1949-12-31 14:55:00.000000');
+INSERT INTO sensor VALUES (2, '1949-12-31 14:55:00.000000');

--- a/binding/rdf4j/src/test/resources/strstarts-function/sparql-strstarts.sql
+++ b/binding/rdf4j/src/test/resources/strstarts-function/sparql-strstarts.sql
@@ -1,6 +1,7 @@
 CREATE TABLE person (
-    person_id integer NOT NULL,
-    first_name text
+    person_id integer NOT NULL ,
+    first_name text,
+    PRIMARY KEY (person_id)
 );
 INSERT INTO person VALUES (1, 'Mary');
 INSERT INTO person VALUES (2, 'John');
@@ -8,9 +9,10 @@ INSERT INTO person VALUES (3, NULL);
 INSERT INTO person VALUES (4, 'James');
 
 CREATE TABLE house (
-    house_id integer NOT NULL,
+    house_id integer NOT NULL ,
     address text NOT NULL,
-    owner integer
+    owner integer,
+    PRIMARY KEY (house_id)
 );
 INSERT INTO house VALUES (100, 'Via Roma, 14', 1);
 INSERT INTO house VALUES (200, 'Piazza Verdi, 1', 1);
@@ -18,10 +20,10 @@ INSERT INTO house VALUES (300, 'Via Manci, 31', 2);
 INSERT INTO house VALUES (400, 'Via Venezia, 27', NULL);
 
 CREATE TABLE sensor (
-    sensor_id integer NOT NULL,
-    timestamp text NOT NULL
+    sensor_id integer NOT NULL ,
+   timestamp text NOT NULL,
+    PRIMARY KEY (sensor_id)
 );
-
 
 INSERT INTO sensor VALUES (1, '1949-12-31 14:55:00.000000');
 INSERT INTO sensor VALUES (2, '1949-12-31 14:55:00.000000');

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultDBStrStartsWithFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultDBStrStartsWithFunctionSymbol.java
@@ -53,12 +53,12 @@ public class DefaultDBStrStartsWithFunctionSymbol extends DBBooleanFunctionSymbo
             }
 
             if (newTerms.get(0) instanceof ImmutableFunctionalTerm) {
-                ImmutableFunctionalTerm firstNonFunctionalTerm = (ImmutableFunctionalTerm) newTerms.get(0);
-                if (firstNonFunctionalTerm.getFunctionSymbol() instanceof IRIStringTemplateFunctionSymbol) {
-                    IRIStringTemplateFunctionSymbol iriTemplate = (IRIStringTemplateFunctionSymbol) firstNonFunctionalTerm.getFunctionSymbol();
+                ImmutableFunctionalTerm firstFunctionalTerm = (ImmutableFunctionalTerm) newTerms.get(0);
+                if (firstFunctionalTerm.getFunctionSymbol() instanceof IRIStringTemplateFunctionSymbol) {
+                    IRIStringTemplateFunctionSymbol iriTemplate = (IRIStringTemplateFunctionSymbol) firstFunctionalTerm.getFunctionSymbol();
                     ImmutableTerm simplifiedTerm = iriTemplate.getTemplate().startsWith(prefixString)
-                            ? termFactory.getTrueOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNotNull(firstNonFunctionalTerm)))
-                            : termFactory.getFalseOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNull(firstNonFunctionalTerm)));
+                            ? termFactory.getTrueOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNotNull(firstFunctionalTerm)))
+                            : termFactory.getFalseOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNull(firstFunctionalTerm)));
                     return simplifiedTerm.simplify(variableNullability);
                 }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultDBStrStartsWithFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultDBStrStartsWithFunctionSymbol.java
@@ -1,9 +1,9 @@
 package it.unibz.inf.ontop.model.term.functionsymbol.db.impl;
 
 import com.google.common.collect.ImmutableList;
-import it.unibz.inf.ontop.model.term.ImmutableExpression;
-import it.unibz.inf.ontop.model.term.ImmutableTerm;
-import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.model.term.*;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.IRIStringTemplateFunctionSymbol;
 import it.unibz.inf.ontop.model.type.DBTermType;
 
 import java.util.function.Function;
@@ -32,7 +32,6 @@ public class DefaultDBStrStartsWithFunctionSymbol extends DBBooleanFunctionSymbo
     public String getNativeDBString(ImmutableList<? extends ImmutableTerm> terms,
                                     Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         ImmutableTerm secondTerm = terms.get(1);
-
         // TODO: use a non-strict equality
         return termConverter.apply(
                 termFactory.getStrictEquality(
@@ -41,6 +40,33 @@ public class DefaultDBStrStartsWithFunctionSymbol extends DBBooleanFunctionSymbo
                                 termFactory.getDBIntegerConstant(1),
                                 termFactory.getDBCharLength(secondTerm)),
                         secondTerm));
+    }
+
+    @Override
+    protected ImmutableTerm buildTermAfterEvaluation(ImmutableList<ImmutableTerm> newTerms, TermFactory termFactory, VariableNullability variableNullability) {
+        if (newTerms.get(1) instanceof DBConstant) {
+            DBConstant pattern = (DBConstant) newTerms.get(1);
+
+            if (newTerms.get(0) instanceof DBConstant) {
+                DBConstant value = (DBConstant) newTerms.get(0);
+                return value.getValue().startsWith(pattern.getValue())
+                        ? termFactory.getTrueOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNotNull(value)))
+                        : termFactory.getFalseOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNull(value)));
+            }
+
+            if (newTerms.get(0) instanceof ImmutableFunctionalTerm) {
+                ImmutableFunctionalTerm value = (ImmutableFunctionalTerm) newTerms.get(0);
+                if (value.getFunctionSymbol() instanceof IRIStringTemplateFunctionSymbol) {
+                    IRIStringTemplateFunctionSymbol iriTemplate = (IRIStringTemplateFunctionSymbol) value.getFunctionSymbol();
+                    return iriTemplate.getTemplate().startsWith(pattern.getValue())
+                            ? termFactory.getTrueOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNotNull(value)))
+                            : termFactory.getFalseOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNull(value)));
+                }
+
+            }
+        }
+
+        return super.buildTermAfterEvaluation(newTerms, termFactory, variableNullability);
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultDBStrStartsWithFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/DefaultDBStrStartsWithFunctionSymbol.java
@@ -45,22 +45,21 @@ public class DefaultDBStrStartsWithFunctionSymbol extends DBBooleanFunctionSymbo
     @Override
     protected ImmutableTerm buildTermAfterEvaluation(ImmutableList<ImmutableTerm> newTerms, TermFactory termFactory, VariableNullability variableNullability) {
         if (newTerms.get(1) instanceof DBConstant) {
-            DBConstant pattern = (DBConstant) newTerms.get(1);
+            String prefixString = ((DBConstant) newTerms.get(1)).getValue();
 
             if (newTerms.get(0) instanceof DBConstant) {
-                DBConstant value = (DBConstant) newTerms.get(0);
-                return value.getValue().startsWith(pattern.getValue())
-                        ? termFactory.getTrueOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNotNull(value)))
-                        : termFactory.getFalseOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNull(value)));
+                DBConstant firstConstant = (DBConstant) newTerms.get(0);
+                return termFactory.getDBBooleanConstant(firstConstant.getValue().startsWith(prefixString));
             }
 
             if (newTerms.get(0) instanceof ImmutableFunctionalTerm) {
-                ImmutableFunctionalTerm value = (ImmutableFunctionalTerm) newTerms.get(0);
-                if (value.getFunctionSymbol() instanceof IRIStringTemplateFunctionSymbol) {
-                    IRIStringTemplateFunctionSymbol iriTemplate = (IRIStringTemplateFunctionSymbol) value.getFunctionSymbol();
-                    return iriTemplate.getTemplate().startsWith(pattern.getValue())
-                            ? termFactory.getTrueOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNotNull(value)))
-                            : termFactory.getFalseOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNull(value)));
+                ImmutableFunctionalTerm firstNonFunctionalTerm = (ImmutableFunctionalTerm) newTerms.get(0);
+                if (firstNonFunctionalTerm.getFunctionSymbol() instanceof IRIStringTemplateFunctionSymbol) {
+                    IRIStringTemplateFunctionSymbol iriTemplate = (IRIStringTemplateFunctionSymbol) firstNonFunctionalTerm.getFunctionSymbol();
+                    ImmutableTerm simplifiedTerm = iriTemplate.getTemplate().startsWith(prefixString)
+                            ? termFactory.getTrueOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNotNull(firstNonFunctionalTerm)))
+                            : termFactory.getFalseOrNullFunctionalTerm(ImmutableList.of(termFactory.getDBIsNull(firstNonFunctionalTerm)));
+                    return simplifiedTerm.simplify(variableNullability);
                 }
 
             }


### PR DESCRIPTION
This optimization allows to simplify the `STRSTARTS` SPARQL function when the second argument is a constant and the first argument is either:
- **constant**: the two constants values can be directly compared
- **iri template**: the iri template prefix can be compared with the second argument value

### Motivating Example

Query to partially materialize the Ontopic Data Hub dataset into GraphDB that caused the underlying PostgreSQL database to crash:
```
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
INSERT {
  GRAPH <http://example.com/materialized-simple-mapping-query> {
    ?s ?p ?o .
  }
}
WHERE {
  SERVICE <http://172.17.0.1:8080/sparql> {
    ?s ?p ?o .
    FILTER (!STRSTARTS(STR(?s), "https://kg.opendatahub.bz.it/data/observation/"))
  }
}
```

### Optimization Example
```
PREFIX ex: <http://www.example.org/>
SELECT DISTINCT ?s
WHERE {
  ?s ?p ?o.
  FILTER (STRSTARTS(STR(?s), "http://www.example.org/Re"))
}
```
which has as result all triples associated with the `Result`entity
|   	| Results                         	|
|---	|---------------------------------	|
| 1 	| http://www.example.org/Result/1 	|
| 2 	| http://www.example.org/Result/2 	|

 
This query is equivalent to the following unfolded `IQTree`:
```
DISTINCT
   CONSTRUCT [s] []
      FILTER RDF_2_DB_BOOL(SP_STARTS_WITH(SP_STR(s),"http://www.example.org/Re"))
         CONSTRUCT [s, p, o] [s/RDF(v5,IRI), p/RDF(v9,IRI), o/RDF(v18,v19)]
            UNION [v5, v9, v18, v19]
               CONSTRUCT [v5, v9, v18, v19] [v9/"http://www.w3.org/1999/02/22-rdf-syntax-ns#type"^^TEXT, v18/"http://www.example.org/Person"^^TEXT, v19/IRI, v5/http://www.example.org/Person/{}(INTEGERToTEXT(PERSON_ID1m1))]
                  EXTENSIONAL "PERSON"(0:PERSON_ID1m1)
               CONSTRUCT [v5, v9, v18, v19] [v9/"http://www.w3.org/1999/02/22-rdf-syntax-ns#type"^^TEXT, v18/"http://www.example.org/House"^^TEXT, v19/IRI, v5/http://www.example.org/House/{}(INTEGERToTEXT(HOUSE_ID1m3))]
                  EXTENSIONAL "HOUSE"(0:HOUSE_ID1m3)
               CONSTRUCT [v5, v9, v18, v19] [v9/"http://www.w3.org/1999/02/22-rdf-syntax-ns#type"^^TEXT, v18/"http://www.example.org/Result"^^TEXT, v19/IRI, v5/http://www.example.org/Result/{}(INTEGERToTEXT(SENSOR_ID1m6))]
                  EXTENSIONAL "SENSOR"(0:SENSOR_ID1m6)
               CONSTRUCT [v5, v9, v18, v19] [v9/"http://www.example.org/givenName"^^TEXT, v18/CHARACTER VARYINGToTEXT(FIRST_NAME1m2), v19/xsd:string, v5/http://www.example.org/Person/{}(INTEGERToTEXT(PERSON_ID1m2))]
                  FILTER IS_NOT_NULL(FIRST_NAME1m2)
                     EXTENSIONAL "PERSON"(0:PERSON_ID1m2,1:FIRST_NAME1m2)
               CONSTRUCT [v5, v9, v18, v19] [v9/"http://www.example.org/address"^^TEXT, v18/CHARACTER VARYINGToTEXT(ADDRESS1m4), v19/xsd:string, v5/http://www.example.org/House/{}(INTEGERToTEXT(HOUSE_ID1m4))]
                  EXTENSIONAL "HOUSE"(0:HOUSE_ID1m4,1:ADDRESS1m4)
               CONSTRUCT [v5, v9, v18, v19] [v9/"http://www.example.org/belongs"^^TEXT, v18/http://www.example.org/Person/{}(INTEGERToTEXT(OWNER1m5)), v19/IRI, v5/http://www.example.org/House/{}(INTEGERToTEXT(HOUSE_ID1m5))]
                  FILTER IS_NOT_NULL(OWNER1m5)
                     EXTENSIONAL "HOUSE"(0:HOUSE_ID1m5,2:OWNER1m5)
               CONSTRUCT [v5, v9, v18, v19] [v9/"http://www.example.org/hasTimestamp"^^TEXT, v18/CHARACTER VARYINGToTEXT(TIMESTAMP1m7), v19/xsd:dateTime, v5/http://www.example.org/Result/{}(INTEGERToTEXT(SENSOR_ID1m7))]
                  EXTENSIONAL "SENSOR"(0:SENSOR_ID1m7,1:TIMESTAMP1m7)
```
Since the filter is applied on the triples subjects (which are always IRIs), `STRSTARTS` is optimized: all IRIs for the `Person`and `House` entities (respectively `http://www.example.org/Person/{person_id}` and `http://www.example.org/House/{house_id}`) don´t match the `"http://www.example.org/Re"` prefix, and thus the associated nodes are removed from the IQTree, while the ones associated with the `Result`entity (`http://www.example.org/Result/{result_id}`) are kept. 
```
CONSTRUCT [s] [s/RDF(http://www.example.org/Result/{}(INTEGERToTEXT(SENSOR_ID1m0)),IRI)]
   DISTINCT
      UNION [SENSOR_ID1m0]
         EXTENSIONAL "SENSOR"(0:SENSOR_ID1m0)
         EXTENSIONAL "SENSOR"(0:SENSOR_ID1m0)
```