### PR TITLE
Backport: Conjunctive query containment check with NULLable columns

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/DomainSimplificationTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/DomainSimplificationTest.java
@@ -1,0 +1,42 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class DomainSimplificationTest extends AbstractRDF4JTest {
+
+    private static final String OBDA_FILE = "/domain-simplification/mapping.obda";
+    private static final String SQL_SCRIPT = "/domain-simplification/database.sql";
+    private static final String ONTOLOGY = "/domain-simplification/ontology.ttl";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE, ONTOLOGY);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void testT1() {
+        var query = "prefix ex: <http://example.org/>\n" +
+                "\n" +
+                "select * where {\n" +
+                "  ?t a ex:T1 \n" +
+                "}";
+
+        var sql = reformulateIntoNativeQuery(query).toLowerCase();
+        assertFalse("The union should have been eliminated:\n " + sql,sql.contains("union"));
+    }
+
+
+}

--- a/binding/rdf4j/src/test/resources/domain-simplification/database.sql
+++ b/binding/rdf4j/src/test/resources/domain-simplification/database.sql
@@ -1,0 +1,16 @@
+create table t1 (
+    id text not null,
+    ts timestamp not null,
+    name text not null);
+
+ALTER TABLE t1 ADD CONSTRAINT pk1 primary key (id, ts);
+
+create table t2 (
+    id text not null,
+    ts timestamp not null,
+    v text);
+
+--ALTER TABLE t2 ADD CONSTRAINT pk2 primary key (id, ts, v);
+
+ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (id, ts)
+REFERENCES t1 (id, ts) ;

--- a/binding/rdf4j/src/test/resources/domain-simplification/database.sql
+++ b/binding/rdf4j/src/test/resources/domain-simplification/database.sql
@@ -7,10 +7,8 @@ ALTER TABLE t1 ADD CONSTRAINT pk1 primary key (id, ts);
 
 create table t2 (
     id text not null,
-    ts timestamp not null,
+    ts timestamp,
     v text);
-
---ALTER TABLE t2 ADD CONSTRAINT pk2 primary key (id, ts, v);
 
 ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (id, ts)
 REFERENCES t1 (id, ts) ;

--- a/binding/rdf4j/src/test/resources/domain-simplification/mapping.obda
+++ b/binding/rdf4j/src/test/resources/domain-simplification/mapping.obda
@@ -1,0 +1,12 @@
+[PrefixDeclaration]
+ex: http://example.org/
+
+[MappingDeclaration] @collection [[
+mappingId	map1
+target		ex:t1/{id}/{ts} a ex:T1 ; ex:name {name} .
+source		SELECT * FROM t1
+
+mappingId	map2
+target		ex:t1/{id}/{ts} ex:hasValue {v} .
+source		SELECT * FROM t2
+]]

--- a/binding/rdf4j/src/test/resources/domain-simplification/ontology.ttl
+++ b/binding/rdf4j/src/test/resources/domain-simplification/ontology.ttl
@@ -1,0 +1,6 @@
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:T1 a rdfs:Class .
+ex:hasValue a owl:DatatypeProperty ; rdfs:domain ex:T1 .

--- a/core/model/src/main/java/it/unibz/inf/ontop/constraints/impl/ExtensionalDataNodeListContainmentCheck.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/constraints/impl/ExtensionalDataNodeListContainmentCheck.java
@@ -78,7 +78,8 @@ public class ExtensionalDataNodeListContainmentCheck {
     }
 
     private Optional<ChasedExtensionalDataNode> chase(ForeignKeyConstraint fk, ChasedExtensionalDataNode node, VariableGenerator variableGenerator, ImmutableSet<Variable> nonNullableVariables) {
-        if (fk.getComponents().stream().anyMatch(c -> c.getAttribute().isNullable() && !nonNullableVariables.contains(node.getArgument(c.getAttribute().getIndex() - 1))))
+        if (fk.getComponents().stream().anyMatch(c -> c.getAttribute().isNullable()
+                && !nonNullableVariables.contains(node.getArgument(c.getAttribute().getIndex() - 1))))
             return Optional.empty();
 
         ImmutableMap<Integer, VariableOrGroundTerm> referencedArgumentMap = fk.getComponents().stream()

--- a/core/model/src/main/java/it/unibz/inf/ontop/constraints/impl/ExtensionalDataNodeListContainmentCheck.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/constraints/impl/ExtensionalDataNodeListContainmentCheck.java
@@ -8,6 +8,7 @@ import it.unibz.inf.ontop.constraints.HomomorphismFactory;
 import it.unibz.inf.ontop.dbschema.ForeignKeyConstraint;
 import it.unibz.inf.ontop.dbschema.RelationDefinition;
 import it.unibz.inf.ontop.iq.node.ExtensionalDataNode;
+import it.unibz.inf.ontop.model.term.Variable;
 import it.unibz.inf.ontop.model.term.VariableOrGroundTerm;
 import it.unibz.inf.ontop.utils.CoreUtilsFactory;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
@@ -26,7 +27,7 @@ public class ExtensionalDataNodeListContainmentCheck {
         this.coreUtilsFactory = coreUtilsFactory;
     }
 
-    public boolean isContainedIn(ImmutableList<? extends VariableOrGroundTerm> answerVariables1, ImmutableList<ExtensionalDataNode> nodes1, ImmutableList<? extends VariableOrGroundTerm> answerVariables2, ImmutableList<ExtensionalDataNode> nodes2) {
+    public boolean isContainedIn(ImmutableList<? extends VariableOrGroundTerm> answerVariables1, ImmutableList<ExtensionalDataNode> nodes1, ImmutableSet<Variable> nonNullableVariables1, ImmutableList<? extends VariableOrGroundTerm> answerVariables2, ImmutableList<ExtensionalDataNode> nodes2) {
         Homomorphism.Builder builder = homomorphismFactory.getHomomorphismBuilder();
         // get the substitution for the answer variables first
         // this will ensure that all answer variables are mapped either to constants or
@@ -38,7 +39,7 @@ public class ExtensionalDataNodeListContainmentCheck {
             builder.extend(answerVariables1.get(i), answerVariables2.get(i));
 
         if (builder.isValid()) {
-            ImmutableSet<ChasedExtensionalDataNode> chase = chase(nodes1);
+            ImmutableSet<ChasedExtensionalDataNode> chase = chase(nodes1, nonNullableVariables1);
             ImmutableSet<RelationDefinition> relationsInChase = chase.stream()
                     .map(ChasedExtensionalDataNode::getRelationDefinition)
                     .collect(ImmutableCollectors.toSet());
@@ -58,34 +59,34 @@ public class ExtensionalDataNodeListContainmentCheck {
     }
 
 
-    public ImmutableSet<ChasedExtensionalDataNode> chase(ImmutableList<ExtensionalDataNode> nodes) {
+    public ImmutableSet<ChasedExtensionalDataNode> chase(ImmutableList<ExtensionalDataNode> nodes, ImmutableSet<Variable> nonNullableVariables) {
         VariableGenerator variableGenerator = coreUtilsFactory.createVariableGenerator(nodes.stream()
                 .flatMap(n -> n.getVariables().stream())
                 .collect(ImmutableCollectors.toSet()));
 
         return nodes.stream()
-                .flatMap(node -> chase(node, variableGenerator))
+                .flatMap(node -> chase(node, variableGenerator, nonNullableVariables))
                 .collect(ImmutableCollectors.toSet());
     }
 
-    private Stream<ChasedExtensionalDataNode> chase(ExtensionalDataNode node, VariableGenerator variableGenerator) {
+    private Stream<ChasedExtensionalDataNode> chase(ExtensionalDataNode node, VariableGenerator variableGenerator, ImmutableSet<Variable> nonNullableVariables) {
         ChasedExtensionalDataNode chasedNode = new ChasedExtensionalDataNode(node, variableGenerator);
         return Stream.concat(Stream.of(chasedNode),
                 node.getRelationDefinition().getForeignKeys().stream()
-                        .map(fk -> chase(fk, chasedNode, variableGenerator))
+                        .map(fk -> chase(fk, chasedNode, variableGenerator, nonNullableVariables))
                         .flatMap(Optional::stream));
     }
 
-    private Optional<ChasedExtensionalDataNode> chase(ForeignKeyConstraint fk, ChasedExtensionalDataNode node, VariableGenerator variableGenerator) {
-        if (fk.getComponents().stream().anyMatch(c -> c.getAttribute().isNullable()))
+    private Optional<ChasedExtensionalDataNode> chase(ForeignKeyConstraint fk, ChasedExtensionalDataNode node, VariableGenerator variableGenerator, ImmutableSet<Variable> nonNullableVariables) {
+        if (fk.getComponents().stream().anyMatch(c -> c.getAttribute().isNullable() && !nonNullableVariables.contains(node.getArgument(c.getAttribute().getIndex() - 1))))
             return Optional.empty();
 
-        ImmutableMap<Integer, VariableOrGroundTerm> map = fk.getComponents().stream()
+        ImmutableMap<Integer, VariableOrGroundTerm> referencedArgumentMap = fk.getComponents().stream()
                 .collect(ImmutableCollectors.toMap(
                         c ->c.getReferencedAttribute().getIndex() - 1,
                         c -> node.getArgument(c.getAttribute().getIndex() - 1)));
 
-        ChasedExtensionalDataNode chasedNode = new ChasedExtensionalDataNode(fk.getReferencedRelation(), map, variableGenerator);
+        ChasedExtensionalDataNode chasedNode = new ChasedExtensionalDataNode(fk.getReferencedRelation(), referencedArgumentMap, variableGenerator);
         return Optional.of(chasedNode);
     }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/evaluator/impl/TermNullabilityEvaluatorImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/evaluator/impl/TermNullabilityEvaluatorImpl.java
@@ -37,8 +37,8 @@ public class TermNullabilityEvaluatorImpl implements TermNullabilityEvaluator {
 
     @Override
     public boolean isFilteringNullValue(ImmutableExpression expression, Variable variable) {
-        ImmutableExpression nullCaseExpression = Stream.of(variable)
-                .collect(substitutionFactory.toSubstitution(v -> termFactory.getNullConstant()))
+        ImmutableExpression nullCaseExpression =
+                substitutionFactory.getSubstitution(variable,  termFactory.getNullConstant())
                 .apply(expression);
 
         return nullCaseExpression.evaluate2VL(coreUtilsFactory.createSimplifiedVariableNullability(expression))

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/spec/mapping/transformer/impl/MappingAssertionUnion.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/spec/mapping/transformer/impl/MappingAssertionUnion.java
@@ -473,7 +473,6 @@ public class MappingAssertionUnion {
         return Optional.of(new ExtensionalDataNodeHomomorphismIteratorImpl(
                 h,
                 from.getDatabaseAtoms(),
-
                 cqc.chase(to.getDatabaseAtoms(), to.getNonNullableVariables())));
     }
 

--- a/mapping/core/src/main/java/it/unibz/inf/ontop/spec/mapping/transformer/impl/MappingCQCOptimizerImpl.java
+++ b/mapping/core/src/main/java/it/unibz/inf/ontop/spec/mapping/transformer/impl/MappingCQCOptimizerImpl.java
@@ -67,7 +67,7 @@ public class MappingCQCOptimizerImpl implements MappingCQCOptimizer {
                             .containsAll(answerVariables)) {
 
                         if (cqContainmentCheck.isContainedIn(
-                                answerVariables, extensionalDataNodesExceptCurrent, answerVariables, extensionalDataNodes)) {
+                                answerVariables, extensionalDataNodesExceptCurrent, ImmutableSet.of(), answerVariables, extensionalDataNodes)) {
                             //System.out.println("CQC-REMOVED: " + extensionalDataNodes.get(currentIndex) + " FROM " + extensionalDataNodes);
                             log.debug("CQC-REMOVED: " + extensionalDataNodes.get(currentIndex) + " FROM " + extensionalDataNodes);
                             extensionalDataNodes = extensionalDataNodesExceptCurrent;

--- a/mapping/core/src/test/java/it/unibz/inf/ontop/spec/mapping/MappingAssertionMergeWithCQCTest.java
+++ b/mapping/core/src/test/java/it/unibz/inf/ontop/spec/mapping/MappingAssertionMergeWithCQCTest.java
@@ -101,7 +101,7 @@ public class MappingAssertionMergeWithCQCTest {
         IQ affiliatedWriterIQ = getAffiliatedWritersIQ(ImmutableMap.of(0, C));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(authorIQ, null));
         entry.add(new MappingAssertion(affiliatedWriterIQ, null));
         MappingAssertion result = entry.build().get();
@@ -115,7 +115,7 @@ public class MappingAssertionMergeWithCQCTest {
         IQ affiliatedWriterIQ = getAffiliatedWritersIQ(ImmutableMap.of(0, C));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(affiliatedWriterIQ, null));
         entry.add(new MappingAssertion(authorIQ, null));
         MappingAssertion result = entry.build().get();
@@ -149,7 +149,7 @@ public class MappingAssertionMergeWithCQCTest {
         IQ studentIQ2 = getStudentIQ(ImmutableMap.of(0, C, 2, B));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(studentIQ1, null));
         entry.add(new MappingAssertion(studentIQ2, null));
         MappingAssertion result = entry.build().get();
@@ -163,7 +163,7 @@ public class MappingAssertionMergeWithCQCTest {
         IQ studentIQ2 = getStudentIQ(ImmutableMap.of(0, C, 2, B));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(studentIQ2, null));
         entry.add(new MappingAssertion(studentIQ1, null));
         MappingAssertion result = entry.build().get();
@@ -201,7 +201,7 @@ public class MappingAssertionMergeWithCQCTest {
                                 IQ_FACTORY.createExtensionalDataNode(TABLE_ADDRESS, ImmutableMap.of(0, C, 1, B)))));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(addressIQ1, null));
         entry.add(new MappingAssertion(addressIQ2, null));
         MappingAssertion result = entry.build().get();
@@ -229,7 +229,7 @@ public class MappingAssertionMergeWithCQCTest {
                                 IQ_FACTORY.createExtensionalDataNode(TABLE_ADDRESS, ImmutableMap.of(0, C, 1, B)))));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(addressIQ2, null));
         entry.add(new MappingAssertion(addressIQ1, null));
         MappingAssertion result = entry.build().get();
@@ -259,7 +259,7 @@ public class MappingAssertionMergeWithCQCTest {
                                 IQ_FACTORY.createExtensionalDataNode(TABLE_STUDENT, ImmutableMap.of(0, C, 3, B)))));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(studentIQ1, null));
         entry.add(new MappingAssertion(studentIQ2, null));
         MappingAssertion result = entry.build().get();
@@ -298,7 +298,7 @@ public class MappingAssertionMergeWithCQCTest {
                                 IQ_FACTORY.createExtensionalDataNode(TABLE_STUDENT, ImmutableMap.of(0, C, 3, B)))));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(studentIQ1, null));
         entry.add(new MappingAssertion(studentIQ2, null));
         MappingAssertion result = entry.build().get();
@@ -342,7 +342,7 @@ public class MappingAssertionMergeWithCQCTest {
                                 IQ_FACTORY.createExtensionalDataNode(TABLE_STUDENT, ImmutableMap.of(0, C, 4, B)))));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(studentIQ1, null));
         entry.add(new MappingAssertion(studentIQ2, null));
         MappingAssertion result = entry.build().get();
@@ -389,7 +389,7 @@ public class MappingAssertionMergeWithCQCTest {
                                 IQ_FACTORY.createExtensionalDataNode(TABLE_STUDENT, ImmutableMap.of(0, C, 4, B)))));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(studentIQ2, null));
         entry.add(new MappingAssertion(studentIQ1, null));
         MappingAssertion result = entry.build().get();
@@ -440,7 +440,7 @@ public class MappingAssertionMergeWithCQCTest {
                                 IQ_FACTORY.createExtensionalDataNode(TABLE_STUDENT, ImmutableMap.of(0, C, 3, A, 4, B)))));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(studentIQ1, null));
         entry.add(new MappingAssertion(studentIQ2, null));
         MappingAssertion result = entry.build().get();
@@ -491,7 +491,7 @@ public class MappingAssertionMergeWithCQCTest {
                                         ImmutableMap.of(B, TERM_FACTORY.getDBIntegerConstant(3))))))));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(studentIQ1, null));
         entry.add(new MappingAssertion(studentIQ2, null));
         MappingAssertion result = entry.build().get();
@@ -527,7 +527,7 @@ public class MappingAssertionMergeWithCQCTest {
                                         ImmutableMap.of(B, TERM_FACTORY.getDBIntegerConstant(3))))))));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(studentIQ2, null));
         entry.add(new MappingAssertion(studentIQ1, null));
         MappingAssertion result = entry.build().get();
@@ -563,7 +563,7 @@ public class MappingAssertionMergeWithCQCTest {
                                         ImmutableMap.of(B, TERM_FACTORY.getDBIntegerConstant(3))))))));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(studentIQ1, null));
         entry.add(new MappingAssertion(studentIQ2, null));
         MappingAssertion result = entry.build().get();
@@ -611,7 +611,7 @@ public class MappingAssertionMergeWithCQCTest {
                                         ImmutableMap.of(B, TERM_FACTORY.getDBIntegerConstant(3))))))));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(studentIQ2, null));
         entry.add(new MappingAssertion(studentIQ1, null));
         MappingAssertion result = entry.build().get();
@@ -682,7 +682,7 @@ public class MappingAssertionMergeWithCQCTest {
                                         MEASUREMENT_TYPE, ImmutableMap.of(0, NAME, 1, TERM_FACTORY.getDBStringConstant("[m/s]")))))));
 
         ExtensionalDataNodeListContainmentCheck cqc = new ExtensionalDataNodeListContainmentCheck(HOMOMORPHISM_FACTORY, CORE_UTILS_FACTORY);
-        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER);
+        MappingAssertionUnion entry = new MappingAssertionUnion(cqc, CORE_SINGLETONS, UNION_BASED_QUERY_MERGER, TERM_NULLABILITY_EVALUATOR);
         entry.add(new MappingAssertion(mDegreeCelsius, null));
         entry.add(new MappingAssertion(mMeterPerSecond, null));
         entry.add(new MappingAssertion(mMeterPerSecond2, null));

--- a/mapping/core/src/test/java/it/unibz/inf/ontop/utils/MappingTestingTools.java
+++ b/mapping/core/src/test/java/it/unibz/inf/ontop/utils/MappingTestingTools.java
@@ -7,6 +7,7 @@ import it.unibz.inf.ontop.constraints.HomomorphismFactory;
 import it.unibz.inf.ontop.dbschema.*;
 import it.unibz.inf.ontop.dbschema.impl.DatabaseTableDefinition;
 import it.unibz.inf.ontop.dbschema.impl.OfflineMetadataProviderBuilder;
+import it.unibz.inf.ontop.evaluator.TermNullabilityEvaluator;
 import it.unibz.inf.ontop.injection.*;
 import it.unibz.inf.ontop.datalog.UnionFlattener;
 import it.unibz.inf.ontop.iq.tools.UnionBasedQueryMerger;
@@ -58,6 +59,7 @@ public class MappingTestingTools {
     public static final NamedRelationDefinition TABLE3_AR3;
     public static final NamedRelationDefinition TABLE4_AR3;
     public static final UnionBasedQueryMerger UNION_BASED_QUERY_MERGER;
+    public static final TermNullabilityEvaluator TERM_NULLABILITY_EVALUATOR;
 
     static {
         OntopMappingConfiguration defaultConfiguration = OntopMappingConfiguration.defaultBuilder()
@@ -85,6 +87,7 @@ public class MappingTestingTools {
         CORE_UTILS_FACTORY = injector.getInstance(CoreUtilsFactory.class);
         CORE_SINGLETONS = injector.getInstance(CoreSingletons.class);
         UNION_BASED_QUERY_MERGER = injector.getInstance(UnionBasedQueryMerger.class);
+        TERM_NULLABILITY_EVALUATOR = injector.getInstance(TermNullabilityEvaluator.class);
 
         EMPTY_PREFIX_MANAGER = SPECIFICATION_FACTORY.createPrefixManager(ImmutableMap.of());
 


### PR DESCRIPTION
This PR backports the changes introduced in pull request #872  in order for them to be included in the 5.3.1 release.