### PR TITLE
Recognize H2 system tables

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/H2DBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/H2DBMetadataProvider.java
@@ -2,6 +2,7 @@ package it.unibz.inf.ontop.dbschema.impl;
 
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import it.unibz.inf.ontop.dbschema.RelationID;
 import it.unibz.inf.ontop.exception.MetadataExtractionException;
 import it.unibz.inf.ontop.injection.CoreSingletons;
 
@@ -15,5 +16,10 @@ public class H2DBMetadataProvider extends DefaultSchemaCatalogDBMetadataProvider
                "SELECT DATABASE() AS TABLE_CAT, SCHEMA() AS TABLE_SCHEM");
         // http://www.h2database.com/html/functions.html#current_schema
         // the .getSchema() does work for OntopExtractDBMetadataTest
+    }
+
+    @Override
+    protected boolean isRelationExcluded(RelationID id) {
+        return getRelationSchema(id).equals("INFORMATION_SCHEMA");
     }
 }


### PR DESCRIPTION
This PR identifies the H2 system tables present in the `INFORMATION_SCHEMA` so that they can be excluded from the tables accessible by Ontop via the `ontop.exposeSystemTables` property.
