### PR TITLE
Fix for issue #803

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLServerQuotedIDFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLServerQuotedIDFactory.java
@@ -47,17 +47,21 @@ import java.util.Objects;
 @NonNullByDefault
 public class SQLServerQuotedIDFactory extends SQLStandardQuotedIDFactory {
 
+	// both quoated and unquoted identifiers are case-insensitive (or, rather it depends on collation)
+	// https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers
+	private static final boolean CASE_SENSITIVE = false;
+
 	@Override
 	protected QuotedID createFromString(String s) {
 		Objects.requireNonNull(s);
 
 		if (s.startsWith(QUOTATION_STRING) && s.endsWith(QUOTATION_STRING))
-			return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING, true);
+			return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING, CASE_SENSITIVE);
 
 		if (s.startsWith("[") && s.endsWith("]"))
-			return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING, true);
+			return new QuotedIDImpl(s.substring(1, s.length() - 1), QUOTATION_STRING, CASE_SENSITIVE);
 
-		return new QuotedIDImpl(s, NO_QUOTATION, true);
+		return new QuotedIDImpl(s, NO_QUOTATION, CASE_SENSITIVE);
 	}
 
 	@Override

--- a/db/rdb/src/test/java/it/unibz/inf/ontop/spec/sqlparser/SelectQueryAttributeExtractorTest.java
+++ b/db/rdb/src/test/java/it/unibz/inf/ontop/spec/sqlparser/SelectQueryAttributeExtractorTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.dbschema.*;
 import it.unibz.inf.ontop.dbschema.impl.OfflineMetadataProviderBuilder;
+import it.unibz.inf.ontop.dbschema.impl.SQLServerQuotedIDFactory;
 import it.unibz.inf.ontop.exception.InvalidQueryException;
 import it.unibz.inf.ontop.spec.sqlparser.exception.UnsupportedSelectQueryException;
 import org.junit.Test;
@@ -64,6 +65,29 @@ public class SelectQueryAttributeExtractorTest {
                 idfac.createAttributeID("FECBLO1"),
                 idfac.createAttributeID("STCMIN"),
                 idfac.createAttributeID("PRECIOFINAL")), res);
+    }
+
+    @Test
+    public void test_approximation_803() throws InvalidQueryException {
+        QuotedIDFactory idfac = new SQLServerQuotedIDFactory();
+
+        ApproximateSelectQueryAttributeExtractor aex = new ApproximateSelectQueryAttributeExtractor(idfac);
+
+        ImmutableList<QuotedID> res = aex.getAttributes("SELECT\n" +
+                "                    measurement_id,\n" +
+                "                    m.value_as_number [value],\n" +
+                "                    unit_c.concept_code unit,\n" +
+                "                    unit_c.concept_code code\n" +
+                "                FROM\n" +
+                "                    measurement m\n" +
+                "                    LEFT JOIN concept unit_c ON unit_c.concept_id = m.unit_concept_id\n" +
+                "                    AND unit_c.concept_id != 0"
+        );
+        assertEquals(ImmutableList.of(
+                idfac.createAttributeID("measurement_id"),
+                idfac.createAttributeID("value"),
+                idfac.createAttributeID("unit"),
+                idfac.createAttributeID("code")), res);
     }
 
     // issue 366

--- a/test/docker-tests/src/test/java/it/unibz/inf/ontop/docker/mssql/MsSQLIdentifierTest.java
+++ b/test/docker-tests/src/test/java/it/unibz/inf/ontop/docker/mssql/MsSQLIdentifierTest.java
@@ -68,4 +68,18 @@ public class MsSQLIdentifierTest extends AbstractVirtualModeTest {
 		String val = runQueryAndReturnStringOfIndividualX(query);
 		assertEquals("<http://www.semanticweb.org/ontologies/2013/7/untitled-ontology-150#Country4-111>", val);
 	}
+
+	@Test
+	public void testAliasQuotedCaseInsensitive() throws Exception {
+		String query = "PREFIX : <http://www.semanticweb.org/ontologies/2013/7/untitled-ontology-150#> SELECT ?x WHERE {?x a :Country5} ORDER BY ?x";
+		String val = runQueryAndReturnStringOfIndividualX(query);
+		assertEquals("<http://www.semanticweb.org/ontologies/2013/7/untitled-ontology-150#Country5-211>", val);
+	}
+
+	@Test
+	public void testAliasUnquotedCaseInsensitive() throws Exception {
+		String query = "PREFIX : <http://www.semanticweb.org/ontologies/2013/7/untitled-ontology-150#> SELECT ?x WHERE {?x a :Country6} ORDER BY ?x";
+		String val = runQueryAndReturnStringOfIndividualX(query);
+		assertEquals("<http://www.semanticweb.org/ontologies/2013/7/untitled-ontology-150#Country6-211>", val);
+	}
 }

--- a/test/docker-tests/src/test/resources/mssql/identifiers-mssql.obda
+++ b/test/docker-tests/src/test/resources/mssql/identifiers-mssql.obda
@@ -19,6 +19,13 @@ mappingId	Countries4
 target		:Country4-{investor} a :Country4 .
 source		select [id] as [investor], name, lastname, dateofbirth, ssn from person
 
+mappingId	Countries5
+target		:Country5-{id} a :Country5 .
+source		select [Id] from company
+
+mappingId	Countries6
+target		:Country6-{id} a :Country6 .
+source		select Id from company
 
 
 ]]

--- a/test/docker-tests/src/test/resources/mssql/identifiers.owl
+++ b/test/docker-tests/src/test/resources/mssql/identifiers.owl
@@ -36,6 +36,9 @@
     <Declaration>
         <Class IRI="#Country5"/>
     </Declaration>
+    <Declaration>
+        <Class IRI="#Country6"/>
+    </Declaration>
 </Ontology>
 
 


### PR DESCRIPTION
MS SQL Server identifiers are not case-sensitive (even if quoted).

The keyword `AS` for introducing column aliases is optional. The updated approximate column name extraction now allows that.