### PR TITLE
Spark Docker Image Update

### DIFF
--- a/test/lightweight-tests/lightweight-db-test-images/spark/Dockerfile
+++ b/test/lightweight-tests/lightweight-db-test-images/spark/Dockerfile
@@ -1,9 +1,12 @@
-FROM bitnami/minideb:buster
+FROM bitnami/minideb:bookworm
 
 RUN install_packages curl ca-certificates -y
-RUN install_packages wget procps openjdk-11-jdk-headless git python3 -y
+RUN install_packages wget procps git python3 java-common -y
 
 WORKDIR /tmp
+
+RUN wget https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.deb
+RUN dpkg --install amazon-corretto-11-x64-linux-jdk.deb
 
 RUN wget https://archive.apache.org/dist/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz
 RUN tar xvf spark-*


### PR DESCRIPTION
This PR updates the base Debian version used in the Spark Docker image for testing from `buster` to `bookworm`, as the `buster` repositories have been archived.

Debian `bookworm` no longer includes the `openjdk-11-jdk-headless` package in its standard repositories. To address this, the JDK is now installed manually by following the official [Amazon Corretto 11 installation guide](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/generic-linux-install.html).