### PR TITLE
Partial support for FILTER NOT EXISTS

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/NotExistsTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/NotExistsTest.java
@@ -1,0 +1,119 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+
+public class NotExistsTest extends AbstractRDF4JTest {
+    private static final String OBDA_FILE = "/person/person_not_exists.obda";
+    private static final String SQL_SCRIPT = "/person/person_not_exists.sql";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void notExistsTest() {
+        String sparql = "PREFIX  : <http://person.example.org/> \n" +
+                "\n" +
+                "SELECT ?v\n" +
+                "WHERE \n" +
+                "{\n" +
+                "    ?v a :Person .\n" +
+                "    FILTER NOT EXISTS { ?v :firstName ?fname }\n" +
+                "}\n";
+
+        runQueryAndCompare(sparql, ImmutableSet.of("http://person.example.org/person/3", "http://person.example.org/person/4"));
+    }
+
+    @Ignore("Non overlapping variables are not supported")
+    @Test
+    public void testNonOverlappingVariables() {
+        String sparql = "SELECT * \n" +
+                "WHERE { ?s ?p ?o \n" +
+                "         FILTER NOT EXISTS { ?x ?y ?z } \n" +
+                "}\n";
+        int countResults = runQueryAndCount(sparql);
+        assertEquals(0, countResults);
+    }
+
+    @Test
+    public void testFilterConstants() {
+        String sparql = "PREFIX : <http://person.example.org/>\n" +
+                "\n" +
+                "SELECT ?v \n" +
+                "WHERE { ?v :firstName ?fname ; \n" +
+                "       FILTER NOT EXISTS { :1 :firstName ?fname } \n" +
+                "}\n";
+        runQueryAndCompare(sparql, ImmutableSet.of("http://person.example.org/person/2"));
+    }
+
+    @Ignore("Variables in the not exists condition must be defined in the filter itself")
+    @Test
+    public void testFilterUnboundVariable() {
+        String sparql = "PREFIX : <http://person.example.org/>\n" +
+                "SELECT ?v WHERE {\n" +
+                "        ?v :firstName ?fname .\n" +
+                "        FILTER NOT EXISTS {\n" +
+                "                ?v :nickname ?nick .\n" +
+                "                FILTER(?fname = ?nick)\n" +
+                "        }\n" +
+                "}";
+        runQueryAndCompare(sparql, ImmutableSet.of("http://person.example.org/person/1"));
+    }
+
+    @Test
+    public void testFilterSharedConstants() {
+        String sparql = "PREFIX : <http://person.example.org/>\n" +
+                "SELECT ?v WHERE {\n" +
+                "    ?v a :Person ;\n" +
+                "        :firstName \"Roger\" .\n" +
+                "   FILTER NOT EXISTS {\n" +
+                "       ?v :firstName ?fname .\n" +
+                "       FILTER (?fname NOT IN (\"Roger\", \"Paul\"))\n" +
+                "    }\n" +
+                "}\n";
+        runQueryAndCompare(sparql, ImmutableSet.of("http://person.example.org/person/1"));
+    }
+
+    @Test
+    public void testGraphPatternFilterOrder() {
+        String sparql = "PREFIX : <http://person.example.org/>\n" +
+                "\n" +
+                "SELECT ?v ?lname\n" +
+                "WHERE \n" +
+                "{\n" +
+                "    ?v a :Person .\n" +
+                "    FILTER NOT EXISTS { ?v :firstName ?fname }\n" +
+                "    ?v :lastName ?lname\n" +
+                "}\n";
+        runQueryAndCompare(sparql, ImmutableSet.of("http://person.example.org/person/3"));
+    }
+
+    @Test
+    public void testSharedVariables() {
+        String sparql = "PREFIX : <http://person.example.org/>\n" +
+                "\n" +
+                "SELECT ?v \n" +
+                "WHERE \n" +
+                "{\n" +
+                "    ?v a :Person .\n" +
+                "    FILTER NOT EXISTS { ?person :firstName ?sharedName }\n" +
+                "    ?v :nickname ?sharedName\n" +
+                "}\n";
+        runQueryAndCompare(sparql, ImmutableSet.of("http://person.example.org/person/1", "http://person.example.org/person/3", "http://person.example.org/person/4"));
+    }
+}

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/NotExistsTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/NotExistsTest.java
@@ -50,6 +50,7 @@ public class NotExistsTest extends AbstractRDF4JTest {
         assertEquals(0, countResults);
     }
 
+    @Ignore("Constants subjects in the not exists condition are not supported")
     @Test
     public void testFilterConstants() {
         String sparql = "PREFIX : <http://person.example.org/>\n" +

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/NotExistsTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/NotExistsTest.java
@@ -62,8 +62,8 @@ public class NotExistsTest extends AbstractRDF4JTest {
         runQueryAndCompare(sparql, ImmutableSet.of("http://person.example.org/person/2"));
     }
 
-    @Ignore("At least one variable must be present in the not exists graph pattern")
-    @Test
+    // Not supported (no present in the not exists graph pattern)
+    @Test(expected = QueryEvaluationException.class)
     public void testFilterConstants2() {
         String sparql = "PREFIX : <http://person.example.org/>\n" +
                 "\n" +

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/NotExistsTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/NotExistsTest.java
@@ -1,6 +1,7 @@
 package it.unibz.inf.ontop.rdf4j.repository;
 
 import com.google.common.collect.ImmutableSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -39,8 +40,8 @@ public class NotExistsTest extends AbstractRDF4JTest {
         runQueryAndCompare(sparql, ImmutableSet.of("http://person.example.org/person/3", "http://person.example.org/person/4"));
     }
 
-    @Ignore("Non overlapping variables are not supported")
-    @Test
+    // Non overlapping variables are not supported
+    @Test(expected = QueryEvaluationException.class)
     public void testNonOverlappingVariables() {
         String sparql = "SELECT * \n" +
                 "WHERE { ?s ?p ?o \n" +
@@ -74,8 +75,8 @@ public class NotExistsTest extends AbstractRDF4JTest {
         assertEquals(0, countResults);
     }
 
-    @Ignore("The inner filter variables must be bound in the not exists graph pattern")
-    @Test
+    // The inner filter variables not bound in the not exists graph pattern is not supported
+    @Test(expected = QueryEvaluationException.class)
     public void testFilterUnboundVariable() {
         String sparql = "PREFIX : <http://person.example.org/>\n" +
                 "SELECT ?v WHERE {\n" +
@@ -128,5 +129,20 @@ public class NotExistsTest extends AbstractRDF4JTest {
                 "    ?v :nickname ?sharedName\n" +
                 "}\n";
         runQueryAndCompare(sparql, ImmutableSet.of("http://person.example.org/person/1", "http://person.example.org/person/3", "http://person.example.org/person/4"));
+    }
+
+    // Not yet supported
+    @Test(expected = QueryEvaluationException.class)
+    public void testNullableOrTheRight() {
+        String sparql = "PREFIX : <http://person.example.org/>\n" +
+                "\n" +
+                "SELECT ?v \n" +
+                "WHERE \n" +
+                "{\n" +
+                "    ?v a :Person .\n" +
+                "    FILTER NOT EXISTS { ?person a :Person . OPTIONAL { ?person :locality ?sharedName } }\n" +
+                "    ?v :nickname ?sharedName\n" +
+                "}\n";
+        runQueryAndCompare(sparql, ImmutableSet.of());
     }
 }

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/NotExistsTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/NotExistsTest.java
@@ -50,19 +50,31 @@ public class NotExistsTest extends AbstractRDF4JTest {
         assertEquals(0, countResults);
     }
 
-    @Ignore("Constants subjects in the not exists condition are not supported")
     @Test
-    public void testFilterConstants() {
+    public void testFilterConstants1() {
         String sparql = "PREFIX : <http://person.example.org/>\n" +
                 "\n" +
                 "SELECT ?v \n" +
                 "WHERE { ?v :firstName ?fname ; \n" +
-                "       FILTER NOT EXISTS { :1 :firstName ?fname } \n" +
+                "       FILTER NOT EXISTS { <http://person.example.org/person/1> :firstName ?fname } \n" +
                 "}\n";
         runQueryAndCompare(sparql, ImmutableSet.of("http://person.example.org/person/2"));
     }
 
-    @Ignore("Variables in the not exists condition must be defined in the filter itself")
+    @Ignore("At least one variable must be present in the not exists graph pattern")
+    @Test
+    public void testFilterConstants2() {
+        String sparql = "PREFIX : <http://person.example.org/>\n" +
+                "\n" +
+                "SELECT ?v \n" +
+                "WHERE { ?v :firstName ?fname ; \n" +
+                "       FILTER NOT EXISTS { <http://person.example.org/person/1> :firstName \"Roger\" } \n" +
+                "}\n";
+        int countResults = runQueryAndCount(sparql);
+        assertEquals(0, countResults);
+    }
+
+    @Ignore("The inner filter variables must be bound in the not exists graph pattern")
     @Test
     public void testFilterUnboundVariable() {
         String sparql = "PREFIX : <http://person.example.org/>\n" +

--- a/binding/rdf4j/src/test/resources/person/person_not_exists.obda
+++ b/binding/rdf4j/src/test/resources/person/person_not_exists.obda
@@ -1,0 +1,17 @@
+[PrefixDeclaration]
+:		http://person.example.org/
+owl:		http://www.w3.org/2002/07/owl#
+rdf:		http://www.w3.org/1999/02/22-rdf-syntax-ns#
+xml:		http://www.w3.org/XML/1998/namespace
+xsd:		http://www.w3.org/2001/XMLSchema#
+obda:		https://w3id.org/obda/vocabulary#
+rdfs:		http://www.w3.org/2000/01/rdf-schema#
+quest:		http://obda.org/quest#
+
+[MappingDeclaration] @collection [[
+mappingId	MAPID-person
+target		:person/{id} a :Person ; :firstName {firstName} ; :lastName {lastName} ; :nickname {nickname} ; :country {country} ; :locality {locality} .
+source		SELECT "id", "firstName", "lastName", "nickname", "country", "locality" FROM "person";
+
+]]
+

--- a/binding/rdf4j/src/test/resources/person/person_not_exists.sql
+++ b/binding/rdf4j/src/test/resources/person/person_not_exists.sql
@@ -1,0 +1,22 @@
+create table "person" (
+                          "id" int primary key,
+                          "firstName" varchar(100),
+                          "lastName" varchar(100),
+                          "nickname" varchar(100),
+                          "status" int NOT NULL,
+                          "country" varchar(100) NOT NULL,
+                          "locality" varchar(100)
+);
+
+insert into "person" ("id", "firstName", "lastName", "nickname", "status", "country", "locality") values (1, 'Roger', 'Smith', 'Roger Smith', 1, 'it', NULL);
+insert into "person" ("id", "firstName", "lastName", "nickname", "status", "country", "locality") values (2, 'John', NULL, 'John',0, 'uk', 'Belfast');
+insert into "person" ("id", "firstName", "lastName", "nickname", "status", "country", "locality") values (3, NULL, 'Doe', 'Jane Doe', 0, 'ie', 'Dublin');
+insert into "person" ("id", "firstName", "lastName", "nickname", "status", "country", "locality") values (4, NULL, NULL, 'Corto Maltese', 0, 'mt', 'Valletta');
+
+create table "statuses" (
+                            "status_id" int primary key,
+                            "description" varchar(100) NOT NULL
+);
+
+insert into "statuses" ("status_id", "description") values (1, 'OK');
+

--- a/core/kg-query/src/main/java/it/unibz/inf/ontop/query/translation/impl/RDF4JTupleExprTranslator.java
+++ b/core/kg-query/src/main/java/it/unibz/inf/ontop/query/translation/impl/RDF4JTupleExprTranslator.java
@@ -349,7 +349,7 @@ public class RDF4JTupleExprTranslator {
         }
 
         if (sharedVariables.stream().allMatch(v -> v.isNullable(leftTranslation.nullableVariables)
-                && v.isNullable(rightTranslation.nullableVariables))) {
+                || v.isNullable(rightTranslation.nullableVariables))) {
             throw new OntopUnsupportedKGQueryException("The NOT EXISTS operator is not supported when there is no non-nullable common variable");
         }
 

--- a/test/sparql-compliance/src/test/java/it/unibz/inf/ontop/test/sparql11/MemorySPARQL11QueryTest.java
+++ b/test/sparql-compliance/src/test/java/it/unibz/inf/ontop/test/sparql11/MemorySPARQL11QueryTest.java
@@ -62,8 +62,6 @@ public class MemorySPARQL11QueryTest extends MemoryOntopTestCase {
 			constructManifest + "constructwhere04", // CONSTRUCT FROM <data.ttl> not supported by the SPARQL-to-IQ translation
 
 			/* NEGATION */
-            negationManifest + "subset-by-exclusion-nex-1", // EXISTS not supported by the SPARQL-to-IQ translation
-			negationManifest + "temporal-proximity-by-exclusion-nex-1", // EXISTS not supported by the SPARQL-to-IQ translation
 			negationManifest + "subset-01", // EXISTS not supported by the SPARQL-to-IQ translation
 			negationManifest + "subset-02", // EXISTS not supported by the SPARQL-to-IQ translation
 			negationManifest + "set-equals-1", // EXISTS not supported by the SPARQL-to-IQ translation


### PR DESCRIPTION
The `FILTER NOT EXISTS` clause is currently not supported since from an algebraic point of view it is evaluated in a top-down manner, while Ontop evaluates queries with a bottom-up approach.

 However, in the majority of cases, the `FILTER NOT EXISTS` clause can be replaced by a `MINUS` clause which instead can be evaluated in a bottom-up manner. The differences between the two are discussed in the [SPARQL 1.1 specification](https://www.w3.org/TR/sparql11-query/#neg-notexists-minus) but in general, the two are not equivalent when:
- No non-nullable variables are shared between the left and right side of the `FILTER NOT EXISTS` clause.
- Inner filters  in the `FILTER NOT EXISTS` involving variables not in its scope. For example, the following query
    ```sparql
    PREFIX : <http://example.com/>
    SELECT * WHERE {
            ?x :p ?n
            FILTER NOT EXISTS {
                    ?x :q ?m .
                    FILTER(?n = ?m)
            }
    }
    ```
    cannot be translated into a `MINUS` clause since in a bottom-up parsing, the filter `?n = ?m` cannot be evaluated since `?n` is not bound.

The `MINUS` is translated in an `IQTree` using a `LEFT JOIN` followed by a `FILTER` checking whether a variable unique to the right side of the join is `NULL`. Additionally, it is also required that at least one of the shared variables between the left and right child of the left join is non nullable.

For example, the following query:
```sparql
PREFIX : <http://www.example.org/>
SELECT ?person
WHERE {
  ?person a :Person .
  FILTER NOT EXISTS { ?person :firstName ?fname }
}
```
is translated into the following `IQTree`:
```
CONSTRUCT [person] []
   FILTER IS_NULL(fname)
      LJ
         CONSTRUCT [person] [person/RDF(http://person.example.org/person/{}(INTEGERToTEXT(id1m1)),IRI)]
            EXTENSIONAL "person"(0:id1m1)
         CONSTRUCT [person, fname] [person/RDF(http://person.example.org/person/{}(INTEGERToTEXT(id1m2)),IRI), fname/RDF(CHARACTER VARYINGToTEXT(firstName1m2),xsd:string)]
            FILTER IS_NOT_NULL(firstName1m2)
               EXTENSIONAL "person"(0:id1m2,1:firstName1m2)
```

