### PR TITLE
Arity violation issue

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/Issue858Test.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/Issue858Test.java
@@ -1,0 +1,44 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class Issue858Test extends AbstractRDF4JTest {
+    private static final String OBDA_FILE = "/issue858/mapping.obda";
+    private static final String SQL_FILE = "/issue858/db.sql";
+
+    @BeforeClass
+    public static void before() throws Exception {
+        initOBDA(SQL_FILE, OBDA_FILE);
+    }
+
+    @AfterClass
+    public static void after() throws Exception {
+        release();
+    }
+
+    @Test
+    public void testQueryWorking() {
+        String sparql =
+                "PREFIX ex: <http://example.org/>\n" +
+                        "SELECT * WHERE {\n" +
+                        "  ?s ?p ?o .\n" +
+                        "}";
+        int count = runQueryAndCount(sparql);
+        assertEquals(1, count);
+    }
+
+    @Test
+    public void testQueryError() {
+        String sparql =
+                "PREFIX ex: <http://example.org/>\n" +
+                        "SELECT * WHERE {\n" +
+                        "  <http://eg.com/something> ?p ?o .\n" +
+                        "}";
+        int count = runQueryAndCount(sparql);
+        assertEquals(0, count);
+    }
+}

--- a/binding/rdf4j/src/test/resources/issue858/db.sql
+++ b/binding/rdf4j/src/test/resources/issue858/db.sql
@@ -1,0 +1,63 @@
+CREATE TABLE "ingredientevents" (
+    "subject_id" INTEGER,
+    "hadm_id" INTEGER,
+    "stay_id" INTEGER,
+    "caregiver_id" INTEGER,
+    "starttime" TIMESTAMP,
+    "endtime" TIMESTAMP,
+    "storetime" TIMESTAMP,
+    "itemid" INTEGER,
+    "amount" REAL,
+    "amountuom" TEXT,
+    "rate" REAL,
+    "rateuom" TEXT,
+    "orderid" INTEGER,
+    "linkorderid" INTEGER,
+    "statusdescription" TEXT,
+    "originalamount" REAL,
+    "originalrate" REAL
+);
+
+INSERT INTO "ingredientevents" (
+    "subject_id",
+    "hadm_id",
+    "stay_id",
+    "caregiver_id",
+    "starttime",
+    "endtime",
+    "storetime",
+    "itemid",
+    "amount",
+    "amountuom",
+    "rate",
+    "rateuom",
+    "orderid",
+    "linkorderid",
+    "statusdescription",
+    "originalamount",
+    "originalrate"
+) VALUES (
+    1,
+    1,
+    1,
+    1,
+    '2023-10-01 00:00:00',
+    '2023-10-01 01:00:00',
+    '2023-10-01 02:00:00',
+    1,
+    100.0,
+    'mg',
+    10.0,
+    'ml/h',
+    1,
+    1,
+    'active',
+    100.0,
+    10.0
+);
+
+CREATE TABLE "patients" (
+    "subject_id" INTEGER);
+
+INSERT INTO "patients" ("subject_id") VALUES (1);
+

--- a/binding/rdf4j/src/test/resources/issue858/mapping.obda
+++ b/binding/rdf4j/src/test/resources/issue858/mapping.obda
@@ -1,0 +1,14 @@
+[PrefixDeclaration]
+rdf:        http://www.w3.org/1999/02/22-rdf-syntax-ns#
+rdfs:       http://www.w3.org/2000/01/rdf-schema#
+owl:        http://www.w3.org/2002/07/owl#
+xsd:        http://www.w3.org/2001/XMLSchema#
+obda:       https://w3id.org/obda/vocabulary#
+
+[MappingDeclaration] @collection [[
+
+mappingId   MAPPING-ID85
+target      _:ontop-bnode-18{ingredientevents_subject_id}/{ingredientevents_hadm_id}/{ingredientevents_stay_id}/{ingredientevents_caregiver_id}/{ingredientevents_starttime}/{ingredientevents_endtime}/{ingredientevents_storetime}/{ingredientevents_itemid}/{ingredientevents_amount}/{ingredientevents_amountuom}/{ingredientevents_rate}/{ingredientevents_rateuom}/{ingredientevents_orderid}/{ingredientevents_linkorderid}/{ingredientevents_statusdescription}/{ingredientevents_originalamount}/{ingredientevents_originalrate} <http://eg.com/ingredientevents#ref-subject_id> <http://eg.com/patients/subject_id={patients_subject_id}> .
+source      SELECT "ingredientevents"."subject_id" AS "ingredientevents_subject_id", "ingredientevents"."hadm_id" AS "ingredientevents_hadm_id", "ingredientevents"."stay_id" AS "ingredientevents_stay_id", "ingredientevents"."caregiver_id" AS "ingredientevents_caregiver_id", "ingredientevents"."starttime" AS "ingredientevents_starttime", "ingredientevents"."endtime" AS "ingredientevents_endtime", "ingredientevents"."storetime" AS "ingredientevents_storetime", "ingredientevents"."itemid" AS "ingredientevents_itemid", "ingredientevents"."amount" AS "ingredientevents_amount", "ingredientevents"."amountuom" AS "ingredientevents_amountuom", "ingredientevents"."rate" AS "ingredientevents_rate", "ingredientevents"."rateuom" AS "ingredientevents_rateuom", "ingredientevents"."orderid" AS "ingredientevents_orderid", "ingredientevents"."linkorderid" AS "ingredientevents_linkorderid", "ingredientevents"."statusdescription" AS "ingredientevents_statusdescription", "ingredientevents"."originalamount" AS "ingredientevents_originalamount", "ingredientevents"."originalrate" AS "ingredientevents_originalrate", "patients"."subject_id" AS "patients_subject_id" FROM "ingredientevents", "patients" WHERE "ingredientevents"."subject_id" = "patients"."subject_id"
+
+]]

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractOrNullFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractOrNullFunctionSymbol.java
@@ -21,6 +21,7 @@ import java.util.stream.IntStream;
 public abstract class AbstractOrNullFunctionSymbol extends DBBooleanFunctionSymbolImpl {
 
     private final boolean possibleBoolean;
+    private final DBTermType dbBooleanType;
 
     protected AbstractOrNullFunctionSymbol(@Nonnull String name, int arity, DBTermType dbBooleanTermType,
                                            boolean possibleBoolean) {
@@ -28,6 +29,7 @@ public abstract class AbstractOrNullFunctionSymbol extends DBBooleanFunctionSymb
                 .mapToObj(i -> dbBooleanTermType)
                 .collect(ImmutableCollectors.toList()), dbBooleanTermType);
         this.possibleBoolean = possibleBoolean;
+        this.dbBooleanType = dbBooleanTermType;
         if (arity <= 0)
             throw new IllegalArgumentException("Arity must be >= 1");
     }
@@ -74,9 +76,13 @@ public abstract class AbstractOrNullFunctionSymbol extends DBBooleanFunctionSymb
                 .map(t -> (ImmutableExpression) t)
                 .collect(ImmutableCollectors.toList());
 
-        return remainingExpressions.isEmpty()
-                ? termFactory.getNullConstant()
-                : termFactory.getImmutableExpression(this, remainingExpressions);
+        if (remainingExpressions.isEmpty())
+            return termFactory.getNullConstant();
+
+        int newArity = remainingExpressions.size();
+        return possibleBoolean
+                ? termFactory.getImmutableExpression(new TrueOrNullFunctionSymbolImpl(newArity, dbBooleanType), remainingExpressions)
+                : termFactory.getImmutableExpression(new FalseOrNullFunctionSymbolImpl(newArity, dbBooleanType), remainingExpressions);
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractOrNullFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractOrNullFunctionSymbol.java
@@ -21,7 +21,6 @@ import java.util.stream.IntStream;
 public abstract class AbstractOrNullFunctionSymbol extends DBBooleanFunctionSymbolImpl {
 
     private final boolean possibleBoolean;
-    private final DBTermType dbBooleanType;
 
     protected AbstractOrNullFunctionSymbol(@Nonnull String name, int arity, DBTermType dbBooleanTermType,
                                            boolean possibleBoolean) {
@@ -29,7 +28,6 @@ public abstract class AbstractOrNullFunctionSymbol extends DBBooleanFunctionSymb
                 .mapToObj(i -> dbBooleanTermType)
                 .collect(ImmutableCollectors.toList()), dbBooleanTermType);
         this.possibleBoolean = possibleBoolean;
-        this.dbBooleanType = dbBooleanTermType;
         if (arity <= 0)
             throw new IllegalArgumentException("Arity must be >= 1");
     }
@@ -58,31 +56,6 @@ public abstract class AbstractOrNullFunctionSymbol extends DBBooleanFunctionSymb
     @Override
     public boolean canBePostProcessed(ImmutableList<? extends ImmutableTerm> arguments) {
         return true;
-    }
-
-    @Override
-    protected ImmutableTerm buildTermAfterEvaluation(ImmutableList<ImmutableTerm> newTerms,
-                                                     TermFactory termFactory, VariableNullability variableNullability) {
-        DBConstant possibleBooleanConstant = termFactory.getDBBooleanConstant(possibleBoolean);
-        if (newTerms.stream()
-                .anyMatch(possibleBooleanConstant::equals))
-            return possibleBooleanConstant;
-
-        /*
-         * We don't care about other constants
-         */
-        ImmutableList<ImmutableExpression> remainingExpressions = newTerms.stream()
-                .filter(t -> (t instanceof ImmutableExpression))
-                .map(t -> (ImmutableExpression) t)
-                .collect(ImmutableCollectors.toList());
-
-        if (remainingExpressions.isEmpty())
-            return termFactory.getNullConstant();
-
-        int newArity = remainingExpressions.size();
-        return possibleBoolean
-                ? termFactory.getImmutableExpression(new TrueOrNullFunctionSymbolImpl(newArity, dbBooleanType), remainingExpressions)
-                : termFactory.getImmutableExpression(new FalseOrNullFunctionSymbolImpl(newArity, dbBooleanType), remainingExpressions);
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/TrueOrNullFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/TrueOrNullFunctionSymbolImpl.java
@@ -1,19 +1,20 @@
 package it.unibz.inf.ontop.model.term.functionsymbol.db.impl;
 
 import com.google.common.collect.ImmutableList;
-import it.unibz.inf.ontop.model.term.ImmutableExpression;
-import it.unibz.inf.ontop.model.term.ImmutableFunctionalTerm;
-import it.unibz.inf.ontop.model.term.ImmutableTerm;
-import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.model.term.functionsymbol.db.TrueOrNullFunctionSymbol;
 import it.unibz.inf.ontop.model.type.DBTermType;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
 
 import java.util.function.Function;
 
 public class TrueOrNullFunctionSymbolImpl extends AbstractOrNullFunctionSymbol implements TrueOrNullFunctionSymbol {
+    private final DBTermType dbBooleanType;
 
     protected TrueOrNullFunctionSymbolImpl(int arity, DBTermType dbBooleanTermType) {
         super("TRUE_OR_NULL" + arity, arity, dbBooleanTermType, true);
+        this.dbBooleanType = dbBooleanTermType;
     }
 
     @Override
@@ -23,5 +24,29 @@ public class TrueOrNullFunctionSymbolImpl extends AbstractOrNullFunctionSymbol i
 
         ImmutableFunctionalTerm newExpression = termFactory.getBooleanIfElseNull(condition, termFactory.getIsTrue(termFactory.getDBBooleanConstant(true)));
         return termConverter.apply(newExpression);
+    }
+
+    @Override
+    protected ImmutableTerm buildTermAfterEvaluation(ImmutableList<ImmutableTerm> newTerms,
+                                                     TermFactory termFactory, VariableNullability variableNullability) {
+        DBConstant trueConstant = termFactory.getDBBooleanConstant(true);
+        if (newTerms.stream()
+                .anyMatch(trueConstant::equals))
+            return trueConstant;
+
+        /*
+         * We don't care about other constants
+         */
+        ImmutableList<ImmutableExpression> remainingExpressions = newTerms.stream()
+                .filter(t -> (t instanceof ImmutableExpression))
+                .map(t -> (ImmutableExpression) t)
+                .collect(ImmutableCollectors.toList());
+
+        int newArity = remainingExpressions.size();
+        return remainingExpressions.isEmpty()
+                ? termFactory.getNullConstant()
+                : termFactory.getImmutableExpression(
+                        new TrueOrNullFunctionSymbolImpl(newArity, dbBooleanType),
+                remainingExpressions);
     }
 }


### PR DESCRIPTION
This PR fixes issue #858.

The problem was that when building `AbstractOrNullFunctionSymbol`, terms that were simplified to either `true` or `false` constants were removed but the function arity was not updated, causing the function to expect more arguments than those actually present.