### PR TITLE
Union graph (magic IRI)

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/BasicGraphTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/BasicGraphTest.java
@@ -1,0 +1,91 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.*;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.*;
+
+public class BasicGraphTest extends AbstractRDF4JTest {
+    private static final String OBDA_FILE = "/union-graph-test/mapping.obda";
+    private static final String SQL_SCRIPT = "/union-graph-test/schema.sql";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE, null);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void testBasicTripleQuery() {
+        String query = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT * WHERE { " +
+            "  ?person a foaf:Person ; foaf:name ?name " +
+            "} LIMIT 5";
+        
+        int count = runQueryAndCount(query);
+        System.out.println("Basic triple query count: " + count);
+        
+        ImmutableList<ImmutableMap<String, String>> results = executeQuery(query);
+        System.out.println("Basic triple query results: " + results);
+    }
+
+    @Test
+    public void testGraphVariableQuery() {
+        String query = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT * WHERE { " +
+            "  GRAPH ?g { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "  } " +
+            "} LIMIT 5";
+        
+        int count = runQueryAndCount(query);
+        System.out.println("GRAPH ?g query count: " + count);
+        
+        ImmutableList<ImmutableMap<String, String>> results = executeQuery(query);
+        System.out.println("GRAPH ?g query results: " + results);
+    }
+
+    @Test
+    public void testSpecificGraphQuery() {
+        String query = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT * WHERE { " +
+            "  GRAPH <http://example.org/graph/corp> { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "  } " +
+            "} LIMIT 5";
+        
+        int count = runQueryAndCount(query);
+        System.out.println("Specific graph query count: " + count);
+        
+        ImmutableList<ImmutableMap<String, String>> results = executeQuery(query);
+        System.out.println("Specific graph query results: " + results);
+    }
+
+    @Test
+    public void testUnionGraphQuery() {
+        String query = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT * WHERE { " +
+            "  GRAPH <urn:x-arq:UnionGraph> { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "  } " +
+            "} LIMIT 5";
+        
+        int count = runQueryAndCount(query);
+        System.out.println("UnionGraph query count: " + count);
+        
+        ImmutableList<ImmutableMap<String, String>> results = executeQuery(query);
+        System.out.println("UnionGraph query results: " + results);
+    }
+}

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/UnionGraphDebugTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/UnionGraphDebugTest.java
@@ -1,0 +1,80 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.*;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.*;
+
+public class UnionGraphDebugTest extends AbstractRDF4JTest {
+    private static final String OBDA_FILE = "/union-graph-test/mapping.obda";
+    private static final String SQL_SCRIPT = "/union-graph-test/schema.sql";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE, null);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void debugUnionGraphVsGraphVariable() {
+        System.out.println("=== Testing GRAPH ?g ===");
+        String graphVarQuery = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT * WHERE { " +
+            "  GRAPH ?g { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "  } " +
+            "}";
+        
+        ImmutableList<ImmutableMap<String, String>> graphVarResults = executeQuery(graphVarQuery);
+        System.out.println("GRAPH ?g results: " + graphVarResults.size());
+        for (ImmutableMap<String, String> result : graphVarResults) {
+            System.out.println("  " + result);
+        }
+
+        System.out.println("\n=== Testing UnionGraph ===");
+        String unionGraphQuery = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT * WHERE { " +
+            "  GRAPH <urn:x-arq:UnionGraph> { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "  } " +
+            "}";
+        
+        System.out.println("UnionGraph query: " + unionGraphQuery);
+        ImmutableList<ImmutableMap<String, String>> unionResults = executeQuery(unionGraphQuery);
+        System.out.println("UnionGraph results: " + unionResults.size());
+        for (ImmutableMap<String, String> result : unionResults) {
+            System.out.println("  " + result);
+        }
+
+        System.out.println("\n=== Testing with FROM NAMED ===");
+        String unionWithDatasetQuery = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT * " +
+            "FROM NAMED <http://example.org/graph/corp> " +
+            "FROM NAMED <http://example.org/graph/academic> " +
+            "WHERE { " +
+            "  GRAPH <urn:x-arq:UnionGraph> { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "  } " +
+            "}";
+        
+        ImmutableList<ImmutableMap<String, String>> datasetResults = executeQuery(unionWithDatasetQuery);
+        System.out.println("UnionGraph with FROM NAMED results: " + datasetResults.size());
+        for (ImmutableMap<String, String> result : datasetResults) {
+            System.out.println("  " + result);
+        }
+
+        // The UnionGraph should work the same as GRAPH ?g when no dataset is specified
+        assertTrue("GRAPH ?g should return results", graphVarResults.size() > 0);
+    }
+}

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/UnionGraphQuadTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/UnionGraphQuadTest.java
@@ -1,0 +1,188 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.eclipse.rdf4j.query.*;
+import org.junit.*;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class UnionGraphQuadTest extends AbstractRDF4JTest {
+    private static final String OBDA_FILE = "/union-graph-test/mapping.obda";
+    private static final String SQL_SCRIPT = "/union-graph-test/schema.sql";
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE, null);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void testUnionGraphReturnsAllNamedGraphData() {
+        String unionGraphQuery = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "PREFIX org: <http://www.w3.org/ns/org#> " +
+            "SELECT * WHERE { " +
+            "  GRAPH <urn:x-arq:UnionGraph> { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "  } " +
+            "} ORDER BY ?name";
+        
+        int unionCount = runQueryAndCount(unionGraphQuery);
+        
+        // Should return all persons from all named graphs (5 persons total)
+        assertTrue("UnionGraph should return all persons from all graphs", unionCount >= 5);
+    }
+
+    @Test 
+    public void testUnionGraphVsRegularGraphVariable() {
+        // Query using regular graph variable
+        String graphVarQuery = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT * WHERE { " +
+            "  GRAPH ?g { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "  } " +
+            "} ORDER BY ?name";
+            
+        // Query using UnionGraph
+        String unionGraphQuery = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT * WHERE { " +
+            "  GRAPH <urn:x-arq:UnionGraph> { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "  } " +
+            "} ORDER BY ?name";
+        
+        int graphVarCount = runQueryAndCount(graphVarQuery);
+        int unionGraphCount = runQueryAndCount(unionGraphQuery);
+        
+        // Both should return the same number of results
+        assertEquals("UnionGraph and GRAPH ?g should return same number of results", 
+                     graphVarCount, unionGraphCount);
+        assertTrue("Should have found some persons", unionGraphCount > 0);
+    }
+
+    @Test
+    public void testUnionGraphWithComplexPattern() {
+        // Test UnionGraph returns all people across multiple named graphs (simplified version)
+        String unionGraphQuery = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT ?person ?name WHERE { " +
+            "  GRAPH <urn:x-arq:UnionGraph> { " +
+            "    ?person a foaf:Person ; " +
+            "            foaf:name ?name " +
+            "  } " +
+            "} ORDER BY ?name";
+        
+        int count = runQueryAndCount(unionGraphQuery);
+        assertTrue("Should find people across all graphs", count >= 3);
+    }
+
+    @Test
+    public void testUnionGraphWithSpecificNamedGraph() {
+        // First, test a query restricted to a specific named graph
+        String specificGraphQuery = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT * WHERE { " +
+            "  GRAPH <http://example.org/graph/corp> { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "  } " +
+            "} ORDER BY ?name";
+            
+        int specificCount = runQueryAndCount(specificGraphQuery);
+        
+        // Now test UnionGraph which should return more results (from all graphs)
+        String unionGraphQuery = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT * WHERE { " +
+            "  GRAPH <urn:x-arq:UnionGraph> { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "  } " +
+            "} ORDER BY ?name";
+            
+        int unionCount = runQueryAndCount(unionGraphQuery);
+        
+        assertTrue("Specific graph should have some results", specificCount > 0);
+        assertTrue("UnionGraph should have more results than any single graph", 
+                   unionCount > specificCount);
+    }
+
+    @Test
+    public void testUnionGraphResultContent() {
+        // Test that we actually get the expected content
+        String unionGraphQuery = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT ?name WHERE { " +
+            "  GRAPH <urn:x-arq:UnionGraph> { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "  } " +
+            "} ORDER BY ?name";
+        
+        ImmutableList<ImmutableMap<String, String>> results = executeQuery(unionGraphQuery);
+        
+        Set<String> names = new HashSet<>();
+        for (ImmutableMap<String, String> row : results) {
+            String name = row.get("name");
+            if (name != null) {
+                names.add(name);
+            }
+        }
+        
+        // Verify we got names from different graphs
+        assertTrue("Should contain John Smith from corp graph", names.contains("John Smith"));
+        assertTrue("Should contain Prof. Wilson from academic graph", names.contains("Prof. Wilson"));
+        assertTrue("Should contain Dr. Brown from research graph", names.contains("Dr. Brown"));
+        assertTrue("Should have found at least 3 different names", names.size() >= 3);
+    }
+
+    @Test
+    public void testUnionGraphWithSpecificPerson() {
+        // Test finding a specific person in the union of all graphs
+        String findPersonQuery = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT ?name WHERE { " +
+            "  GRAPH <urn:x-arq:UnionGraph> { " +
+            "    ?person a foaf:Person ; foaf:name ?name " +
+            "    FILTER(?name = \"Dr. Brown\") " +
+            "  } " +
+            "}";
+        
+        ImmutableList<ImmutableMap<String, String>> results = executeQuery(findPersonQuery);
+        
+        assertFalse("Should find Dr. Brown in the union of all graphs", results.isEmpty());
+        assertEquals("Should find exactly one Dr. Brown", 1, results.size());
+        assertEquals("Dr. Brown", results.get(0).get("name"));
+    }
+
+    @Test
+    public void testUnionGraphWithCount() {
+        // Test aggregate functions with UnionGraph
+        String countQuery = 
+            "PREFIX foaf: <http://xmlns.com/foaf/0.1/> " +
+            "SELECT (COUNT(*) AS ?count) WHERE { " +
+            "  GRAPH <urn:x-arq:UnionGraph> { " +
+            "    ?person a foaf:Person " +
+            "  } " +
+            "}";
+        
+        ImmutableList<ImmutableMap<String, String>> results = executeQuery(countQuery);
+        
+        assertFalse("Should have a count result", results.isEmpty());
+        String countStr = results.get(0).get("count");
+        assertNotNull("Count should not be null", countStr);
+        int count = Integer.parseInt(countStr);
+        
+        assertTrue("Should count all persons across all graphs", count >= 5);
+    }
+}

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/UnionGraphTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/UnionGraphTest.java
@@ -1,0 +1,81 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import org.eclipse.rdf4j.query.*;
+import org.junit.*;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.*;
+
+public class UnionGraphTest extends AbstractRDF4JTest {
+    private static final String OBDA_FILE = "/person/person.obda";
+    private static final String SQL_SCRIPT = "/person/person.sql";
+    private static final String ONTOLOGY_FILE = null;
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        initOBDA(SQL_SCRIPT, OBDA_FILE, ONTOLOGY_FILE);
+    }
+
+    @AfterClass
+    public static void after() throws SQLException {
+        release();
+    }
+
+    @Test
+    public void testUnionGraphBasicQuery() {
+        String sparqlQuery = "SELECT * WHERE { GRAPH <urn:x-arq:UnionGraph> { ?s ?p ?o } } LIMIT 10";
+        
+        int count = runQueryAndCount(sparqlQuery);
+        
+        // The query should execute without throwing an exception
+        // The count may be 0 if no data exists, but no exception should occur
+        assertTrue("UnionGraph query should execute successfully", count >= 0);
+    }
+
+    @Test
+    public void testUnionGraphWithNamedDataset() {
+        String sparqlQuery = 
+            "SELECT * FROM NAMED <http://example.org/graph1> FROM NAMED <http://example.org/graph2> " +
+            "WHERE { GRAPH <urn:x-arq:UnionGraph> { ?s ?p ?o } } LIMIT 5";
+        
+        int count = runQueryAndCount(sparqlQuery);
+        
+        // This test verifies that the query doesn't throw an exception
+        // Even if no named graphs exist in the test data, the query should execute successfully
+        assertTrue("Query executed successfully", count >= 0);
+    }
+
+    @Test  
+    public void testUnionGraphVsRegularGraphQuery() {
+        // First, run a regular query to get baseline data
+        String regularQuery = "SELECT * WHERE { ?s ?p ?o } LIMIT 10";
+        int regularCount = runQueryAndCount(regularQuery);
+        
+        // Now run the same query using UnionGraph
+        String unionGraphQuery = "SELECT * WHERE { GRAPH <urn:x-arq:UnionGraph> { ?s ?p ?o } } LIMIT 10";
+        int unionGraphCount = runQueryAndCount(unionGraphQuery);
+        
+        // In this test setup, UnionGraph should return similar data to the regular query
+        // since we're querying the default graph
+        assertTrue("UnionGraph should return results", unionGraphCount >= 0);
+        assertTrue("Regular query should return results", regularCount >= 0);
+    }
+
+    @Test
+    public void testUnionGraphConstantDetection() {
+        // This test verifies that the UnionGraph URI is correctly recognized
+        String sparqlQuery = "SELECT (COUNT(*) as ?count) WHERE { GRAPH <urn:x-arq:UnionGraph> { ?s ?p ?o } }";
+        
+        try {
+            int count = runQueryAndCount(sparqlQuery);
+            
+            // The query should execute without throwing an exception
+            // The result depends on available data, but the important thing is no exception occurs
+            assertTrue("Query executed without error", count >= 0);
+        } catch (Exception e) {
+            fail("UnionGraph query should not throw exception: " + e.getMessage());
+        }
+    }
+}

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/UnionGraphTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/UnionGraphTest.java
@@ -12,10 +12,11 @@ public class UnionGraphTest extends AbstractRDF4JTest {
     private static final String OBDA_FILE = "/person/person.obda";
     private static final String SQL_SCRIPT = "/person/person.sql";
     private static final String ONTOLOGY_FILE = null;
+    private static final String VIEW_FILE = "/person/views/mirror_views.json";
 
     @BeforeClass
     public static void before() throws IOException, SQLException {
-        initOBDA(SQL_SCRIPT, OBDA_FILE, ONTOLOGY_FILE);
+        initOBDA(SQL_SCRIPT, OBDA_FILE, ONTOLOGY_FILE, null, VIEW_FILE);
     }
 
     @AfterClass

--- a/binding/rdf4j/src/test/resources/person/person.obda
+++ b/binding/rdf4j/src/test/resources/person/person.obda
@@ -11,7 +11,7 @@ quest:		http://obda.org/quest#
 [MappingDeclaration] @collection [[
 mappingId	MAPID-person
 target		:person/{"id"} a :Person ; :fullName {"fullName"} ; :country {"country"} ; :locality {"locality"} .
-source		SELECT "id", "fullName", "status", "country", "locality" FROM "hr"."persons";
+source		SELECT "id", "fullName", "status", "country", "locality" FROM "person";
 
 ]]
 

--- a/binding/rdf4j/src/test/resources/person/person.obda
+++ b/binding/rdf4j/src/test/resources/person/person.obda
@@ -11,7 +11,7 @@ quest:		http://obda.org/quest#
 [MappingDeclaration] @collection [[
 mappingId	MAPID-person
 target		:person/{"id"} a :Person ; :fullName {"fullName"} ; :country {"country"} ; :locality {"locality"} .
-source		SELECT "id", "fullName", "status", "country", "locality" FROM "person";
+source		SELECT "id", "fullName", "status", "country", "locality" FROM "hr"."persons";
 
 ]]
 

--- a/binding/rdf4j/src/test/resources/union-graph-test/mapping.obda
+++ b/binding/rdf4j/src/test/resources/union-graph-test/mapping.obda
@@ -1,0 +1,20 @@
+[PrefixDeclaration]
+:		http://example.org/
+foaf:		http://xmlns.com/foaf/0.1/
+rdf:		http://www.w3.org/1999/02/22-rdf-syntax-ns#
+rdfs:		http://www.w3.org/2000/01/rdf-schema#
+xsd:		http://www.w3.org/2001/XMLSchema#
+
+[MappingDeclaration] @collection [[
+mappingId	persons-corp
+target		GRAPH <http://example.org/graph/corp> { :person/{"id"} a foaf:Person ; foaf:name {"name"} ; :hasRole {"role"} . }
+source		SELECT "id", "name", "role" FROM "persons_corp"
+
+mappingId	persons-academic
+target		GRAPH <http://example.org/graph/academic> { :person/{"id"} a foaf:Person ; foaf:name {"name"} ; :hasRole {"role"} . }
+source		SELECT "id", "name", "role" FROM "persons_academic"
+
+mappingId	persons-research
+target		GRAPH <http://example.org/graph/research> { :person/{"id"} a foaf:Person ; foaf:name {"name"} ; :hasRole {"role"} . }
+source		SELECT "id", "name", "role" FROM "persons_research"
+]]

--- a/binding/rdf4j/src/test/resources/union-graph-test/schema.sql
+++ b/binding/rdf4j/src/test/resources/union-graph-test/schema.sql
@@ -1,0 +1,25 @@
+create table "persons_corp" (
+    "id" int primary key,
+    "name" varchar(100) NOT NULL,
+    "role" varchar(100)
+);
+
+create table "persons_academic" (
+    "id" int primary key,
+    "name" varchar(100) NOT NULL,
+    "role" varchar(100)
+);
+
+create table "persons_research" (
+    "id" int primary key,
+    "name" varchar(100) NOT NULL,
+    "role" varchar(100)
+);
+
+insert into "persons_corp" ("id", "name", "role") values (1, 'John Smith', 'developer');
+insert into "persons_corp" ("id", "name", "role") values (2, 'Jane Doe', 'manager');
+
+insert into "persons_academic" ("id", "name", "role") values (3, 'Prof. Wilson', 'professor');
+insert into "persons_academic" ("id", "name", "role") values (5, 'Alice Johnson', 'student');
+
+insert into "persons_research" ("id", "name", "role") values (4, 'Dr. Brown', 'researcher');


### PR DESCRIPTION
in apache jena you can run queries like:
```sparql
PREFIX cco: <http://www.ontologyrepository.com/CommonCoreOntologies/>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
SELECT * WHERE {
  graph <urn:x-arq:UnionGraph> {
  ?s a cco:InformationBearingEntity .
  ?s cco:designated_by/cco:has_text_value ?name .
} 
}
LIMIT 101
```

which allow you to do property paths across named graphs (e.g. if names and InformationBearingEntities are in a different named graphs).

this PR adds that support to ontop.

`urn:x-arq:UnionGraph` described here:
https://jena.apache.org/documentation/tdb/datasets.html