### PR TITLE
Preserve FK inference in lenses in the presence of IRI safeness declarations

### DIFF
--- a/binding/rdf4j/src/test/java/QueryContainmentIRISafeTest.java
+++ b/binding/rdf4j/src/test/java/QueryContainmentIRISafeTest.java
@@ -1,0 +1,35 @@
+import it.unibz.inf.ontop.rdf4j.repository.AbstractRDF4JTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class QueryContainmentIRISafeTest extends AbstractRDF4JTest {
+
+    private static final String MAPPING_FILE = "/iri-safe-query-containment/mapping.obda";
+    private static final String SQL_SCRIPT = "/iri-safe-query-containment/example.sql";
+    private static final String ONTOLOGY_FILE = "/iri-safe-query-containment/ontology.ttl";
+    private static final String LENSES_FILE = "/iri-safe-query-containment/lenses.json";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, MAPPING_FILE, ONTOLOGY_FILE, null, LENSES_FILE);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+    @Test
+    public void testT() {
+        var sql = reformulateIntoNativeQuery("SELECT * WHERE {\n" +
+                "\t?s a <http://example.org/ontology#T>\n" +
+                "}");
+        assertFalse("Should not contain an UNION", sql.toLowerCase().contains("union"));
+    }
+}

--- a/binding/rdf4j/src/test/resources/iri-safe-query-containment/example.sql
+++ b/binding/rdf4j/src/test/resources/iri-safe-query-containment/example.sql
@@ -1,0 +1,3 @@
+CREATE TABLE t (t_id VARCHAR(100) primary key);
+CREATE TABLE r (r_id VARCHAR(100) primary key,
+    t_id VARCHAR(100) not null references t(t_id));

--- a/binding/rdf4j/src/test/resources/iri-safe-query-containment/lenses.json
+++ b/binding/rdf4j/src/test/resources/iri-safe-query-containment/lenses.json
@@ -1,0 +1,24 @@
+{
+  "relations": [
+    {
+      "name": ["\"lenses\"", "\"T\""],
+      "baseRelation": ["\"T\""],
+      "iriSafeConstraints": {
+        "added": [
+          "\"T_ID\""
+        ]
+      },
+      "type": "BasicLens"
+    },
+    {
+      "name": ["\"lenses\"", "\"R\""],
+      "baseRelation": ["\"R\""],
+      "iriSafeConstraints": {
+        "added": [
+          "\"T_ID\""
+        ]
+      },
+      "type": "BasicLens"
+    }
+  ]
+}

--- a/binding/rdf4j/src/test/resources/iri-safe-query-containment/mapping.obda
+++ b/binding/rdf4j/src/test/resources/iri-safe-query-containment/mapping.obda
@@ -1,0 +1,16 @@
+[PrefixDeclaration]
+: http://example.org/ontology#
+data: http://example.org/data/
+rdfs: http://www.w3.org/2000/01/rdf-schema#
+
+[MappingDeclaration] @collection [[
+
+mappingId   t
+target      data:t/{t_id} a :T .
+source      SELECT t_id FROM "lenses"."T"
+
+mappingId   r
+target      data:r/{r_id} :p data:t/{t_id} .
+source      SELECT r_id, t_id FROM "lenses"."R"
+
+]]

--- a/binding/rdf4j/src/test/resources/iri-safe-query-containment/ontology.ttl
+++ b/binding/rdf4j/src/test/resources/iri-safe-query-containment/ontology.ttl
@@ -1,0 +1,10 @@
+@prefix : <http://example.org/ontology#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:T a owl:Class .
+:R a owl:Class .
+
+:p a owl:ObjectProperty ;
+    rdfs:domain :R ;
+    rdfs:range :T .

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/BasicLensFKSaturator.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/BasicLensFKSaturator.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.inject.Inject;
 import it.unibz.inf.ontop.dbschema.*;
 import it.unibz.inf.ontop.dbschema.impl.json.JsonLens;
+import it.unibz.inf.ontop.injection.CoreSingletons;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 
 import java.util.UUID;
@@ -16,8 +17,11 @@ import java.util.stream.IntStream;
  */
 public class BasicLensFKSaturator implements LensFKSaturator {
 
+    private final CoreSingletons coreSingletons;
+
     @Inject
-    protected BasicLensFKSaturator() {
+    protected BasicLensFKSaturator(CoreSingletons coreSingletons) {
+        this.coreSingletons = coreSingletons;
     }
 
     @Override
@@ -74,7 +78,8 @@ public class BasicLensFKSaturator implements LensFKSaturator {
 
         jsonViewMap.get(childIdOfTarget).getAttributesIncludingParentOnes(
                 childRelation,
-                targetAttributes)
+                targetAttributes,
+                coreSingletons)
                 .forEach(as -> addForeignKey(sourceView, foreignKey, childRelation, as));
     }
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonBasicLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonBasicLens.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.*;
 import it.unibz.inf.ontop.dbschema.*;
 import it.unibz.inf.ontop.exception.MetadataExtractionException;
+import it.unibz.inf.ontop.injection.CoreSingletons;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 
 import javax.annotation.Nonnull;
@@ -47,12 +48,13 @@ public class JsonBasicLens extends JsonBasicOrJoinLens {
      */
     @Override
     public ImmutableList<ImmutableList<Attribute>> getAttributesIncludingParentOnes(Lens lens,
-                                                                                    ImmutableList<Attribute> parentAttributes) {
+                                                                                    ImmutableList<Attribute> parentAttributes,
+                                                                                    CoreSingletons coreSingletons) {
         if (filterExpression != null && (!filterExpression.isEmpty()))
             // TODO: log a warning
             return ImmutableList.of();
 
-        return getDerivedFromParentAttributes(lens, parentAttributes);
+        return getDerivedFromParentAttributes(lens, parentAttributes, coreSingletons);
     }
 
     public boolean propagateUniqueConstraintsUp(Lens relation, ImmutableList<NamedRelationDefinition> parents,

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonBasicOrJoinLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonBasicOrJoinLens.java
@@ -115,7 +115,8 @@ public abstract class JsonBasicOrJoinLens extends JsonBasicOrJoinOrNestedLens {
 
         insertForeignKeys(relation, metadataLookupForFK,
                 (foreignKeys != null) ? foreignKeys.added : ImmutableList.of(),
-                baseRelations);
+                baseRelations,
+                coreSingletons);
     }
 
     private IQ createIQ(RelationID relationId, ImmutableList<ParentDefinition> parentDefinitions, DBParameters dbParameters)

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonFlattenLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonFlattenLens.java
@@ -272,7 +272,8 @@ public class JsonFlattenLens extends JsonBasicOrJoinOrNestedLens {
                                 inferForeignKeysFromParentUCs(keptColumns, baseRelation).stream()
                         )
                         .collect(ImmutableCollectors.toList()),
-                baseRelations);
+                baseRelations,
+                dbParameters.getCoreSingletons());
     }
 
     private ImmutableList<AddForeignKey> inferForeignKeysFromParentUCs(ImmutableSet<QuotedID> keptColumns, NamedRelationDefinition baseRelation) {
@@ -326,7 +327,8 @@ public class JsonFlattenLens extends JsonBasicOrJoinOrNestedLens {
 
     @Override
     public ImmutableList<ImmutableList<Attribute>> getAttributesIncludingParentOnes(Lens lens,
-                                                                                    ImmutableList<Attribute> parentAttributes) {
+                                                                                    ImmutableList<Attribute> parentAttributes,
+                                                                                    CoreSingletons coreSingletons) {
         return ImmutableList.of();
     }
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonJoinLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonJoinLens.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 import it.unibz.inf.ontop.dbschema.*;
 import it.unibz.inf.ontop.exception.MetadataExtractionException;
+import it.unibz.inf.ontop.injection.CoreSingletons;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -55,7 +56,9 @@ public class JsonJoinLens extends JsonBasicOrJoinLens {
      * TODO: consider implementing it (using FKs between parents)
      */
     @Override
-    public ImmutableList<ImmutableList<Attribute>> getAttributesIncludingParentOnes(Lens lens, ImmutableList<Attribute> parentAttributes) {
+    public ImmutableList<ImmutableList<Attribute>> getAttributesIncludingParentOnes(Lens lens,
+                                                                                    ImmutableList<Attribute> parentAttributes,
+                                                                                    CoreSingletons coreSingletons) {
         return ImmutableList.of();
     }
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonLens.java
@@ -105,7 +105,7 @@ public abstract class JsonLens extends JsonOpenObject {
      * Parent attributes are expected to all come from the same parent.
      */
     public abstract ImmutableList<ImmutableList<Attribute>> getAttributesIncludingParentOnes(
-            Lens lens, ImmutableList<Attribute> parentAttributes);
+            Lens lens, ImmutableList<Attribute> parentAttributes, CoreSingletons coreSingletons);
 
     protected RelationDefinition.AttributeListBuilder createAttributeBuilder(IQ iq, DBParameters dbParameters)  {
         SingleTermTypeExtractor uniqueTermTypeExtractor = dbParameters.getCoreSingletons().getUniqueTermTypeExtractor();

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonSQLLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonSQLLens.java
@@ -94,7 +94,9 @@ public class JsonSQLLens extends JsonLens {
     }
 
     @Override
-    public ImmutableList<ImmutableList<Attribute>> getAttributesIncludingParentOnes(Lens lens, ImmutableList<Attribute> parentAttributes) {
+    public ImmutableList<ImmutableList<Attribute>> getAttributesIncludingParentOnes(Lens lens,
+                                                                                    ImmutableList<Attribute> parentAttributes,
+                                                                                    CoreSingletons coreSingletons) {
         return ImmutableList.of();
     }
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonUnionLens.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonUnionLens.java
@@ -108,7 +108,8 @@ public class JsonUnionLens extends JsonLens {
     }
 
     @Override
-    public ImmutableList<ImmutableList<Attribute>> getAttributesIncludingParentOnes(Lens lens, ImmutableList<Attribute> parentAttributes) {
+    public ImmutableList<ImmutableList<Attribute>> getAttributesIncludingParentOnes(Lens lens, ImmutableList<Attribute> parentAttributes,
+                                                                                    CoreSingletons coreSingletons) {
         return ImmutableList.of();
     }
 


### PR DESCRIPTION
Column IRI safeness is currently implemented internally using a special function symbol. 

This PR makes the foreign key inference robust to the presence of such functions symbols.