### PR TITLE
Multi-line target queries in OBDA files

### DIFF
--- a/mapping/sql/all/src/test/java/it/unibz/inf/ontop/spec/mapping/parser/NativeMappingParserTest.java
+++ b/mapping/sql/all/src/test/java/it/unibz/inf/ontop/spec/mapping/parser/NativeMappingParserTest.java
@@ -164,7 +164,14 @@ public class NativeMappingParserTest {
 
     @Test
     public void testLoadConcat() throws Exception {
-        mappingParser.parse(new File(ROOT2 + "mapping-northwind.obda"));
+        var mapping = mappingParser.parse(new File(ROOT2 + "mapping-northwind.obda"));
+        assertEquals(7, mapping.getTripleMaps().get(0).getTargetAtoms().size());
+    }
+
+    @Test
+    public void testLoadMultiline() throws Exception {
+        var mapping = mappingParser.parse(new File(ROOT2 + "mapping-northwind-multiline.obda"));
+        assertEquals(7, mapping.getTripleMaps().get(0).getTargetAtoms().size());
     }
 
     @Test

--- a/mapping/sql/all/src/test/java/it/unibz/inf/ontop/spec/mapping/parser/NativeMappingParserTest.java
+++ b/mapping/sql/all/src/test/java/it/unibz/inf/ontop/spec/mapping/parser/NativeMappingParserTest.java
@@ -88,78 +88,124 @@ public class NativeMappingParserTest {
 
     @Test
     public void testLoadWithBlankMappingId() {
-        assertThrows(InvalidMappingException.class,
-                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile5.obda")),
-                "\n" +
+        var ex = assertThrows(InvalidMappingException.class,
+                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile5.obda")));
+        assertEquals("\n" +
                         "The syntax of the mapping is invalid (and therefore cannot be processed). Problems:\n" +
                         "\n" +
-                        "Line 10: Mapping ID is missing\n");
+                        "Line 10: Mapping ID is missing\n", ex.getMessage());
+    }
+
+    @Test
+    public void testLoadMultilineWithBlankMappingId() {
+        var ex = assertThrows(InvalidMappingException.class,
+                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile5m.obda")));
+        assertEquals("\n" +
+                        "The syntax of the mapping is invalid (and therefore cannot be processed). Problems:\n" +
+                        "\n" +
+                        "Line 10: Mapping ID is missing\n", ex.getMessage());
     }
 
     @Test
     public void testLoadWithBlankTargetQuery() {
-        assertThrows(InvalidMappingException.class,
-                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile6.obda")),
-                "\n" +
+        var ex = assertThrows(InvalidMappingException.class,
+                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile6.obda")));
+        assertEquals("\n" +
                         "The syntax of the mapping is invalid (and therefore cannot be processed). Problems:\n" +
                         "\n" +
                         "MappingId = 'M2'\n" +
-                        "Line 15: Target is missing\n" +
-                        "\n");
+                        "Line 15: Target query is missing\n", ex.getMessage());
+    }
+
+    @Test
+    public void testLoadWithMissingTargetQuery() {
+        var ex = assertThrows(InvalidMappingException.class,
+                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile6m.obda")));
+        assertEquals("\n" +
+                        "The syntax of the mapping is invalid (and therefore cannot be processed). Problems:\n" +
+                        "\n" +
+                        "MappingId = 'M2'\n" +
+                        "Line 16: Target is missing\n", ex.getMessage());
     }
 
     @Test
     public void testLoadWithBlankSourceQuery()  {
-        assertThrows(InvalidMappingException.class,
-                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile7.obda")),
-                "\n" +
+        var ex = assertThrows(InvalidMappingException.class,
+                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile7.obda")));
+        assertEquals("\n" +
                         "The syntax of the mapping is invalid (and therefore cannot be processed). Problems:\n" +
                         "\n" +
                         "MappingId = 'M3'\n" +
-                        "Line 20: Source query is missing\n" +
-                        "\n");
+                        "Line 20: Source query is missing\n", ex.getMessage());
+    }
+
+    @Test
+    public void testLoadWithMissingSourceQuery()  {
+        var ex = assertThrows(InvalidMappingException.class,
+                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile7m.obda")));
+        assertEquals("\n" +
+                        "The syntax of the mapping is invalid (and therefore cannot be processed). Problems:\n" +
+                        "\n" +
+                        "MappingId = 'M3'\n" +
+                        "Line 24: Source is missing\n", ex.getMessage());
     }
 
     @Test
     public void testLoadWithBadTargetQuery() {
-        assertThrows(InvalidMappingException.class,
-                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile8.obda")),
-                "\n" +
+        var ex = assertThrows(InvalidMappingException.class,
+                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile8.obda")));
+        assertEquals("\n" +
                         "The syntax of the mapping is invalid (and therefore cannot be processed). Problems:\n" +
                         "\n" +
                         "MappingId = 'M1'\n" +
-                        "Line 12: Invalid target: ':P{id} :Student ; :firstName {fname} ; :lastName {lname} ; :age {age}^^xsd:integer .'\n" +
+                        "Line 14: Invalid target: ':P{id} :Student ; :firstName {fname} ; :lastName {lname} ; :age {age}^^xsd:integer .'\n" +
                         "Debug information\n" +
                         "extraneous input ';' expecting {'true', 'false', 'TRUE', 'True', 'FALSE', 'False', ENCLOSED_COLUMN_NAME, IRIREF, PNAME_LN, BLANK_NODE_LABEL, INTEGER, DECIMAL, DOUBLE, STRING_LITERAL_QUOTE, ANON}\n" +
                         "MappingId = 'M2'\n" +
-                        "Line 17: Invalid target: ':C{id} a :Course ; :title {title} ; :hasLecturer :L{id} ; description {description}@en-US .'\n" +
+                        "Line 19: Invalid target: ':C{id} a :Course ; :title {title} ; :hasLecturer :L{id} ; description {description}@en-US .'\n" +
                         "Debug information\n" +
-                        "mismatched input 'description' expecting {'.', ';', 'a', IRIREF, PNAME_LN}\n");
+                        "mismatched input 'description' expecting {'.', ';', 'a', IRIREF, PNAME_LN}", ex.getMessage());
+    }
+
+    @Test
+    public void testLoadWithBadMultilineTargetQuery() {
+        var ex = assertThrows(InvalidMappingException.class,
+                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile8m.obda")));
+        assertEquals("\n" +
+                "The syntax of the mapping is invalid (and therefore cannot be processed). Problems:\n" +
+                "\n" +
+                "MappingId = 'M1'\n" +
+                "Line 17: Invalid target: ':P{id} :Student ; :firstName {fname} ; :lastName {lname} ; :age {age}^^xsd:integer .'\n" +
+                "Debug information\n" +
+                "extraneous input ';' expecting {'true', 'false', 'TRUE', 'True', 'FALSE', 'False', ENCLOSED_COLUMN_NAME, IRIREF, PNAME_LN, BLANK_NODE_LABEL, INTEGER, DECIMAL, DOUBLE, STRING_LITERAL_QUOTE, ANON}\n" +
+                "MappingId = 'M2'\n" +
+                "Line 25: Invalid target: ':C{id} a :Course ; :title {title} ; :hasLecturer :L{id} ; description {description}@en-US .'\n" +
+                "Debug information\n" +
+                "mismatched input 'description' expecting {'.', ';', 'a', IRIREF, PNAME_LN}", ex.getMessage());
     }
 
     @Test
     public void testLoadWithPredicateDeclarations()  {
-        assertThrows(MappingIOException.class,
-                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile9.obda")),
-                "java.io.IOException: ERROR reading SchoolBadFile9.obda at line: 9\n" +
-                        "MESSAGE: The tag [ClassDeclaration] is no longer supported. You may safely remove the content from the file.\n");
+        var ex = assertThrows(MappingIOException.class,
+                () -> mappingParser.parse(new File(ROOT + "SchoolBadFile9.obda")));
+        assertEquals("java.io.IOException: ERROR reading SchoolBadFile9.obda at line: 9\n" +
+                        "MESSAGE: The tag [ClassDeclaration] is no longer supported. You may safely remove the content from the file.", ex.getMessage());
     }
 
     @Test
     public void testLoadWithAllMistakes() {
-            assertThrows(InvalidMappingException.class,
-                    () -> mappingParser.parse(new File(ROOT + "SchoolBadFile10.obda")),
-                    "\n" +
+            var ex = assertThrows(InvalidMappingException.class,
+                    () -> mappingParser.parse(new File(ROOT + "SchoolBadFile10.obda")));
+            assertEquals("\n" +
                             "The syntax of the mapping is invalid (and therefore cannot be processed). Problems:\n" +
                             "\n" +
                             "Line 11: Mapping ID is missing\n" +
                             "\n" +
                             "MappingId = 'M2'\n" +
-                            "Line 17: Target is missing\n" +
+                            "Line 17: Target query is missing\n" +
                             "\n" +
                             "MappingId = 'M3'\n" +
-                            "Line 23: Source query is missing\n" +
-                            "\n");
+                            "Line 23: Source query is missing\n", ex.getMessage());
     }
 
     @Test
@@ -181,10 +227,10 @@ public class NativeMappingParserTest {
 
     @Test
     public void testEndCollectionSymbolRequirement() {
-        assertThrows(MappingIOException.class,
-                () -> mappingParser.parse(new File(ROOT2 + "missingCollectionEnding.obda")),
-                "java.io.IOException: ERROR reading missingCollectionEnding.obda at line: 48\n" +
-                        "MESSAGE: End collection symbol ]] is missing.\n");
+        var ex = assertThrows(MappingIOException.class,
+                () -> mappingParser.parse(new File(ROOT2 + "missingCollectionEnding.obda")));
+        assertEquals("java.io.IOException: ERROR reading missingCollectionEnding.obda at line: 48\n" +
+                        "MESSAGE: End collection symbol ]] is missing.", ex.getMessage());
     }
 
     @Test

--- a/mapping/sql/all/src/test/resources/format/obda/mapping-northwind-multiline.obda
+++ b/mapping/sql/all/src/test/resources/format/obda/mapping-northwind-multiline.obda
@@ -1,0 +1,18 @@
+[PrefixDeclaration]
+xsd:		http://www.w3.org/2001/XMLSchema#
+owl:		http://www.w3.org/2002/07/owl#
+quest:		http://obda.org/quest#
+rdf:		http://www.w3.org/1999/02/22-rdf-syntax-ns#
+rdfs:		http://www.w3.org/2000/01/rdf-schema#
+
+[MappingDeclaration] @collection [[
+mappingId	mapping-356733897
+target		<http://www.optique-project.eu/resource/employeesLocation/{EMPLOYEEID}> a <http://www.optique-project.eu/resource/northwind-h2-db/NORTHWIND/LOCATION> ; 
+                   <http://www.optique-project.eu/resource/northwind-h2-db/NORTHWIND/LOCATION/CITY> {CITY} ; 
+                   rdfs:label "adres: {ADDRESS} \\{city:\\} \\{a:\\}{CITY}country: {COUNTRY} something\\{c:\\}\\{b:\\}"@en-us ; 
+                   <http://www.optique-project.eu/resource/northwind-h2-db/NORTHWIND/LOCATION/COUNTRY> {COUNTRY} ; 
+                   <http://www.optique-project.eu/resource/northwind-h2-db/NORTHWIND/LOCATION/ADDRESS> {ADDRESS} ; 
+                   <http://www.optique-project.eu/resource/northwind-h2-db/NORTHWIND/LOCATION/REGION> {REGION} ; 
+                   <http://www.optique-project.eu/resource/northwind-h2-db/NORTHWIND/LOCATION/POSTALCODE> {POSTALCODE} . 
+source		SELECT * FROM NORTHWIND.EMPLOYEES
+]]

--- a/mapping/sql/all/src/test/resources/it/unibz/inf/ontop/io/SchoolBadFile5m.obda
+++ b/mapping/sql/all/src/test/resources/it/unibz/inf/ontop/io/SchoolBadFile5m.obda
@@ -1,0 +1,25 @@
+[PrefixDeclaration]
+xsd:        http://www.w3.org/2001/XMLSchema#
+owl:        http://www.w3.org/2002/07/owl#
+quest:      http://obda.org/quest#
+:           http://www.semanticweb.org/ontologies/2012/5/Ontology1340973114537.owl#
+rdf:        http://www.w3.org/1999/02/22-rdf-syntax-ns#
+rdfs:       http://www.w3.org/2000/01/rdf-schema#
+
+[MappingDeclaration] @collection [[
+mappingId
+target      :P{id} a :Student ;
+                    :firstName {fname} ;
+                    :lastName {lname} ;
+                    :age {age}^^xsd:integer .
+source      select id, fname, lname, age from student
+
+mappingId   M2
+target      :C{id} a :Course ; :title {title} ; :hasLecturer :L{lecturer} ; :description {description}@en-US .
+source      select id, title, lecturer, description from course
+
+mappingId   M3
+target      :P{sid} :hasEnrollment :C{cid} .
+source      select sid, cid from enrollment
+]]
+

--- a/mapping/sql/all/src/test/resources/it/unibz/inf/ontop/io/SchoolBadFile6m.obda
+++ b/mapping/sql/all/src/test/resources/it/unibz/inf/ontop/io/SchoolBadFile6m.obda
@@ -1,0 +1,21 @@
+[PrefixDeclaration]
+xsd:        http://www.w3.org/2001/XMLSchema#
+owl:        http://www.w3.org/2002/07/owl#
+quest:      http://obda.org/quest#
+:           http://www.semanticweb.org/ontologies/2012/5/Ontology1340973114537.owl#
+rdf:        http://www.w3.org/1999/02/22-rdf-syntax-ns#
+rdfs:       http://www.w3.org/2000/01/rdf-schema#
+
+[MappingDeclaration] @collection [[
+mappingId   M1
+target      :P{id} a :Student ; :firstName {fname} ; :lastName {lname} ; :age {age}^^xsd:integer .
+source      select id, fname, lname, age from student
+
+mappingId   M2
+source      select id, title, lecturer, description from course
+
+mappingId   M3
+target      :P{sid} :hasEnrollment :C{cid} .
+source      select sid, cid from enrollment
+]]
+

--- a/mapping/sql/all/src/test/resources/it/unibz/inf/ontop/io/SchoolBadFile7m.obda
+++ b/mapping/sql/all/src/test/resources/it/unibz/inf/ontop/io/SchoolBadFile7m.obda
@@ -1,0 +1,25 @@
+[PrefixDeclaration]
+xsd:        http://www.w3.org/2001/XMLSchema#
+owl:        http://www.w3.org/2002/07/owl#
+quest:      http://obda.org/quest#
+:           http://www.semanticweb.org/ontologies/2012/5/Ontology1340973114537.owl#
+rdf:        http://www.w3.org/1999/02/22-rdf-syntax-ns#
+rdfs:       http://www.w3.org/2000/01/rdf-schema#
+
+[MappingDeclaration] @collection [[
+mappingId   M1
+target      :P{id} a :Student ; :firstName {fname} ; :lastName {lname} ; :age {age}^^xsd:integer .
+source      select id, fname, lname, age
+                from student
+
+mappingId   M2
+target      :C{id} a :Course ; :title {title} ; :hasLecturer :L{id} ; :description {description}@en-US .
+source      select id, title, lecturer, description
+            from course
+
+mappingId   M3
+target      :P{sid}
+               :hasEnrollment
+                  :C{cid} .
+]]
+

--- a/mapping/sql/all/src/test/resources/it/unibz/inf/ontop/io/SchoolBadFile8m.obda
+++ b/mapping/sql/all/src/test/resources/it/unibz/inf/ontop/io/SchoolBadFile8m.obda
@@ -1,0 +1,30 @@
+[PrefixDeclaration]
+xsd:        http://www.w3.org/2001/XMLSchema#
+owl:        http://www.w3.org/2002/07/owl#
+quest:      http://obda.org/quest#
+:           http://www.semanticweb.org/ontologies/2012/5/Ontology1340973114537.owl#
+rdf:        http://www.w3.org/1999/02/22-rdf-syntax-ns#
+rdfs:       http://www.w3.org/2000/01/rdf-schema#
+
+[MappingDeclaration] @collection [[
+; Missing "rdf:type" predicate of Student
+mappingId   M1
+target      :P{id} :Student ;
+            :firstName {fname} ;
+            :lastName {lname} ;
+            :age {age}^^xsd:integer .
+source      select id, fname, lname, age from student
+
+; Missing default prefix in "description" predicate
+mappingId   M2
+target      :C{id} a :Course ;
+               :title {title} ;
+               :hasLecturer :L{id} ;
+               description {description}@en-US .
+source      select id, title, lecturer, description from course
+
+mappingId   M3
+target      :P{sid} :hasEnrollment :C{cid} .
+source      select sid, cid from enrollment
+]]
+

--- a/mapping/sql/native/src/main/java/it/unibz/inf/ontop/spec/mapping/parser/impl/OntopNativeMappingParser.java
+++ b/mapping/sql/native/src/main/java/it/unibz/inf/ontop/spec/mapping/parser/impl/OntopNativeMappingParser.java
@@ -266,25 +266,27 @@ public class OntopNativeMappingParser implements SQLMappingParser {
 
         String currentLabel = ""; // the reader is working on which label
         String line;
-        while ((line = reader.readLine())!= null) {
-            if (line.trim().equals(END_COLLECTION_SYMBOL)) {
+        while ((line = reader.readLine()) != null) {
+            String trimmedLine = line.trim();
+            if (trimmedLine.equals(END_COLLECTION_SYMBOL)) {
                 current.build(parser).ifPresent(mappings::add);
                 return mappings.build();
             }
-            else if (line.isEmpty()) {
+            else if (trimmedLine.isEmpty()) {
                 current.build(parser).ifPresent(mappings::add);
                 current = new MappingBuilder(invalidMappingIndicators, reader::getLineNumber);
             }
             // skip the comment lines (which have ; as their first non-space symbol)
             //      and invalid mappings
-            else if (line.trim().indexOf(COMMENT_SYMBOL) != 0 && current.isValid()) {
+            else if (trimmedLine.indexOf(COMMENT_SYMBOL) != 0 && current.isValid()) {
                 String[] tokens = line.split("[\t| ]+", 2);
-                String value = tokens[tokens.length - 1].trim();
-                if (tokens.length > 1) {
-                    String label = tokens[0].trim();
-                    if (!label.isEmpty())
-                        currentLabel = label;
-                }
+                String label = tokens[0].trim();
+                if (!label.isEmpty())
+                    currentLabel = label;
+
+                String value = (tokens.length > 1)
+                    ? value = tokens[1].trim()
+                    : "";
 
                 switch (currentLabel) {
                     case MAPPING_ID_LABEL:

--- a/mapping/sql/native/src/main/java/it/unibz/inf/ontop/spec/mapping/parser/impl/OntopNativeMappingParser.java
+++ b/mapping/sql/native/src/main/java/it/unibz/inf/ontop/spec/mapping/parser/impl/OntopNativeMappingParser.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import it.unibz.inf.ontop.exception.*;
 import it.unibz.inf.ontop.injection.TargetQueryParserFactory;
+import it.unibz.inf.ontop.spec.mapping.SQLPPSourceQuery;
 import it.unibz.inf.ontop.spec.mapping.TargetAtom;
 import it.unibz.inf.ontop.injection.SQLPPMappingFactory;
 import it.unibz.inf.ontop.injection.SpecificationFactory;
@@ -107,8 +108,8 @@ public class OntopNativeMappingParser implements SQLMappingParser {
     }
 
 
-	private SQLPPMapping load(Reader reader, SpecificationFactory specificationFactory,
-                                     SQLPPMappingFactory ppMappingFactory, String fileName)
+    private SQLPPMapping load(Reader reader, SpecificationFactory specificationFactory,
+                              SQLPPMappingFactory ppMappingFactory, String fileName)
             throws MappingIOException, InvalidMappingException {
 
         ImmutableMap.Builder<String, String> prefixes = ImmutableMap.builder();
@@ -160,7 +161,7 @@ public class OntopNativeMappingParser implements SQLMappingParser {
 
         PrefixManager prefixManager = specificationFactory.createPrefixManager(prefixes.build());
         return ppMappingFactory.createSQLPreProcessedMapping(mappings.build(), prefixManager);
-	}
+    }
 
     /*
      * Helper methods related to load file.
@@ -182,8 +183,8 @@ public class OntopNativeMappingParser implements SQLMappingParser {
         private final Supplier<Integer> line;
 
         private String mappingId = "";
-        private final ImmutableList.Builder<String> sourceQuery = ImmutableList.builder();
-        private String targetString = null;
+        private final ImmutableList.Builder<String> source = ImmutableList.builder();
+        private final ImmutableList.Builder<String> target = ImmutableList.builder();
         private ImmutableList<TargetAtom> targetQuery = null;
         boolean isMappingValid = true;
 
@@ -199,25 +200,11 @@ public class OntopNativeMappingParser implements SQLMappingParser {
 
         boolean isValid() { return isMappingValid; }
 
-        Optional<OntopNativeSQLPPTriplesMap> build() {
-            return (!mappingId.isEmpty() && isMappingValid)
-                ? Optional.of(new OntopNativeSQLPPTriplesMap(
-                        mappingId,
-                        sourceQueryFactory.createSourceQuery(
-                                String.join("\n", sourceQuery.build())),
-                        targetString,
-                        targetQuery))
-                : Optional.empty();
-        }
+        Optional<OntopNativeSQLPPTriplesMap> build(TargetQueryParser parser) {
+            if (mappingId.isEmpty() || !isMappingValid)
+                return Optional.empty();
 
-        void setMappingId(String value) {
-            mappingId = value;
-            if (mappingId.isEmpty())
-                fail(String.format("Line %d: Mapping ID is missing\n", line.get()));
-        }
-
-        void setTarget(String value, TargetQueryParser parser) {
-            targetString = value;
+            String targetString = String.join(" ", target.build());
             if (!targetString.isEmpty()) {
                 try {
                     targetQuery = parser.parse(targetString);
@@ -228,11 +215,36 @@ public class OntopNativeMappingParser implements SQLMappingParser {
             }
             else
                 fail(String.format("Line %d: Target is missing\n", line.get()));
+
+            String sourceString = String.join("\n", source.build());
+            SQLPPSourceQuery sourceQuery = null;
+            if (!sourceString.isEmpty()) {
+                sourceQuery = sourceQueryFactory.createSourceQuery(sourceString);
+            }
+            else
+                fail(String.format("Line %d: Source is missing\n", line.get()));
+
+            return isMappingValid
+                    ? Optional.of(new OntopNativeSQLPPTriplesMap(mappingId, sourceQuery, targetString, targetQuery))
+                    : Optional.empty();
+        }
+
+        void setMappingId(String value) {
+            mappingId = value;
+            if (mappingId.isEmpty())
+                fail(String.format("Line %d: Mapping ID is missing\n", line.get()));
+        }
+
+        void setTarget(String value) {
+            if (!value.isEmpty())
+                target.add(value);
+            else
+                fail(String.format("Line %d: Target query is missing\n", line.get()));
         }
 
         void setSource(String value) {
             if (!value.isEmpty())
-                sourceQuery.add(value);
+                source.add(value);
             else
                 fail(String.format("Line %d: Source query is missing\n", line.get()));
         }
@@ -246,8 +258,8 @@ public class OntopNativeMappingParser implements SQLMappingParser {
      * @throws IOException
      */
     private ImmutableList<SQLPPTriplesMap> readMappingDeclaration(LineNumberReader reader,
-                                                                TargetQueryParser parser,
-                                                                List<String> invalidMappingIndicators) throws IOException {
+                                                                  TargetQueryParser parser,
+                                                                  List<String> invalidMappingIndicators) throws IOException {
 
         ImmutableList.Builder<SQLPPTriplesMap> mappings = ImmutableList.builder();
         MappingBuilder current = new MappingBuilder(invalidMappingIndicators, reader::getLineNumber);
@@ -256,11 +268,11 @@ public class OntopNativeMappingParser implements SQLMappingParser {
         String line;
         while ((line = reader.readLine())!= null) {
             if (line.trim().equals(END_COLLECTION_SYMBOL)) {
-                current.build().ifPresent(mappings::add);
+                current.build(parser).ifPresent(mappings::add);
                 return mappings.build();
             }
             else if (line.isEmpty()) {
-                current.build().ifPresent(mappings::add);
+                current.build(parser).ifPresent(mappings::add);
                 current = new MappingBuilder(invalidMappingIndicators, reader::getLineNumber);
             }
             // skip the comment lines (which have ; as their first non-space symbol)
@@ -279,7 +291,7 @@ public class OntopNativeMappingParser implements SQLMappingParser {
                         current.setMappingId(value);
                         break;
                     case TARGET_LABEL:
-                        current.setTarget(value, parser);
+                        current.setTarget(value);
                         break;
                     case SOURCE_LABEL:
                         current.setSource(value);


### PR DESCRIPTION
Better handling of labels (`mappingId`, `target`, `source`) in OBDA files allows introduction of multi-line target queries for command-line tools (to address issue #458). 

Note, however, that the Protege plugin will not preserve line breaks in the target queries (in the same way as it does not preserve the order of mappings).