### PR TITLE
Allow IRI decomposition with more than 1 argument when some arguments are nullable

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/ANRTutelleTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/ANRTutelleTest.java
@@ -1,0 +1,44 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ANRTutelleTest extends AbstractRDF4JTest {
+
+    private static final String OBDA_FILE = "/anr-tutelle/mapping.obda";
+    private static final String SQL_SCRIPT = "/anr-tutelle/database.sql";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+    @Test
+    public void testQuery() {
+        var query = "prefix ex: <http://example.org/>\n" +
+                "\n" +
+                "select * where {\n" +
+                "  ?partner ex:tutelle ?t.\n" +
+                "  OPTIONAL { \n" +
+                "     ?t ex:name ?name \n" +
+                "  }\n" +
+                "}";
+        int count = runQueryAndCount(query);
+        assertEquals(2, count);
+
+        var sql = reformulateIntoNativeQuery(query).toLowerCase();
+        assertFalse("The left-join should have been optimized out:\n " + sql,sql.contains("left"));
+    }
+
+}

--- a/binding/rdf4j/src/test/resources/anr-tutelle/database.sql
+++ b/binding/rdf4j/src/test/resources/anr-tutelle/database.sql
@@ -1,0 +1,7 @@
+create table tutelle (
+                         partner_id varchar unique not null,
+                         tutelle_name text,
+                         tutelle_category text);
+
+insert into tutelle (partner_id, tutelle_name, tutelle_category) values ('x1', 'univ-1', 'univ');
+insert into tutelle (partner_id, tutelle_name, tutelle_category) values ('x2', 'univ-1', 'univ');

--- a/binding/rdf4j/src/test/resources/anr-tutelle/mapping.obda
+++ b/binding/rdf4j/src/test/resources/anr-tutelle/mapping.obda
@@ -1,0 +1,12 @@
+[PrefixDeclaration]
+ex: http://example.org/
+
+[MappingDeclaration] @collection [[
+mappingId	map1
+target		ex:partner/{partner_id} ex:tutelle ex:tutelle/{tutelle_name}/{tutelle_category} .
+source		SELECT * FROM tutelle
+
+mappingId	map2
+target		ex:tutelle/{tutelle_name}/{tutelle_category} ex:name {tutelle_name} .
+source		SELECT * FROM tutelle
+]]

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/ObjectStringTemplateFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/ObjectStringTemplateFunctionSymbolImpl.java
@@ -328,11 +328,11 @@ public abstract class ObjectStringTemplateFunctionSymbolImpl extends FunctionSym
     }
 
     @Override
-    protected boolean canBeSafelyDecomposedIntoConjunction(ImmutableList<? extends ImmutableTerm> terms,
-                                                           VariableNullability variableNullability,
-                                                           ImmutableList<? extends ImmutableTerm> otherTerms) {
+    protected Decomposability testDecomposabilityIntoConjunction(ImmutableList<? extends ImmutableTerm> terms,
+                                                         VariableNullability variableNullability,
+                                                         ImmutableList<? extends ImmutableTerm> otherTerms) {
         if (isAlwaysInjectiveInTheAbsenceOfNonInjectiveFunctionalTerms())
-            return canBeSafelyDecomposedIntoConjunctionWhenInjective(terms, variableNullability, otherTerms);
+            return testDecomposabilityIntoConjunctionWhenInjective(terms, variableNullability, otherTerms);
 
         ImmutableSet<Integer> columnPositions = IntStream.range(0, components.size())
                 .filter(i -> components.get(i).isColumnNameReference())
@@ -341,7 +341,7 @@ public abstract class ObjectStringTemplateFunctionSymbolImpl extends FunctionSym
 
         // Needs to have a separator between variables
         if (columnPositions.stream().anyMatch(i -> columnPositions.contains(i+1)))
-            return false;
+            return Decomposability.CANNOT_BE_DECOMPOSED;
 
         ImmutableSet<Integer> separatorPositions = IntStream.range(0, components.size())
                 .filter(i -> !components.get(i).isColumnNameReference())
@@ -351,16 +351,16 @@ public abstract class ObjectStringTemplateFunctionSymbolImpl extends FunctionSym
         // TODO: remove this restriction and tolerates consecutive separators
         if (IntStream.range(0, components.size() - 1)
                 .anyMatch(i -> separatorPositions.contains(i) && separatorPositions.contains(i+1)))
-            return false;
+            return Decomposability.CANNOT_BE_DECOMPOSED;
 
         if (separatorPositions.stream()
                 // Only those separating columns
                 .filter(i -> columnPositions.contains(i-1) && columnPositions.contains(i+1))
                 .allMatch(i -> isSafelySeparating(i, terms, otherTerms))) {
-            return canBeSafelyDecomposedIntoConjunctionWhenInjective(terms, variableNullability, otherTerms);
+            return testDecomposabilityIntoConjunctionWhenInjective(terms, variableNullability, otherTerms);
         }
 
-        return false;
+        return Decomposability.CANNOT_BE_DECOMPOSED;
     }
 
     private boolean isSafelySeparating(int separatorIndex, ImmutableList<? extends ImmutableTerm> terms,

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/RDFTermFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/RDFTermFunctionSymbolImpl.java
@@ -156,10 +156,10 @@ public class RDFTermFunctionSymbolImpl extends FunctionSymbolImpl implements RDF
      * TODO: stop overriding (only use the top implementation)
      */
     @Override
-    protected boolean canBeSafelyDecomposedIntoConjunction(ImmutableList<? extends ImmutableTerm> terms,
-                                                           VariableNullability variableNullability,
-                                                           ImmutableList<? extends ImmutableTerm> otherTerms) {
-        return true;
+    protected Decomposability testDecomposabilityIntoConjunction(ImmutableList<? extends ImmutableTerm> terms,
+                                                         VariableNullability variableNullability,
+                                                         ImmutableList<? extends ImmutableTerm> otherTerms) {
+        return Decomposability.NO_WRAPPING_NEEDED;
     }
 
     /**


### PR DESCRIPTION
Useful when dealing with denormalized data. See `ANRTutelleTest` for an example.

Now wraps into an IF-ELSE-NULL expression if some arguments are nullable. The IF-ELSE-NULL typically gets later on simplified in a 2VL context.