### PR TITLE
DISCUSSION: user impersonation / bearer token authorization

### DIFF
--- a/client/endpoint-core/src/main/java/it/unibz/inf/ontop/endpoint/processor/AuthorizationContext.java
+++ b/client/endpoint-core/src/main/java/it/unibz/inf/ontop/endpoint/processor/AuthorizationContext.java
@@ -1,0 +1,52 @@
+package it.unibz.inf.ontop.endpoint.processor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Thread-local context to track whether the current request has an Authorization header.
+ * This is used to coordinate JDBC URL modification between the SPARQL query processor
+ * and the JDBC connection creation layer.
+ */
+public class AuthorizationContext {
+    
+    private static final Logger logger = LoggerFactory.getLogger(AuthorizationContext.class);
+    
+    private static final ThreadLocal<String> AUTHORIZATION_TOKEN = new ThreadLocal<>();
+    
+    /**
+     * Sets the Authorization header value for the current request.
+     */
+    public static void setAuthorizationHeader(String authHeader) {
+        logger.info("Setting authorization header: {}", authHeader != null ? "[TOKEN]" : "null");
+        AUTHORIZATION_TOKEN.set(authHeader);
+    }
+    
+    /**
+     * Returns whether the current request has an Authorization header.
+     */
+    public static boolean hasAuthorizationHeader() {
+        String value = AUTHORIZATION_TOKEN.get();
+        boolean result = value != null && !value.trim().isEmpty();
+        logger.debug("Has authorization header: {}", result);
+        return result;
+    }
+    
+    /**
+     * Returns the Authorization header value, extracting the token if it's a Bearer token.
+     */
+    public static String getAuthorizationToken() {
+        String value = AUTHORIZATION_TOKEN.get();
+        if (value != null && value.trim().toLowerCase().startsWith("bearer ")) {
+            return value.trim().substring(7); // Remove "Bearer " prefix
+        }
+        return value;
+    }
+    
+    /**
+     * Clears the thread-local context.
+     */
+    public static void clear() {
+        AUTHORIZATION_TOKEN.remove();
+    }
+}


### PR DESCRIPTION
if you have multiple users with varying access to the underlying data stores (trino, postgres, etc.) it can be necessary to allow ontop to impersonate each user running queries.

currently in a properties file if you do something like:
```
jdbc:trino://sometrino.server:8443/some-catalog/some-schema?SSL=true&accessToken=BEARER_TOKEN_HERE
```

it allows ontop to initialize BUT then ontop can't impersonate the user that runs the SPARQL query.

this PR allows you to set your properties like like the example but then if a query to ontop arrives with an HTTP `Authorization: bearer BEARER_TOKEN_HERE` header then it will remove the `accessToken` from the JDBC URL and it will append the `Authorization` header to the outgoing SQL query (thereby allowing ontop to run SQL as user X).

this approach is specific to trino with OAUTH authentication so i don't expect it to be merged as is but perhaps it could lead to a more general user impersonation solution.