### PR TITLE
Numeric Binary Operations Refactoring

### DIFF
--- a/core/kg-query/src/main/java/it/unibz/inf/ontop/query/translation/impl/RDF4JValueExprTranslator.java
+++ b/core/kg-query/src/main/java/it/unibz/inf/ontop/query/translation/impl/RDF4JValueExprTranslator.java
@@ -328,7 +328,7 @@ public class RDF4JValueExprTranslator {
             }
         }
         if (expr instanceof MathExpr) {
-            return new ExtendedTerm(getFunctionalTerm(NumericalOperations.get(((MathExpr) expr).getOperator()),
+            return new ExtendedTerm(getFunctionalTerm(ArithmeticOperations.get(((MathExpr) expr).getOperator()),
                     term1, term2), existsMap);
         }
         /*
@@ -420,7 +420,7 @@ public class RDF4JValueExprTranslator {
                     : termFactory.getSPARQLEffectiveBooleanValue(term);
     }
 
-    private static final ImmutableMap<MathExpr.MathOp, String> NumericalOperations =
+    private static final ImmutableMap<MathExpr.MathOp, String> ArithmeticOperations =
             ImmutableMap.<MathExpr.MathOp, String>builder()
                     .put(MathExpr.MathOp.PLUS, SPARQL.ADD)
                     .put(MathExpr.MathOp.MINUS, SPARQL.SUBTRACT)

--- a/core/kg-query/src/main/java/it/unibz/inf/ontop/query/translation/impl/RDF4JValueExprTranslator.java
+++ b/core/kg-query/src/main/java/it/unibz/inf/ontop/query/translation/impl/RDF4JValueExprTranslator.java
@@ -422,10 +422,10 @@ public class RDF4JValueExprTranslator {
 
     private static final ImmutableMap<MathExpr.MathOp, String> NumericalOperations =
             ImmutableMap.<MathExpr.MathOp, String>builder()
-                    .put(MathExpr.MathOp.PLUS, SPARQL.NUMERIC_ADD)
-                    .put(MathExpr.MathOp.MINUS, SPARQL.NUMERIC_SUBTRACT)
-                    .put(MathExpr.MathOp.MULTIPLY, SPARQL.NUMERIC_MULTIPLY)
-                    .put(MathExpr.MathOp.DIVIDE, SPARQL.NUMERIC_DIVIDE)
+                    .put(MathExpr.MathOp.PLUS, SPARQL.ADD)
+                    .put(MathExpr.MathOp.MINUS, SPARQL.SUBTRACT)
+                    .put(MathExpr.MathOp.MULTIPLY, SPARQL.MULTIPLY)
+                    .put(MathExpr.MathOp.DIVIDE, SPARQL.DIVIDE)
                     .build();
 
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/TermFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/TermFactory.java
@@ -520,18 +520,6 @@ public interface TermFactory {
 	 *
 	 */
 
-	ImmutableFunctionalTerm getBinaryArithmeticLexicalFunctionalTerm(String dbOperationName,
-															  ImmutableTerm lexicalTerm1,
-															  ImmutableTerm lexicalTerm2,
-															  ImmutableTerm inputRDFTypeTerm1,
-															  ImmutableTerm inputRDFTypeTerm2,
-															  ImmutableTerm returnedRDFTypeTerm);
-
-	ImmutableFunctionalTerm getBinaryArithmeticTypeFunctionalTerm(String dbOperationName,
-															  ImmutableTerm lexicalTerm1,
-															  ImmutableTerm lexicalTerm2,
-															  ImmutableTerm inputRDFTypeTerm1,
-															  ImmutableTerm inputRDFTypeTerm2);
 
 	ImmutableFunctionalTerm getDBBinaryNumericFunctionalTerm(String dbNumericOperationName, DBTermType dbNumericType,
 															 ImmutableTerm dbTerm1, ImmutableTerm dbTerm2);

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/TermFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/TermFactory.java
@@ -519,10 +519,19 @@ public interface TermFactory {
 	 * TODO: find a better name
 	 *
 	 */
-	ImmutableFunctionalTerm getBinaryNumericLexicalFunctionalTerm(String dbNumericOperationName,
-																  ImmutableTerm lexicalTerm1,
-																  ImmutableTerm lexicalTerm2,
-																  ImmutableTerm rdfTypeTerm);
+
+	ImmutableFunctionalTerm getBinaryArithmeticLexicalFunctionalTerm(String dbOperationName,
+															  ImmutableTerm lexicalTerm1,
+															  ImmutableTerm lexicalTerm2,
+															  ImmutableTerm inputRDFTypeTerm1,
+															  ImmutableTerm inputRDFTypeTerm2,
+															  ImmutableTerm returnedRDFTypeTerm);
+
+	ImmutableFunctionalTerm getBinaryArithmeticTypeFunctionalTerm(String dbOperationName,
+															  ImmutableTerm lexicalTerm1,
+															  ImmutableTerm lexicalTerm2,
+															  ImmutableTerm inputRDFTypeTerm1,
+															  ImmutableTerm inputRDFTypeTerm2);
 
 	ImmutableFunctionalTerm getDBBinaryNumericFunctionalTerm(String dbNumericOperationName, DBTermType dbNumericType,
 															 ImmutableTerm dbTerm1, ImmutableTerm dbTerm2);

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/FunctionSymbolFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/FunctionSymbolFactory.java
@@ -122,10 +122,6 @@ public interface FunctionSymbolFactory {
      */
     BooleanFunctionSymbol getLexicalLangMatches();
 
-    FunctionSymbol getBinaryArithmeticLexicalFunctionSymbol(String dbOperationName);
-
-    FunctionSymbol getBinaryArithmeticTypeFunctionSymbol(String dbOperationName);
-
     FunctionSymbol getUnaryLatelyTypedFunctionSymbol(Function<DBTermType, Optional<DBFunctionSymbol>> dbFunctionSymbolFct,
                                                      DBTermType targetType);
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/FunctionSymbolFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/FunctionSymbolFactory.java
@@ -122,7 +122,9 @@ public interface FunctionSymbolFactory {
      */
     BooleanFunctionSymbol getLexicalLangMatches();
 
-    FunctionSymbol getBinaryNumericLexicalFunctionSymbol(String dbNumericOperationName);
+    FunctionSymbol getBinaryArithmeticLexicalFunctionSymbol(String dbOperationName);
+
+    FunctionSymbol getBinaryArithmeticTypeFunctionSymbol(String dbOperationName);
 
     FunctionSymbol getUnaryLatelyTypedFunctionSymbol(Function<DBTermType, Optional<DBFunctionSymbol>> dbFunctionSymbolFct,
                                                      DBTermType targetType);

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractDBFunctionSymbolFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/AbstractDBFunctionSymbolFactory.java
@@ -1397,13 +1397,13 @@ public abstract class AbstractDBFunctionSymbolFactory implements DBFunctionSymbo
     protected DBMathBinaryOperator createDBBinaryMathOperator(String dbMathOperatorName, DBTermType dbNumericType)
         throws UnsupportedOperationException {
         switch (dbMathOperatorName) {
-            case SPARQL.NUMERIC_MULTIPLY:
+            case SPARQL.MULTIPLY:
                 return createMultiplyOperator(dbNumericType);
-            case SPARQL.NUMERIC_DIVIDE:
+            case SPARQL.DIVIDE:
                 return createDivideOperator(dbNumericType);
-            case SPARQL.NUMERIC_ADD:
+            case SPARQL.ADD:
                 return createAddOperator(dbNumericType);
-            case SPARQL.NUMERIC_SUBTRACT:
+            case SPARQL.SUBTRACT:
                 return createSubtractOperator(dbNumericType);
             default:
                 throw new UnsupportedOperationException("The math operator " + dbMathOperatorName + " is not supported");
@@ -1431,13 +1431,13 @@ public abstract class AbstractDBFunctionSymbolFactory implements DBFunctionSymbo
 
     protected DBMathBinaryOperator createUntypedDBBinaryMathOperator(String dbMathOperatorName) throws UnsupportedOperationException {
         switch (dbMathOperatorName) {
-            case SPARQL.NUMERIC_MULTIPLY:
+            case SPARQL.MULTIPLY:
                 return createUntypedMultiplyOperator();
-            case SPARQL.NUMERIC_DIVIDE:
+            case SPARQL.DIVIDE:
                 return createUntypedDivideOperator();
-            case SPARQL.NUMERIC_ADD:
+            case SPARQL.ADD:
                 return createUntypedAddOperator();
-            case SPARQL.NUMERIC_SUBTRACT:
+            case SPARQL.SUBTRACT:
                 return createUntypedSubtractOperator();
             default:
                 throw new UnsupportedOperationException("The untyped math operator " + dbMathOperatorName + " is not supported");

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/BinaryArithmeticLexicalFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/BinaryArithmeticLexicalFunctionSymbolImpl.java
@@ -20,7 +20,7 @@ public class BinaryArithmeticLexicalFunctionSymbolImpl extends FunctionSymbolImp
 
     protected BinaryArithmeticLexicalFunctionSymbolImpl(String dbOperationName, DBTermType dbStringType,
                                                         MetaRDFTermType metaRDFTermType, TypeFactory typeFactory) {
-        super("BINARY_LEXICAL_" + dbOperationName, ImmutableList.of(dbStringType, dbStringType, metaRDFTermType, metaRDFTermType, metaRDFTermType));
+        super("LEXICAL_BINARY_" + dbOperationName, ImmutableList.of(dbStringType, dbStringType, metaRDFTermType, metaRDFTermType, metaRDFTermType));
         this.dbOperationName = dbOperationName;
         this.dbStringType = dbStringType;
         this.typeFactory = typeFactory;
@@ -63,10 +63,8 @@ public class BinaryArithmeticLexicalFunctionSymbolImpl extends FunctionSymbolImp
 
             if (rdfType.isA(termFactory.getTypeFactory().getAbstractOntopNumericDatatype())) {
                 return getNumericLexicalTerm(newTerms, termFactory, rdfType);
-            } else if (rdfType.isA(termFactory.getTypeFactory().getAbstractOntopTemporalDatatype())) {
-                throw new UnsupportedOperationException("Binary arithmetic operations on temporal types are not yet supported");
             } else {
-                return termFactory.getRDFFunctionalTerm(termFactory.getNullConstant(), termFactory.getNullConstant());
+                return termFactory.getNullConstant();
             }
         }
         else if ((rdfTypeTerm instanceof ImmutableFunctionalTerm)

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/BinaryArithmeticSPARQLFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/BinaryArithmeticSPARQLFunctionSymbolImpl.java
@@ -4,33 +4,39 @@ import com.google.common.collect.ImmutableList;
 import it.unibz.inf.ontop.iq.node.VariableNullability;
 import it.unibz.inf.ontop.model.term.ImmutableTerm;
 import it.unibz.inf.ontop.model.term.TermFactory;
-import it.unibz.inf.ontop.model.type.RDFDatatype;
-import it.unibz.inf.ontop.model.type.TermTypeInference;
+import it.unibz.inf.ontop.model.type.*;
 
 import java.util.Optional;
 
 public class BinaryArithmeticSPARQLFunctionSymbolImpl extends ReduciblePositiveAritySPARQLFunctionSymbolImpl {
-    protected BinaryArithmeticSPARQLFunctionSymbolImpl(String functionSymbolName, String officialName, RDFDatatype abstractTemporalOrNumericType) {
-        super(functionSymbolName, officialName,
-                ImmutableList.of(abstractTemporalOrNumericType, abstractTemporalOrNumericType));
+    private final TypeFactory typeFactory;
+    private final MetaRDFTermType metaRDFTermType;
+    private final DBTermType dbStringType;
+
+    protected BinaryArithmeticSPARQLFunctionSymbolImpl(String functionSymbolName, String officialName, RDFDatatype abstractType, TypeFactory typeFactory) {
+        super(functionSymbolName, officialName, ImmutableList.of(abstractType, abstractType));
+
+        this.dbStringType = typeFactory.getDBTypeFactory().getDBStringType();
+        this.metaRDFTermType = typeFactory.getMetaRDFTermType();
+        this.typeFactory = typeFactory;
     }
 
     @Override
     protected ImmutableTerm computeTypeTerm(ImmutableList<? extends ImmutableTerm> subLexicalTerms,
                                             ImmutableList<ImmutableTerm> typeTerms, TermFactory termFactory,
                                             VariableNullability variableNullability) {
-        return termFactory.getBinaryArithmeticTypeFunctionalTerm(getOfficialName(),
-                subLexicalTerms.get(0), subLexicalTerms.get(1),
-                typeTerms.get(0), typeTerms.get(1));
+        return termFactory.getImmutableFunctionalTerm(
+                new BinaryArithmeticTermTypeFunctionSymbolImpl(getOfficialName(), dbStringType, metaRDFTermType, typeFactory),
+                subLexicalTerms.get(0), subLexicalTerms.get(1), typeTerms.get(0), typeTerms.get(1));
     }
 
     @Override
     protected ImmutableTerm computeLexicalTerm(ImmutableList<ImmutableTerm> subLexicalTerms,
                                                ImmutableList<ImmutableTerm> typeTerms, TermFactory termFactory,
                                                ImmutableTerm returnedRDFTypeTerm) {
-        return termFactory.getBinaryArithmeticLexicalFunctionalTerm(getOfficialName(),
-                subLexicalTerms.get(0), subLexicalTerms.get(1),
-                typeTerms.get(0), typeTerms.get(1), returnedRDFTypeTerm);
+        return termFactory.getImmutableFunctionalTerm(
+                new BinaryArithmeticLexicalFunctionSymbolImpl(getOfficialName(), dbStringType, metaRDFTermType, typeFactory),
+                subLexicalTerms.get(0), subLexicalTerms.get(1), typeTerms.get(0), typeTerms.get(1), returnedRDFTypeTerm);
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/BinaryArithmeticSPARQLFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/BinaryArithmeticSPARQLFunctionSymbolImpl.java
@@ -9,33 +9,32 @@ import it.unibz.inf.ontop.model.type.TermTypeInference;
 
 import java.util.Optional;
 
-
-public class NumericBinarySPARQLFunctionSymbolImpl extends ReduciblePositiveAritySPARQLFunctionSymbolImpl {
-
-    protected NumericBinarySPARQLFunctionSymbolImpl(String functionSymbolName, String officialName,
-                                                    RDFDatatype abstractNumericType) {
-        super(functionSymbolName, officialName, ImmutableList.of(abstractNumericType, abstractNumericType));
+public class BinaryArithmeticSPARQLFunctionSymbolImpl extends ReduciblePositiveAritySPARQLFunctionSymbolImpl {
+    protected BinaryArithmeticSPARQLFunctionSymbolImpl(String functionSymbolName, String officialName, RDFDatatype abstractTemporalOrNumericType) {
+        super(functionSymbolName, officialName,
+                ImmutableList.of(abstractTemporalOrNumericType, abstractTemporalOrNumericType));
     }
 
     @Override
     protected ImmutableTerm computeTypeTerm(ImmutableList<? extends ImmutableTerm> subLexicalTerms,
                                             ImmutableList<ImmutableTerm> typeTerms, TermFactory termFactory,
                                             VariableNullability variableNullability) {
-        return termFactory.getCommonPropagatedOrSubstitutedNumericType(typeTerms.get(0), typeTerms.get(1));
+        return termFactory.getBinaryArithmeticTypeFunctionalTerm(getOfficialName(),
+                subLexicalTerms.get(0), subLexicalTerms.get(1),
+                typeTerms.get(0), typeTerms.get(1));
     }
 
     @Override
     protected ImmutableTerm computeLexicalTerm(ImmutableList<ImmutableTerm> subLexicalTerms,
                                                ImmutableList<ImmutableTerm> typeTerms, TermFactory termFactory,
                                                ImmutableTerm returnedRDFTypeTerm) {
-        return termFactory.getBinaryNumericLexicalFunctionalTerm(getOfficialName(),
-                subLexicalTerms.get(0),
-                subLexicalTerms.get(1),
-                returnedRDFTypeTerm);
+        return termFactory.getBinaryArithmeticLexicalFunctionalTerm(getOfficialName(),
+                subLexicalTerms.get(0), subLexicalTerms.get(1),
+                typeTerms.get(0), typeTerms.get(1), returnedRDFTypeTerm);
     }
 
     @Override
-    public boolean isAlwaysInjectiveInTheAbsenceOfNonInjectiveFunctionalTerms() {
+    protected boolean isAlwaysInjectiveInTheAbsenceOfNonInjectiveFunctionalTerms() {
         return false;
     }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/BinaryArithmeticTermTypeFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/BinaryArithmeticTermTypeFunctionSymbolImpl.java
@@ -12,14 +12,14 @@ import it.unibz.inf.ontop.utils.ImmutableCollectors;
 
 import java.util.Optional;
 
-public class BinaryArithmeticTypeFunctionSymbolImpl extends FunctionSymbolImpl{
+public class BinaryArithmeticTermTypeFunctionSymbolImpl extends FunctionSymbolImpl{
 
     private final MetaRDFTermType metaRDFTermType;
     private final TypeFactory typeFactory;
 
-    protected BinaryArithmeticTypeFunctionSymbolImpl(String dbOperationName, DBTermType dbTermType,
-                                                     MetaRDFTermType metaRDFType, TypeFactory typeFactory) {
-        super("LATELY_OP_TYPE_" + dbOperationName, ImmutableList.of(dbTermType, dbTermType, metaRDFType, metaRDFType));
+    protected BinaryArithmeticTermTypeFunctionSymbolImpl(String dbOperationName, DBTermType dbTermType,
+                                                         MetaRDFTermType metaRDFType, TypeFactory typeFactory) {
+        super("BINARY_TYPE_" + dbOperationName, ImmutableList.of(dbTermType, dbTermType, metaRDFType, metaRDFType));
 
         this.metaRDFTermType = metaRDFType;
         this.typeFactory = typeFactory;
@@ -61,11 +61,14 @@ public class BinaryArithmeticTypeFunctionSymbolImpl extends FunctionSymbolImpl{
                     .map(t -> ((RDFTermTypeConstant) t).getRDFTermType())
                     .collect(ImmutableCollectors.toList());
 
-            if (rdfTypeConstants.stream().anyMatch(t -> t.isA(typeFactory.getAbstractOntopTemporalDatatype()))) {
+            if (rdfTypeConstants.stream().allMatch(t -> t.isA(typeFactory.getAbstractOntopNumericDatatype()))) {
+                return termFactory.getCommonPropagatedOrSubstitutedNumericType(typeTerms.get(0), typeTerms.get(1));
+            } else if (rdfTypeConstants.stream().anyMatch(t -> t.isA(typeFactory.getAbstractOntopTemporalDatatype()))) {
                 throw new UnsupportedOperationException(
-                        "Binary arithmetic operations on temporal types are not supported");
+                        "Binary arithmetic operations on temporal types are not yet supported");
+            } else {
+                return termFactory.getRDFFunctionalTerm(termFactory.getNullConstant(), termFactory.getNullConstant());
             }
-            return termFactory.getCommonPropagatedOrSubstitutedNumericType(typeTerms.get(0), typeTerms.get(1));
         } else if (typeTerms.stream().anyMatch(t -> t instanceof ImmutableFunctionalTerm)) {
             return typeTerms.stream()
                     .filter(t -> t instanceof ImmutableFunctionalTerm)

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/BinaryArithmeticTypeFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/BinaryArithmeticTypeFunctionSymbolImpl.java
@@ -1,0 +1,74 @@
+package it.unibz.inf.ontop.model.term.functionsymbol.impl;
+
+import com.google.common.collect.ImmutableList;
+import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.RDFTermTypeConstant;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.type.*;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
+
+import java.util.Optional;
+
+public class BinaryArithmeticTypeFunctionSymbolImpl extends FunctionSymbolImpl{
+
+    private final MetaRDFTermType metaRDFTermType;
+    private final TypeFactory typeFactory;
+
+    protected BinaryArithmeticTypeFunctionSymbolImpl(String dbOperationName, DBTermType dbTermType,
+                                                     MetaRDFTermType metaRDFType, TypeFactory typeFactory) {
+        super("LATELY_OP_TYPE_" + dbOperationName, ImmutableList.of(dbTermType, dbTermType, metaRDFType, metaRDFType));
+
+        this.metaRDFTermType = metaRDFType;
+        this.typeFactory = typeFactory;
+    }
+
+    @Override
+    protected boolean isAlwaysInjectiveInTheAbsenceOfNonInjectiveFunctionalTerms() {
+        return false;
+    }
+
+    @Override
+    protected boolean tolerateNulls() {
+        return false;
+    }
+
+    @Override
+    protected boolean mayReturnNullWithoutNullArguments() {
+        return true;
+    }
+
+    @Override
+    public Optional<TermTypeInference> inferType(ImmutableList<? extends ImmutableTerm> terms) {
+        return Optional.of(TermTypeInference.declareTermType(metaRDFTermType));
+    }
+
+    @Override
+    public boolean canBePostProcessed(ImmutableList<? extends ImmutableTerm> arguments) {
+        return true;
+    }
+
+    @Override
+    protected ImmutableTerm buildTermAfterEvaluation(ImmutableList<ImmutableTerm> newTerms, TermFactory termFactory,
+                                                     VariableNullability variableNullability) {
+
+        ImmutableList<ImmutableTerm> typeTerms = ImmutableList.of(newTerms.get(2), newTerms.get(3));
+
+        if (typeTerms.stream().allMatch(t -> t instanceof RDFTermTypeConstant)) {
+            ImmutableList<RDFTermType> rdfTypeConstants = typeTerms.stream()
+                    .map(t -> ((RDFTermTypeConstant) t).getRDFTermType())
+                    .collect(ImmutableCollectors.toList());
+
+            if (rdfTypeConstants.stream().anyMatch(t -> t.isA(typeFactory.getAbstractOntopTemporalDatatype()))) {
+                throw new UnsupportedOperationException(
+                        "Binary arithmetic operations on temporal types are not supported");
+            }
+            return termFactory.getCommonPropagatedOrSubstitutedNumericType(typeTerms.get(0), typeTerms.get(1));
+        }
+
+        // for now no additional logic
+        return termFactory.getCommonPropagatedOrSubstitutedNumericType(typeTerms.get(0), typeTerms.get(1));
+
+
+    }
+}

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/DivideSPARQLFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/DivideSPARQLFunctionSymbolImpl.java
@@ -7,6 +7,7 @@ import it.unibz.inf.ontop.model.term.ImmutableTerm;
 import it.unibz.inf.ontop.model.term.TermFactory;
 import it.unibz.inf.ontop.model.type.RDFDatatype;
 import it.unibz.inf.ontop.model.type.RDFTermType;
+import it.unibz.inf.ontop.model.type.TypeFactory;
 import it.unibz.inf.ontop.model.vocabulary.SPARQL;
 import it.unibz.inf.ontop.utils.ImmutableCollectors;
 
@@ -17,8 +18,8 @@ public class DivideSPARQLFunctionSymbolImpl extends BinaryArithmeticSPARQLFuncti
 
     private final RDFDatatype xsdDecimalType;
 
-    protected DivideSPARQLFunctionSymbolImpl(RDFDatatype abstractNumericType, RDFDatatype xsdDecimalType) {
-        super("SP_DIVIDE", SPARQL.DIVIDE, abstractNumericType);
+    protected DivideSPARQLFunctionSymbolImpl(RDFDatatype abstractNumericType, RDFDatatype xsdDecimalType, TypeFactory typeFactory) {
+        super("SP_DIVIDE", SPARQL.DIVIDE, abstractNumericType, typeFactory);
         this.xsdDecimalType = xsdDecimalType;
     }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/DivideSPARQLFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/DivideSPARQLFunctionSymbolImpl.java
@@ -13,12 +13,12 @@ import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-public class DivideSPARQLFunctionSymbolImpl extends NumericBinarySPARQLFunctionSymbolImpl {
+public class DivideSPARQLFunctionSymbolImpl extends BinaryArithmeticSPARQLFunctionSymbolImpl {
 
     private final RDFDatatype xsdDecimalType;
 
     protected DivideSPARQLFunctionSymbolImpl(RDFDatatype abstractNumericType, RDFDatatype xsdDecimalType) {
-        super("SP_DIVIDE", SPARQL.NUMERIC_DIVIDE, abstractNumericType);
+        super("SP_DIVIDE", SPARQL.DIVIDE, abstractNumericType);
         this.xsdDecimalType = xsdDecimalType;
     }
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/FunctionSymbolFactoryImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/FunctionSymbolFactoryImpl.java
@@ -186,10 +186,10 @@ public class FunctionSymbolFactoryImpl implements FunctionSymbolFactory {
                 new Sha256SPARQLFunctionSymbolImpl(xsdString),
                 new Sha384SPARQLFunctionSymbolImpl(xsdString),
                 new Sha512SPARQLFunctionSymbolImpl(xsdString),
-                new BinaryArithmeticSPARQLFunctionSymbolImpl("SP_MULTIPLY", SPARQL.MULTIPLY, abstractNumericOrTemporalType),
-                new BinaryArithmeticSPARQLFunctionSymbolImpl("SP_ADD", SPARQL.ADD, abstractNumericOrTemporalType),
-                new BinaryArithmeticSPARQLFunctionSymbolImpl("SP_SUBSTRACT", SPARQL.SUBTRACT, abstractNumericOrTemporalType),
-                new DivideSPARQLFunctionSymbolImpl(abstractNumericType, xsdDecimal),
+                new BinaryArithmeticSPARQLFunctionSymbolImpl("SP_MULTIPLY", SPARQL.MULTIPLY, abstractNumericOrTemporalType, typeFactory),
+                new BinaryArithmeticSPARQLFunctionSymbolImpl("SP_ADD", SPARQL.ADD, abstractNumericOrTemporalType, typeFactory),
+                new BinaryArithmeticSPARQLFunctionSymbolImpl("SP_SUBSTRACT", SPARQL.SUBTRACT, abstractNumericOrTemporalType, typeFactory),
+                new DivideSPARQLFunctionSymbolImpl(abstractNumericType, xsdDecimal, typeFactory),
                 new NonStrictEqSPARQLFunctionSymbolImpl(abstractRDFType, xsdBoolean, dbBoolean),
                 new LessThanSPARQLFunctionSymbolImpl(abstractRDFType, xsdBoolean, dbBoolean),
                 new GreaterThanSPARQLFunctionSymbolImpl(abstractRDFType, xsdBoolean, dbBoolean),
@@ -688,16 +688,6 @@ public class FunctionSymbolFactoryImpl implements FunctionSymbolFactory {
     @Override
     public BooleanFunctionSymbol getLexicalLangMatches() {
         return lexicalLangMatchesFunctionSymbol;
-    }
-
-    @Override
-    public FunctionSymbol getBinaryArithmeticLexicalFunctionSymbol(String dbOperationName) {
-        return new BinaryArithmeticLexicalFunctionSymbolImpl(dbOperationName, dbStringType, metaRDFType);
-    }
-
-    @Override
-    public FunctionSymbol getBinaryArithmeticTypeFunctionSymbol(String dbOperationName) {
-        return new BinaryArithmeticTypeFunctionSymbolImpl(dbOperationName, dbStringType, metaRDFType, typeFactory);
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/FunctionSymbolFactoryImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/FunctionSymbolFactoryImpl.java
@@ -1,6 +1,7 @@
 package it.unibz.inf.ontop.model.term.functionsymbol.impl;
 
 import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
 import com.google.inject.Inject;
@@ -141,6 +142,7 @@ public class FunctionSymbolFactoryImpl implements FunctionSymbolFactory {
         RDFDatatype xsdDatetime = typeFactory.getXsdDatetimeDatatype();
         RDFDatatype xsdDate = typeFactory.getXsdDate();
         RDFDatatype abstractNumericType = typeFactory.getAbstractOntopNumericDatatype();
+        RDFDatatype abstractNumericOrTemporalType = typeFactory.getAbstractOntopNumericOrTemporalDatatype();
         RDFDatatype dateOrDatetime = typeFactory.getAbstractOntopDateOrDatetimeDatatype();
 
         DBTypeFactory dbTypeFactory = typeFactory.getDBTypeFactory();
@@ -184,9 +186,9 @@ public class FunctionSymbolFactoryImpl implements FunctionSymbolFactory {
                 new Sha256SPARQLFunctionSymbolImpl(xsdString),
                 new Sha384SPARQLFunctionSymbolImpl(xsdString),
                 new Sha512SPARQLFunctionSymbolImpl(xsdString),
-                new NumericBinarySPARQLFunctionSymbolImpl("SP_MULTIPLY", SPARQL.NUMERIC_MULTIPLY, abstractNumericType),
-                new NumericBinarySPARQLFunctionSymbolImpl("SP_ADD", SPARQL.NUMERIC_ADD, abstractNumericType),
-                new NumericBinarySPARQLFunctionSymbolImpl("SP_SUBSTRACT", SPARQL.NUMERIC_SUBTRACT, abstractNumericType),
+                new BinaryArithmeticSPARQLFunctionSymbolImpl("SP_MULTIPLY", SPARQL.MULTIPLY, abstractNumericOrTemporalType),
+                new BinaryArithmeticSPARQLFunctionSymbolImpl("SP_ADD", SPARQL.ADD, abstractNumericOrTemporalType),
+                new BinaryArithmeticSPARQLFunctionSymbolImpl("SP_SUBSTRACT", SPARQL.SUBTRACT, abstractNumericOrTemporalType),
                 new DivideSPARQLFunctionSymbolImpl(abstractNumericType, xsdDecimal),
                 new NonStrictEqSPARQLFunctionSymbolImpl(abstractRDFType, xsdBoolean, dbBoolean),
                 new LessThanSPARQLFunctionSymbolImpl(abstractRDFType, xsdBoolean, dbBoolean),
@@ -689,8 +691,13 @@ public class FunctionSymbolFactoryImpl implements FunctionSymbolFactory {
     }
 
     @Override
-    public FunctionSymbol getBinaryNumericLexicalFunctionSymbol(String dbNumericOperationName) {
-        return new BinaryNumericLexicalFunctionSymbolImpl(dbNumericOperationName, dbStringType, metaRDFType);
+    public FunctionSymbol getBinaryArithmeticLexicalFunctionSymbol(String dbOperationName) {
+        return new BinaryArithmeticLexicalFunctionSymbolImpl(dbOperationName, dbStringType, metaRDFType);
+    }
+
+    @Override
+    public FunctionSymbol getBinaryArithmeticTypeFunctionSymbol(String dbOperationName) {
+        return new BinaryArithmeticTypeFunctionSymbolImpl(dbOperationName, dbStringType, metaRDFType, typeFactory);
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/SumSPARQLFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/SumSPARQLFunctionSymbolImpl.java
@@ -24,7 +24,7 @@ public class SumSPARQLFunctionSymbolImpl extends SumLikeSPARQLAggregationFunctio
     @Override
     protected ImmutableTerm combineAggregates(ImmutableTerm aggregate1, ImmutableTerm aggregate2, TermFactory termFactory) {
         DBTermType dbDecimalType = termFactory.getTypeFactory().getDBTypeFactory().getDBDecimalType();
-        return termFactory.getDBBinaryNumericFunctionalTerm(SPARQL.NUMERIC_ADD, dbDecimalType, aggregate1, aggregate2);
+        return termFactory.getDBBinaryNumericFunctionalTerm(SPARQL.ADD, dbDecimalType, aggregate1, aggregate2);
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/impl/TermFactoryImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/impl/TermFactoryImpl.java
@@ -453,13 +453,19 @@ public class TermFactoryImpl implements TermFactory {
 	}
 
 	@Override
-	public ImmutableFunctionalTerm getBinaryNumericLexicalFunctionalTerm(String dbNumericOperationName,
-																		 ImmutableTerm lexicalTerm1,
-																		 ImmutableTerm lexicalTerm2,
-																		 ImmutableTerm rdfTypeTerm) {
+	public ImmutableFunctionalTerm getBinaryArithmeticLexicalFunctionalTerm(String dbOperationName, ImmutableTerm lexicalTerm1, ImmutableTerm lexicalTerm2,
+																		  ImmutableTerm inputRDFType1, ImmutableTerm inputRDFType2, ImmutableTerm returnRDFType) {
 		return getImmutableFunctionalTerm(
-				functionSymbolFactory.getBinaryNumericLexicalFunctionSymbol(dbNumericOperationName),
-				lexicalTerm1, lexicalTerm2, rdfTypeTerm);
+				functionSymbolFactory.getBinaryArithmeticLexicalFunctionSymbol(dbOperationName),
+				lexicalTerm1, lexicalTerm2, inputRDFType1, inputRDFType2, returnRDFType);
+	}
+
+	@Override
+	public ImmutableFunctionalTerm getBinaryArithmeticTypeFunctionalTerm(String dbOperationName, ImmutableTerm lexicalTerm1,
+			ImmutableTerm lexicalTerm2, ImmutableTerm termType1, ImmutableTerm termType2) {
+		return getImmutableFunctionalTerm(
+				functionSymbolFactory.getBinaryArithmeticTypeFunctionSymbol(dbOperationName),
+				lexicalTerm1, lexicalTerm2, termType1, termType2);
 	}
 
 	@Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/impl/TermFactoryImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/impl/TermFactoryImpl.java
@@ -453,22 +453,6 @@ public class TermFactoryImpl implements TermFactory {
 	}
 
 	@Override
-	public ImmutableFunctionalTerm getBinaryArithmeticLexicalFunctionalTerm(String dbOperationName, ImmutableTerm lexicalTerm1, ImmutableTerm lexicalTerm2,
-																		  ImmutableTerm inputRDFType1, ImmutableTerm inputRDFType2, ImmutableTerm returnRDFType) {
-		return getImmutableFunctionalTerm(
-				functionSymbolFactory.getBinaryArithmeticLexicalFunctionSymbol(dbOperationName),
-				lexicalTerm1, lexicalTerm2, inputRDFType1, inputRDFType2, returnRDFType);
-	}
-
-	@Override
-	public ImmutableFunctionalTerm getBinaryArithmeticTypeFunctionalTerm(String dbOperationName, ImmutableTerm lexicalTerm1,
-			ImmutableTerm lexicalTerm2, ImmutableTerm termType1, ImmutableTerm termType2) {
-		return getImmutableFunctionalTerm(
-				functionSymbolFactory.getBinaryArithmeticTypeFunctionSymbol(dbOperationName),
-				lexicalTerm1, lexicalTerm2, termType1, termType2);
-	}
-
-	@Override
 	public ImmutableFunctionalTerm getDBBinaryNumericFunctionalTerm(String dbNumericOperationName,  DBTermType dbNumericType,
 																	ImmutableTerm dbTerm1, ImmutableTerm dbTerm2) {
 		return getImmutableFunctionalTerm(

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/type/TypeFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/type/TypeFactory.java
@@ -24,6 +24,8 @@ public interface TypeFactory {
 
 	RDFDatatype getAbstractOntopNumericDatatype();
 	RDFDatatype getAbstractOntopDateOrDatetimeDatatype();
+	RDFDatatype getAbstractOntopTemporalDatatype();
+	RDFDatatype getAbstractOntopNumericOrTemporalDatatype();
 
 	RDFDatatype getAbstractRDFSLiteral();
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/type/impl/TypeFactoryImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/type/impl/TypeFactoryImpl.java
@@ -41,6 +41,7 @@ public class TypeFactoryImpl implements TypeFactory {
 	private final ConcreteNumericRDFDatatype xsdUnsignedLongDatatype, xsdUnsignedIntDatatype, xsdUnsignedShortDatatype, xsdUnsignedByteDatatype;
 	private final RDFDatatype defaultUnsupportedDatatype, xsdStringDatatype, xsdBooleanDatatype, xsdBase64Datatype;
 	private final RDFDatatype xsdTimeDatatype, xsdDateDatatype, xsdDatetimeDatatype, xsdDatetimeStampDatatype, xsdGYearDatatype;
+	private final RDFDatatype temporalDatatype, numericOrTemporalDatatype;
 	private final DBTypeFactory dbTypeFactory;
 
 	@Inject
@@ -58,7 +59,10 @@ public class TypeFactoryImpl implements TypeFactory {
 		rdfsLiteralDatatype = createSimpleAbstractRDFDatatype(RDFS.LITERAL, rootRDFTermType.getAncestry());
 		registerDatatype(rdfsLiteralDatatype);
 
-		numericDatatype = createAbstractNumericTermType(OntopInternal.NUMERIC, rdfsLiteralDatatype.getAncestry());
+		numericOrTemporalDatatype = createSimpleAbstractRDFDatatype(OntopInternal.NUMERIC_OR_TEMPORAL, rdfsLiteralDatatype.getAncestry());
+		registerDatatype(numericOrTemporalDatatype);
+
+		numericDatatype = createAbstractNumericTermType(OntopInternal.NUMERIC, numericOrTemporalDatatype.getAncestry());
 		registerDatatype(numericDatatype);
 
 		xsdDoubleDatatype = createTopConcreteNumericTermType(XSD.DOUBLE, numericDatatype,
@@ -160,11 +164,14 @@ public class TypeFactoryImpl implements TypeFactory {
 
 		defaultUnsupportedDatatype = UnsupportedRDFDatatype.createUnsupportedDatatype(rdfsLiteralDatatype.getAncestry());
 
-		xsdTimeDatatype = createSimpleConcreteRDFDatatype(XSD.TIME, rdfsLiteralDatatype.getAncestry(),
+		temporalDatatype = createSimpleAbstractRDFDatatype(OntopInternal.TEMPORAL, numericOrTemporalDatatype.getAncestry());
+		registerDatatype(temporalDatatype);
+
+		xsdTimeDatatype = createSimpleConcreteRDFDatatype(XSD.TIME, temporalDatatype.getAncestry(),
 				DBTypeFactory::getDBTimeType);
 		registerDatatype(xsdTimeDatatype);
 
-		dateOrDatetimeDatatype = createSimpleAbstractRDFDatatype(OntopInternal.DATE_OR_DATETIME, rdfsLiteralDatatype.getAncestry());
+		dateOrDatetimeDatatype = createSimpleAbstractRDFDatatype(OntopInternal.DATE_OR_DATETIME, temporalDatatype.getAncestry());
 		registerDatatype(dateOrDatetimeDatatype);
 
 		xsdDateDatatype = createSimpleConcreteRDFDatatype(XSD.DATE, dateOrDatetimeDatatype.getAncestry(),
@@ -177,7 +184,7 @@ public class TypeFactoryImpl implements TypeFactory {
 		xsdDatetimeStampDatatype = createSimpleConcreteRDFDatatype(XSD.DATETIMESTAMP, xsdDatetimeDatatype.getAncestry(),
 				DBTypeFactory::getDBDateTimestampType);
 		registerDatatype(xsdDatetimeStampDatatype);
-		xsdGYearDatatype = createSimpleConcreteRDFDatatype(XSD.GYEAR, rdfsLiteralDatatype.getAncestry(),
+		xsdGYearDatatype = createSimpleConcreteRDFDatatype(XSD.GYEAR, temporalDatatype.getAncestry(),
 				// TODO: check
 				DBTypeFactory::getDBStringType);
 		registerDatatype(xsdGYearDatatype);
@@ -224,14 +231,20 @@ public class TypeFactoryImpl implements TypeFactory {
 	}
 
 	@Override
-	public RDFDatatype getAbstractOntopNumericDatatype() {
-		return numericDatatype;
-	}
+	public RDFDatatype getAbstractOntopNumericDatatype() { return numericDatatype; }
 
 	@Override
 	public RDFDatatype getAbstractOntopDateOrDatetimeDatatype() {
 		return dateOrDatetimeDatatype;
 	}
+
+	@Override
+	public RDFDatatype getAbstractOntopTemporalDatatype() {
+		return temporalDatatype;
+	}
+
+	@Override
+	public RDFDatatype getAbstractOntopNumericOrTemporalDatatype() { return numericOrTemporalDatatype; }
 
 	@Override
 	public RDFDatatype getAbstractRDFSLiteral() {

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/vocabulary/OntopInternal.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/vocabulary/OntopInternal.java
@@ -9,8 +9,11 @@ public class OntopInternal {
     private static final String PREFIX = "urn:it:unibz:inf:ontop:internal:";
 
 
+    // TODO: would it make sense to remove DATE_OR_DATETIME
     public static final IRI NUMERIC;
     public static final IRI DATE_OR_DATETIME;
+    public static final IRI TEMPORAL;
+    public static final IRI NUMERIC_OR_TEMPORAL;
 
     /**
      * TODO: remove it!
@@ -28,6 +31,8 @@ public class OntopInternal {
 
         NUMERIC = rdfFactory.createIRI(PREFIX + "numeric");
         DATE_OR_DATETIME = rdfFactory.createIRI(PREFIX + "dateOrDateTime");
+        TEMPORAL = rdfFactory.createIRI(PREFIX + "temporal");
+        NUMERIC_OR_TEMPORAL = rdfFactory.createIRI(PREFIX + "numericOrTemporal");
         UNSUPPORTED = rdfFactory.createIRI(PREFIX + "unsupported");
         PREFIX_XSD = "xsd:";
         PREFIX_RDF = "rdf:";

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/vocabulary/SPARQL.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/vocabulary/SPARQL.java
@@ -21,10 +21,10 @@ public class SPARQL {
     public static final String SHA256 = "SHA256";
     public static final String SHA384 = "SHA384";
     public static final String SHA512 = "SHA512";
-    public static final String NUMERIC_MULTIPLY = "*";
-    public static final String NUMERIC_DIVIDE = "/";
-    public static final String NUMERIC_ADD = "+";
-    public static final String NUMERIC_SUBTRACT = "-";
+    public static final String MULTIPLY = "*";
+    public static final String DIVIDE = "/";
+    public static final String ADD = "+";
+    public static final String SUBTRACT = "-";
     public static final String EQ = "=";
     public static final String LESS_THAN = "<";
     public static final String GREATER_THAN = ">";

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/BigQueryDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/BigQueryDBFunctionSymbolFactory.java
@@ -11,7 +11,6 @@ import it.unibz.inf.ontop.model.type.TypeFactory;
 import it.unibz.inf.ontop.model.vocabulary.SPARQL;
 
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Function;
 
 public class BigQueryDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFactory {
@@ -276,7 +275,7 @@ public class BigQueryDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
 
     @Override
     protected DBTermType inferOutputTypeMathOperator(String dbMathOperatorName, DBTermType arg1Type, DBTermType arg2Type) {
-        if (dbMathOperatorName.equals(SPARQL.NUMERIC_DIVIDE))
+        if (dbMathOperatorName.equals(SPARQL.DIVIDE))
             return dbDecimalType;
 
         return super.inferOutputTypeMathOperator(dbMathOperatorName, arg1Type, arg2Type);

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/MySQLDBFunctionSymbolFactory.java
@@ -112,7 +112,7 @@ public class MySQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFac
 
     @Override
     protected DBTermType inferOutputTypeMathOperator(String dbMathOperatorName, DBTermType arg1Type, DBTermType arg2Type) {
-        if (dbMathOperatorName.equals(SPARQL.NUMERIC_DIVIDE))
+        if (dbMathOperatorName.equals(SPARQL.DIVIDE))
             return dbDecimalType;
 
         return super.inferOutputTypeMathOperator(dbMathOperatorName, arg1Type, arg2Type);

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/OracleDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/OracleDBFunctionSymbolFactory.java
@@ -587,7 +587,7 @@ public class OracleDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbolFa
 
     @Override
     protected DBTermType inferOutputTypeMathOperator(String dbMathOperatorName, DBTermType arg1Type, DBTermType arg2Type) {
-        if (dbMathOperatorName.equals(SPARQL.NUMERIC_DIVIDE))
+        if (dbMathOperatorName.equals(SPARQL.DIVIDE))
             return dbDecimalType;
 
         return super.inferOutputTypeMathOperator(dbMathOperatorName, arg1Type, arg2Type);

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SnowflakeDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SnowflakeDBFunctionSymbolFactory.java
@@ -294,7 +294,7 @@ public class SnowflakeDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbo
 
     @Override
     protected DBTermType inferOutputTypeMathOperator(String dbMathOperatorName, DBTermType arg1Type, DBTermType arg2Type) {
-        if (dbMathOperatorName.equals(SPARQL.NUMERIC_DIVIDE))
+        if (dbMathOperatorName.equals(SPARQL.DIVIDE))
             return dbDecimalType;
 
         return super.inferOutputTypeMathOperator(dbMathOperatorName, arg1Type, arg2Type);

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SparkSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/SparkSQLDBFunctionSymbolFactory.java
@@ -11,7 +11,6 @@ import it.unibz.inf.ontop.model.vocabulary.SPARQL;
 
 
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static it.unibz.inf.ontop.model.type.impl.SparkSQLDBTypeFactory.DECIMAL_38_10_STR;
 
@@ -306,7 +305,7 @@ public class SparkSQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymbol
 
     @Override
     protected DBTermType inferOutputTypeMathOperator(String dbMathOperatorName, DBTermType arg1Type, DBTermType arg2Type) {
-        if (dbMathOperatorName.equals(SPARQL.NUMERIC_DIVIDE))
+        if (dbMathOperatorName.equals(SPARQL.DIVIDE))
             return dbDecimalType;
 
         return super.inferOutputTypeMathOperator(dbMathOperatorName, arg1Type, arg2Type);

--- a/db/rdb/src/test/java/it/unibz/inf/ontop/spec/sqlparser/ExpressionParserTest.java
+++ b/db/rdb/src/test/java/it/unibz/inf/ontop/spec/sqlparser/ExpressionParserTest.java
@@ -966,7 +966,7 @@ public class ExpressionParserTest {
                 new QualifiedAttributeID(null, IDFAC.createAttributeID("X")), v));
 
         Assert.assertEquals(TERM_FACTORY.getImmutableFunctionalTerm(
-                DB_FS_FACTORY.getUntypedDBMathBinaryOperator(SPARQL.NUMERIC_MULTIPLY),
+                DB_FS_FACTORY.getUntypedDBMathBinaryOperator(SPARQL.MULTIPLY),
                 TERM_FACTORY.getDBConstant("-1", DB_TYPE_FACTORY.getDBLargeIntegerType()),
                 v), translation);
     }


### PR DESCRIPTION
This PR refactors the functions symbols for numeric binary operations in order to make them more generic.

More specifically, the new function symbols consider now general binary arithmetic operations between arbitrary datatypes (e.g. `xsd:dateTime + xsd:duration`), even if currently only numeric operations are supported. This way numeric binary operations become a special case of the more generic binary arithmetic operations instead of being considered as default.

Two function symbols have been introduced:
- `BinaryArithmeticTermTypeFunctionSymbol`: constructs the type part of the RDF term by simplifying the types for the two arguments and returning the type of the result. 
- `BinaryArithmeticLexicalFunctionSymbol`: constructs the lexical part of the RDF term, creating the functional term for the corresponding database-level operation. 
Currently, the lexical function symbol only gets information about the return type of the operation and this is enough for numeric operations but not for other cases where the types of the two arguments are also needed. For example, suppose we know that the result type of the operation  is `xsd:duration`, there is no way to know if the original operation was `xsd:dateTime - xsd:dateTime` or `xsd:integer * xsd:duration`. 
To address this, the lexical function symbol is responsible for simplifying the types of the two arguments as well.