### PR TITLE
Self-left join elimination on nullable FD determinants made robust to provenance variables and trivial FDs

### DIFF
--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalityInsensitiveLJPruningOptimizer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/lj/CardinalityInsensitiveLJPruningOptimizer.java
@@ -15,15 +15,9 @@ import it.unibz.inf.ontop.iq.optimizer.impl.LookForDistinctOrLimit1TransformerIm
 import it.unibz.inf.ontop.iq.transform.IQTreeTransformer;
 import it.unibz.inf.ontop.iq.transform.IQTreeVisitingTransformer;
 import it.unibz.inf.ontop.iq.transform.impl.DefaultNonRecursiveIQTreeTransformer;
-import it.unibz.inf.ontop.model.term.DBConstant;
 import it.unibz.inf.ontop.model.term.ImmutableFunctionalTerm;
-import it.unibz.inf.ontop.model.term.TermFactory;
 import it.unibz.inf.ontop.model.term.Variable;
-import it.unibz.inf.ontop.substitution.SubstitutionFactory;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
-
-import java.util.Map;
-import java.util.stream.Stream;
 
 /**
  * Prunes right children when their variables are not used outside the LJ
@@ -64,9 +58,6 @@ public class CardinalityInsensitiveLJPruningOptimizer implements LeftJoinIQOptim
         private final CoreSingletons coreSingletons;
         private final ImmutableSet<Variable> variablesUsedByAncestors;
         private final IntermediateQueryFactory iqFactory;
-        private final TermFactory termFactory;
-        private final DBConstant provConstant;
-        private final SubstitutionFactory substitutionFactory;
 
         protected CardinalityInsensitiveLJPruningTransformer(IQTreeTransformer lookForDistinctTransformer,
                                                              CoreSingletons coreSingletons,
@@ -75,9 +66,6 @@ public class CardinalityInsensitiveLJPruningOptimizer implements LeftJoinIQOptim
             this.coreSingletons = coreSingletons;
             this.variablesUsedByAncestors = variablesUsedByAncestors;
             this.iqFactory = coreSingletons.getIQFactory();
-            this.termFactory = coreSingletons.getTermFactory();
-            this.substitutionFactory = coreSingletons.getSubstitutionFactory();
-            this.provConstant = termFactory.getProvenanceSpecialConstant();
         }
 
         @Override
@@ -127,16 +115,9 @@ public class CardinalityInsensitiveLJPruningOptimizer implements LeftJoinIQOptim
 
             var leftVariables = leftChild.getVariables();
 
-            var usedVariables = Sets.intersection(variablesUsedByAncestors, treeVariables);
-
-            if (treeVariables.isEmpty() || leftVariables.containsAll(usedVariables))
+            if (treeVariables.isEmpty() || leftVariables.containsAll(Sets.intersection(variablesUsedByAncestors, treeVariables)))
                 // Prunes the right child
                 return leftChild.acceptTransformer(this);
-
-            var provVariables = extractProvenanceVariables(rightChild);
-            if ((!provVariables.isEmpty()) && leftVariables.containsAll(Sets.difference(usedVariables, provVariables)))
-                return liftProvenanceAndPruneRightChild(leftChild, rightChild, provVariables, treeVariables);
-
 
             var commonVariables = Sets.intersection(leftVariables, rightChild.getVariables());
 
@@ -156,46 +137,6 @@ public class CardinalityInsensitiveLJPruningOptimizer implements LeftJoinIQOptim
             return newLeft.equals(leftChild) && newRight.equals(rightChild)
                     ? tree
                     : iqFactory.createBinaryNonCommutativeIQTree(rootNode, newLeft, newRight);
-        }
-
-        private IQTree liftProvenanceAndPruneRightChild(IQTree leftChild, IQTree rightChild,
-                                                        ImmutableSet<Variable> provVariables,
-                                                        ImmutableSet<Variable> treeVariables) {
-            var leftVariables = leftChild.getVariables();
-            var commonVariables = Sets.intersection(leftVariables, rightChild.getVariables());
-            var commonProvVariables = Sets.intersection(commonVariables, provVariables);
-
-            var condition = termFactory.getConjunction(Stream.concat(
-                    commonVariables.stream()
-                            .map(termFactory::getDBIsNotNull),
-                    // Should not happen in practice, but just in case
-                    commonProvVariables.stream()
-                            .map(v -> termFactory.getStrictEquality(v, provConstant)
-                    )));
-
-            var constructionNode = condition
-                    .map(c -> provVariables.stream().collect(
-                            substitutionFactory.toSubstitution(v -> termFactory.getIfElseNull(c, provConstant))))
-                    .map(s -> iqFactory.createConstructionNode(treeVariables, s));
-
-            var newLeftChild = leftChild.acceptTransformer(this);
-
-            return constructionNode
-                    .map(n -> (IQTree) iqFactory.createUnaryIQTree(n, newLeftChild))
-                    .orElse(newLeftChild);
-        }
-
-        private ImmutableSet<Variable> extractProvenanceVariables(IQTree rightChild) {
-            var rootNode = rightChild.getRootNode();
-            if (rootNode instanceof ConstructionNode) {
-                var substitution = ((ConstructionNode) rootNode).getSubstitution();
-                return substitution.stream()
-                        .filter(e -> e.getValue().equals(provConstant))
-                        .map(Map.Entry::getKey)
-                        .collect(ImmutableSet.toImmutableSet());
-            }
-            else
-                return ImmutableSet.of();
         }
 
         @Override

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -5704,6 +5704,7 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
     }
 
+    @Ignore("TODO: the construction below the distinct should not matter for card insensitive")
     @Test
     public void testSelfLeftJoinWithProvenanceBlockedByDistinct2() {
         DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
@@ -5766,153 +5767,6 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
     }
 
-    @Test
-    public void testSelfLeftJoinWithProvenanceBlockedByDistinct4() {
-        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
-                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, C));
-
-        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
-        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(1, ONE, 2, B));
-
-        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
-                IQ_FACTORY.createLeftJoinNode(),
-                dataNode1,
-                IQ_FACTORY.createUnaryIQTree(
-                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
-                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
-                        dataNode2));
-
-        var distinctTree = IQ_FACTORY.createUnaryIQTree(
-                IQ_FACTORY.createDistinctNode(),
-                IQ_FACTORY.createUnaryIQTree(
-                        IQ_FACTORY.createConstructionNode(projectionAtom.getVariables()),
-                        leftJoinTree));
-
-        var newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, F0, 2, B));
-
-        var newTree = IQ_FACTORY.createUnaryIQTree(
-                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
-                        SUBSTITUTION_FACTORY.getSubstitution(C,
-                                TERM_FACTORY.getIfElseNull(
-                                        TERM_FACTORY.getConjunction(
-                                                TERM_FACTORY.getDBIsNotNull(B),
-                                                TERM_FACTORY.getStrictEquality(F0, ONE)
-                                                ),
-                                        TERM_FACTORY.getProvenanceSpecialConstant()))),
-                newDataNode);
-
-
-        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
-    }
-
-    @Test
-    public void testSelfLeftJoinWithProvenanceBlockedByDistinct5() {
-        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
-                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, C));
-
-        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
-        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, ONE, 2, B));
-
-        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
-                IQ_FACTORY.createLeftJoinNode(),
-                dataNode1,
-                IQ_FACTORY.createUnaryIQTree(
-                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
-                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
-                        dataNode2));
-
-        var distinctTree = IQ_FACTORY.createUnaryIQTree(
-                IQ_FACTORY.createDistinctNode(),
-                IQ_FACTORY.createUnaryIQTree(
-                        IQ_FACTORY.createConstructionNode(projectionAtom.getVariables()),
-                        leftJoinTree));
-
-        var newTree = IQ_FACTORY.createUnaryIQTree(
-                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
-                        SUBSTITUTION_FACTORY.getSubstitution(C,
-                                TERM_FACTORY.getIfElseNull(
-                                        TERM_FACTORY.getConjunction(
-                                                TERM_FACTORY.getDBIsNotNull(B),
-                                                TERM_FACTORY.getStrictEquality(A, ONE)
-                                        ),
-                                        TERM_FACTORY.getProvenanceSpecialConstant()))),
-                dataNode1);
-
-        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
-    }
-
-    @Test
-    public void testSelfLeftJoinWithProvenanceBlockedByDistinct6() {
-        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
-                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, C));
-
-        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
-        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(1, B));
-
-        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
-                IQ_FACTORY.createLeftJoinNode(),
-                dataNode1,
-                IQ_FACTORY.createUnaryIQTree(
-                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
-                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
-                        dataNode2));
-
-        var distinctTree = IQ_FACTORY.createUnaryIQTree(
-                IQ_FACTORY.createDistinctNode(),
-                IQ_FACTORY.createUnaryIQTree(
-                        IQ_FACTORY.createConstructionNode(projectionAtom.getVariables()),
-                        leftJoinTree));
-
-        var newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, F0, 2, B));
-
-        var newTree = IQ_FACTORY.createUnaryIQTree(
-                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
-                        SUBSTITUTION_FACTORY.getSubstitution(C,
-                                TERM_FACTORY.getIfElseNull(
-                                        TERM_FACTORY.getStrictEquality(B, F0),
-                                        TERM_FACTORY.getProvenanceSpecialConstant()))),
-                newDataNode);
-
-        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
-    }
-
-    @Test
-    public void testSelfLeftJoinWithProvenanceBlockedByDistinct7() {
-        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
-                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, C));
-
-        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
-        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, ONE, 1, B));
-
-        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
-                IQ_FACTORY.createLeftJoinNode(),
-                dataNode1,
-                IQ_FACTORY.createUnaryIQTree(
-                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
-                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
-                        dataNode2));
-
-        var distinctTree = IQ_FACTORY.createUnaryIQTree(
-                IQ_FACTORY.createDistinctNode(),
-                IQ_FACTORY.createUnaryIQTree(
-                        IQ_FACTORY.createConstructionNode(projectionAtom.getVariables()),
-                        leftJoinTree));
-
-        var newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, F0, 2, B));
-
-        var newTree = IQ_FACTORY.createUnaryIQTree(
-                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
-                        SUBSTITUTION_FACTORY.getSubstitution(C,
-                                TERM_FACTORY.getIfElseNull(
-                                        TERM_FACTORY.getConjunction(
-                                                TERM_FACTORY.getStrictEquality(B, F0),
-                                                TERM_FACTORY.getStrictEquality(A, ONE)
-                                        ),
-                                        TERM_FACTORY.getProvenanceSpecialConstant()))),
-                newDataNode);
-
-        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
-    }
 
     @Test
     public void testSelfLeftJoinWithProvenanceBlockedByDistinct8() {
@@ -6033,6 +5887,60 @@ public class LeftJoinOptimizationTest {
 
 
         optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, dataNode1));
+    }
+
+    /**
+     * No opt because constraint on a non-dependent
+     */
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinctNoOpt1() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, B, C));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(1, ONE, 2, B));
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
+                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                leftJoinTree);
+
+        var initialIQ = IQ_FACTORY.createIQ(projectionAtom, distinctTree);
+        optimizeAndCompare(initialIQ, initialIQ);
+    }
+
+    /**
+     * No opt because no determinant
+     */
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinctNoOpt2() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, B, C));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(1, B));
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
+                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                leftJoinTree);
+
+        var initialIQ = IQ_FACTORY.createIQ(projectionAtom, distinctTree);
+        optimizeAndCompare(initialIQ, initialIQ);
     }
 
 

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -5767,6 +5767,35 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
     }
 
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinct4() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, C));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, ONE));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(2, ONE));
+
+        var substitution = SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant());
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(C), substitution),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                leftJoinTree);
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(), substitution),
+                dataNode1);
+
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
+    }
+
 
     @Test
     public void testSelfLeftJoinWithProvenanceBlockedByDistinct8() {

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -5766,6 +5766,153 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
     }
 
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinct4() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, C));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(1, ONE, 2, B));
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
+                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(projectionAtom.getVariables()),
+                        leftJoinTree));
+
+        var newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, F0, 2, B));
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(C,
+                                TERM_FACTORY.getIfElseNull(
+                                        TERM_FACTORY.getConjunction(
+                                                TERM_FACTORY.getDBIsNotNull(B),
+                                                TERM_FACTORY.getStrictEquality(F0, ONE)
+                                                ),
+                                        TERM_FACTORY.getProvenanceSpecialConstant()))),
+                newDataNode);
+
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
+    }
+
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinct5() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, C));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, ONE, 2, B));
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
+                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(projectionAtom.getVariables()),
+                        leftJoinTree));
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(C,
+                                TERM_FACTORY.getIfElseNull(
+                                        TERM_FACTORY.getConjunction(
+                                                TERM_FACTORY.getDBIsNotNull(B),
+                                                TERM_FACTORY.getStrictEquality(A, ONE)
+                                        ),
+                                        TERM_FACTORY.getProvenanceSpecialConstant()))),
+                dataNode1);
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
+    }
+
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinct6() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, C));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(1, B));
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
+                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(projectionAtom.getVariables()),
+                        leftJoinTree));
+
+        var newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, F0, 2, B));
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(C,
+                                TERM_FACTORY.getIfElseNull(
+                                        TERM_FACTORY.getStrictEquality(B, F0),
+                                        TERM_FACTORY.getProvenanceSpecialConstant()))),
+                newDataNode);
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
+    }
+
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinct7() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, C));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, ONE, 1, B));
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
+                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(projectionAtom.getVariables()),
+                        leftJoinTree));
+
+        var newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, F0, 2, B));
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(C,
+                                TERM_FACTORY.getIfElseNull(
+                                        TERM_FACTORY.getConjunction(
+                                                TERM_FACTORY.getStrictEquality(B, F0),
+                                                TERM_FACTORY.getStrictEquality(A, ONE)
+                                        ),
+                                        TERM_FACTORY.getProvenanceSpecialConstant()))),
+                newDataNode);
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
+    }
 
     @Test
     public void testSelfLeftJoinSameVarsDistinct1() {

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -5915,6 +5915,69 @@ public class LeftJoinOptimizationTest {
     }
 
     @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinct8() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, B, C));
+
+        // B is not nullable
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(1, B));
+
+        var substitution = SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant());
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C), substitution),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                leftJoinTree);
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(), substitution),
+                dataNode1);
+
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
+    }
+
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinct9() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, C));
+
+        // B is not nullable
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 1, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(1, B));
+
+        var substitution = SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant());
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C), substitution),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(projectionAtom.getVariables()), leftJoinTree));
+
+        var newDataNode = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A));
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(), substitution),
+                newDataNode);
+
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
+    }
+
+    @Test
     public void testSelfLeftJoinSameVarsDistinct1() {
         DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
                 ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, B));

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -5738,6 +5738,56 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
     }
 
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinct3() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, C));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of());
+
+        var substitution = SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant());
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(C), substitution),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                leftJoinTree);
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(), substitution),
+                dataNode1);
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
+    }
+
+
+    @Test
+    public void testSelfLeftJoinSameVarsDistinct1() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, B));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(2, B));
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                dataNode2);
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                leftJoinTree);
+
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, dataNode1));
+    }
+
 
     private static void optimizeAndCompare(IQ initialIQ, IQ expectedIQ) {
         LOGGER.debug("Initial query: "+ initialIQ);

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -5796,6 +5796,73 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
     }
 
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinct5() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, B, C));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(2, B));
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(TERM_FACTORY.getStrictEquality(B, ONE)),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
+                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                leftJoinTree);
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(C,
+                                TERM_FACTORY.getIfElseNull(
+                                        TERM_FACTORY.getStrictEquality(B, ONE),
+                                        TERM_FACTORY.getProvenanceSpecialConstant()))),
+                dataNode1);
+
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
+    }
+
+    @Ignore("TODO: make NullableFDSelfLJOptimizer more robust to constants on the right")
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinct6() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, B, C));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(2, ONE));
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
+                                SUBSTITUTION_FACTORY.getSubstitution(
+                                        C, TERM_FACTORY.getProvenanceSpecialConstant(),
+                                        B , ONE)),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                leftJoinTree);
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(C,
+                                TERM_FACTORY.getIfElseNull(
+                                        TERM_FACTORY.getStrictEquality(B, ONE),
+                                        TERM_FACTORY.getProvenanceSpecialConstant()))),
+                dataNode1);
+
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
+    }
+
 
     @Test
     public void testSelfLeftJoinWithProvenanceBlockedByDistinct8() {

--- a/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
+++ b/core/optimization/src/test/java/it/unibz/inf/ontop/iq/executor/LeftJoinOptimizationTest.java
@@ -5672,6 +5672,72 @@ public class LeftJoinOptimizationTest {
         optimizeAndCompare(initialIQ, initialIQ);
     }
 
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinct1() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(3), ImmutableList.of(A, B, C));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(2, B));
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
+                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                leftJoinTree);
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                    SUBSTITUTION_FACTORY.getSubstitution(C,
+                        TERM_FACTORY.getIfElseNull(
+                                TERM_FACTORY.getDBIsNotNull(B),
+                                TERM_FACTORY.getProvenanceSpecialConstant()))),
+                dataNode1);
+
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
+    }
+
+    @Test
+    public void testSelfLeftJoinWithProvenanceBlockedByDistinct2() {
+        DistinctVariableOnlyDataAtom projectionAtom = ATOM_FACTORY.getDistinctVariableOnlyDataAtom(
+                ATOM_FACTORY.getRDFAnswerPredicate(2), ImmutableList.of(A, C));
+
+        var dataNode1 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(0, A, 2, B));
+        var dataNode2 = IQ_FACTORY.createExtensionalDataNode(TABLE1, ImmutableMap.of(2, B));
+
+        var leftJoinTree = IQ_FACTORY.createBinaryNonCommutativeIQTree(
+                IQ_FACTORY.createLeftJoinNode(),
+                dataNode1,
+                IQ_FACTORY.createUnaryIQTree(
+                        IQ_FACTORY.createConstructionNode(ImmutableSet.of(B, C),
+                                SUBSTITUTION_FACTORY.getSubstitution(C, TERM_FACTORY.getProvenanceSpecialConstant())),
+                        dataNode2));
+
+        var distinctTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createDistinctNode(),
+                IQ_FACTORY.createUnaryIQTree(
+                    IQ_FACTORY.createConstructionNode(projectionAtom.getVariables()),
+                        leftJoinTree));
+
+        var newTree = IQ_FACTORY.createUnaryIQTree(
+                IQ_FACTORY.createConstructionNode(projectionAtom.getVariables(),
+                        SUBSTITUTION_FACTORY.getSubstitution(C,
+                                TERM_FACTORY.getIfElseNull(
+                                        TERM_FACTORY.getDBIsNotNull(B),
+                                        TERM_FACTORY.getProvenanceSpecialConstant()))),
+                dataNode1);
+
+
+        optimizeAndCompare(IQ_FACTORY.createIQ(projectionAtom, distinctTree), IQ_FACTORY.createIQ(projectionAtom, newTree));
+    }
+
 
     private static void optimizeAndCompare(IQ initialIQ, IQ expectedIQ) {
         LOGGER.debug("Initial query: "+ initialIQ);


### PR DESCRIPTION
This optimization is able to perform the following optimizations:

```
DISTINCT
   LJ
      EXTENSIONAL TABLE1(0:a,2:b)
      CONSTRUCT [b, c] [c/"ontop-provenance-constant"^^STRING]
         EXTENSIONAL TABLE1(2:b)
```
into
```
CONSTRUCT [a, b, c] [c/IF_ELSE_NULL(IS_NOT_NULL(b),"ontop-provenance-constant"^^STRING)]
   EXTENSIONAL TABLE1(0:a,2:b)
```
with the first column of `TABLE1` being a primary key

and
```
DISTINCT
   LJ
      EXTENSIONAL TABLE22(0:a,1:b)
      CONSTRUCT [b, c, d] [c/"ontop-provenance-constant"^^STRING]
         EXTENSIONAL TABLE22(1:b,2:d)
```
into 
```
CONSTRUCT [a, b, c, d] [c/IF_ELSE_NULL(IS_NOT_NULL(b),"ontop-provenance-constant"^^STRING), d/IF_ELSE_NULL(IS_NOT_NULL(b),df0)]
   EXTENSIONAL TABLE22(0:a,1:b,2:df0)
```
with the first column of `TABLE22` being a primary key and the second column determining the third.

