### PR TITLE
Support paths to files/directories as relation names in FROM clauses in mappings

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/DuckDBFileBasedTableTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/DuckDBFileBasedTableTest.java
@@ -38,6 +38,16 @@ public class DuckDBFileBasedTableTest {
         Assert.assertEquals(4, count);
     }
 
+    @Test
+    public void testDescription() {
+        String sparqlQuery = "PREFIX ex: <http://example.org/>" +
+                "SELECT ?description WHERE { " +
+                "   ?s a ex:Book ;" +
+                "       ex:description ?description }" ;
+        int count = runQueryAndCount(sparqlQuery, CONNECTION);
+        Assert.assertEquals(4, count);
+    }
+
     private static OntopRepositoryConnection initOBDA(String obdaRelativePath, String propertyFile) {
         OntopSQLOWLAPIConfiguration.Builder<?> builder = OntopSQLOWLAPIConfiguration.defaultBuilder()
                 .nativeOntopMappingFile(DuckDBCatalogTest.class.getResource(obdaRelativePath).getPath())

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/DuckDBFileBasedTableTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/DuckDBFileBasedTableTest.java
@@ -1,0 +1,69 @@
+package it.unibz.inf.ontop.rdf4j.repository;
+
+import it.unibz.inf.ontop.injection.OntopSQLOWLAPIConfiguration;
+import it.unibz.inf.ontop.rdf4j.repository.impl.OntopVirtualRepository;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class DuckDBFileBasedTableTest {
+    private final static String OBDA_FILE = "/duckdb-file/mapping.obda";
+    private final static String PROPERTIES_FILE = "/duckdb-file/catalog.properties";
+    private static OntopRepositoryConnection CONNECTION;
+
+    @BeforeClass
+    public static void before() throws IOException, SQLException {
+        CONNECTION = initOBDA(OBDA_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterClass
+    public static void after() {
+        CONNECTION.close();
+    }
+
+    @Test
+    public void testQuery() {
+        String sparqlQuery = "PREFIX ex: <http://example.org/>" +
+                "SELECT DISTINCT ?title WHERE { " +
+                "   ?s a ex:Book ;" +
+                "       ex:title ?title }" ;
+        int count = runQueryAndCount(sparqlQuery, CONNECTION);
+        Assert.assertEquals(4, count);
+    }
+
+    private static OntopRepositoryConnection initOBDA(String obdaRelativePath, String propertyFile) {
+        OntopSQLOWLAPIConfiguration.Builder<?> builder = OntopSQLOWLAPIConfiguration.defaultBuilder()
+                .nativeOntopMappingFile(DuckDBCatalogTest.class.getResource(obdaRelativePath).getPath())
+                .propertyFile(DuckDBCatalogTest.class.getResource(propertyFile).getPath())
+                .enableTestMode();
+
+        OntopSQLOWLAPIConfiguration config = builder.build();
+
+        OntopVirtualRepository repo = OntopRepository.defaultRepository(config);
+        repo.init();
+
+        return repo.getConnection();
+    }
+
+    private int runQueryAndCount(String queryString, OntopRepositoryConnection connection) {
+        TupleQuery query = connection.prepareTupleQuery(QueryLanguage.SPARQL, queryString);
+
+        TupleQueryResult result = query.evaluate();
+        int count = 0;
+        while (result.hasNext()) {
+            result.next();
+            count++;
+        }
+        result.close();
+        return count;
+    }
+
+
+}

--- a/binding/rdf4j/src/test/resources/duckdb-file/books.csv
+++ b/binding/rdf4j/src/test/resources/duckdb-file/books.csv
@@ -1,0 +1,5 @@
+id, title, price, discount, description, lang, publication_date
+1,SPARQL Tutorial, 43, 0.2,good,en,2014-06-05 16:47:52
+2,The Semantic Web, 23, 0.25,bad,en,2011-12-08 11:30:00
+3,Crime and Punishment, 34, 0.2,good,en,2015-09-21 09:23:06
+4,"The Logic Book: Introduction, Second Edition", 10, 0.15,good,en,1970-11-05 07:50:00

--- a/binding/rdf4j/src/test/resources/duckdb-file/catalog.properties
+++ b/binding/rdf4j/src/test/resources/duckdb-file/catalog.properties
@@ -1,0 +1,2 @@
+jdbc.url = jdbc:duckdb:
+jdbc.driver = org.duckdb.DuckDBDriver

--- a/binding/rdf4j/src/test/resources/duckdb-file/catalog.properties
+++ b/binding/rdf4j/src/test/resources/duckdb-file/catalog.properties
@@ -1,2 +1,3 @@
 jdbc.url = jdbc:duckdb:
 jdbc.driver = org.duckdb.DuckDBDriver
+ontop.allowRetrievingBlackBoxViewMetadataFromDB=true

--- a/binding/rdf4j/src/test/resources/duckdb-file/mapping.obda
+++ b/binding/rdf4j/src/test/resources/duckdb-file/mapping.obda
@@ -1,0 +1,10 @@
+[PrefixDeclaration]
+ex:   http://example.org/
+
+
+[MappingDeclaration] @collection [[
+mappingId	books
+target	ex:book/{id} a ex:Book ; ex:title {title} ; ex:price {price} ; ex:discount {discount} ; ex:pubYear {publication_date} ; ex:description {description} .
+source	SELECT id, title, price, discount, publication_date, description, lang FROM "src/test/resources/duckdb-file/books.csv"
+]]
+

--- a/binding/rdf4j/src/test/resources/duckdb-file/mapping.obda
+++ b/binding/rdf4j/src/test/resources/duckdb-file/mapping.obda
@@ -4,7 +4,11 @@ ex:   http://example.org/
 
 [MappingDeclaration] @collection [[
 mappingId	books
-target	ex:book/{id} a ex:Book ; ex:title {title} ; ex:price {price} ; ex:discount {discount} ; ex:pubYear {publication_date} ; ex:description {description} .
+target	ex:book/{id} a ex:Book ; ex:title {title} ; ex:price {price} ; ex:discount {discount} ; ex:pubYear {publication_date}  .
 source	SELECT id, title, price, discount, publication_date, description, lang FROM "src/test/resources/duckdb-file/books.csv"
+
+mappingId	books-function
+target	ex:book/{id} ex:description {description} .
+source	SELECT id, title, price, discount, publication_date, description, lang FROM read_csv_auto('src/test/resources/duckdb-file/books.csv')
 ]]
 

--- a/core/model/src/main/java/it/unibz/inf/ontop/exception/RelationNotFoundInMetadataException.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/exception/RelationNotFoundInMetadataException.java
@@ -6,6 +6,9 @@ import java.util.Collection;
 
 public class RelationNotFoundInMetadataException extends MetadataExtractionException {
     public RelationNotFoundInMetadataException(RelationID id, Collection<RelationID> choices) {
-        super("Cannot find relation " + id + " (available choices: " + choices + ")");
+        this(id, choices, "");
+    }
+    public RelationNotFoundInMetadataException(RelationID id, Collection<RelationID> choices, String additionalMessage) {
+        super("Cannot find relation " + id + " (available choices: " + choices + ")" + additionalMessage);
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AbstractDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AbstractDBMetadataProvider.java
@@ -583,15 +583,15 @@ public abstract class AbstractDBMetadataProvider implements DBMetadataProvider {
         }
     }
 
-    protected final NamedRelationDefinition extractFileBasedTableByConnectingToDB(RelationID id) throws RelationNotFoundInMetadataException {
+    protected final NamedRelationDefinition extractFileBasedTableByConnectingToDB(RelationID id) throws MetadataExtractionException {
         try {
             LOGGER.debug("Connecting to DB to extract metadata for {}", id);
             String query = id.getSQLRendering();
             RelationDefinition.AttributeListBuilder builder = retrieveAttributeListByConnectingToDB(query);
-            return new DatabaseTableDefinition(ImmutableList.of(id), builder);
+            return new FileBasedNamedRelationDefinition(ImmutableList.of(id), builder);
         }
         catch (SQLException e) {
-            throw new RelationNotFoundInMetadataException(id, ImmutableList.of());
+            throw new FileBasedRelationNotFoundInMetadataException(id, getRelationIDs());
         }
     }
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AbstractDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AbstractDBMetadataProvider.java
@@ -183,13 +183,15 @@ public abstract class AbstractDBMetadataProvider implements DBMetadataProvider {
             }
             LOGGER.debug("[DB-METADATA] Column info extracted in {} ms/column", logOperation.getAverageDuration());
 
-            if (relations.size() == 1) {
-                Map.Entry<RelationID, RelationDefinition.AttributeListBuilder> r = relations.entrySet().iterator().next();
-                return new DatabaseTableDefinition(getAllIDs(r.getKey()), r.getValue());
+            switch (relations.size()) {
+                case 0:
+                    throw new RelationNotFoundInMetadataException(id, getRelationIDs());
+                case 1:
+                    Map.Entry<RelationID, RelationDefinition.AttributeListBuilder> r = relations.entrySet().iterator().next();
+                    return new DatabaseTableDefinition(getAllIDs(r.getKey()), r.getValue());
+                default:
+                    throw new MetadataExtractionException("Cannot resolve ambiguous relation id: " + id + ": " + relations.keySet());
             }
-            throw relations.isEmpty()
-                    ? new RelationNotFoundInMetadataException(id, getRelationIDs())
-                    : new MetadataExtractionException("Cannot resolve ambiguous relation id: " + id + ": " + relations.keySet());
         }
         catch (SQLException e) {
             throw new MetadataExtractionException(e);
@@ -571,7 +573,29 @@ public abstract class AbstractDBMetadataProvider implements DBMetadataProvider {
                 : extractBlackBoxViewWithoutConnectingToDB(query);
     }
 
-    protected RelationDefinition extractBlackBoxViewByConnectingToDB(String query) throws MetadataExtractionException {
+    protected final RelationDefinition extractBlackBoxViewByConnectingToDB(String query) throws MetadataExtractionException {
+        try {
+            RelationDefinition.AttributeListBuilder builder = retrieveAttributeListByConnectingToDB("(" + query + ")");
+            return new ParserViewDefinition(builder, query);
+        }
+        catch (SQLException e) {
+            throw new MetadataExtractionException("Cannot extract metadata for a black-box view. " + e.getMessage(), e);
+        }
+    }
+
+    protected final NamedRelationDefinition extractFileBasedTableByConnectingToDB(RelationID id) throws RelationNotFoundInMetadataException {
+        try {
+            LOGGER.debug("Connecting to DB to extract metadata for {}", id);
+            String query = id.getSQLRendering();
+            RelationDefinition.AttributeListBuilder builder = retrieveAttributeListByConnectingToDB(query);
+            return new DatabaseTableDefinition(ImmutableList.of(id), builder);
+        }
+        catch (SQLException e) {
+            throw new RelationNotFoundInMetadataException(id, ImmutableList.of());
+        }
+    }
+
+    protected final RelationDefinition.AttributeListBuilder retrieveAttributeListByConnectingToDB(String query) throws SQLException {
         try (Statement st = connection.createStatement();
              ResultSet resultSet = st.executeQuery(makeQueryMinimizeResultSet(query))) {
 
@@ -594,10 +618,7 @@ public abstract class AbstractDBMetadataProvider implements DBMetadataProvider {
 
                 builder.addAttribute(attributeId, termType, sqlTypeName, true);
             }
-            return new ParserViewDefinition(builder, query);
-
-        } catch (SQLException e) {
-            throw new MetadataExtractionException("Cannot extract metadata for a black-box view. " + e.getMessage(), e);
+            return builder;
         }
     }
 
@@ -605,10 +626,10 @@ public abstract class AbstractDBMetadataProvider implements DBMetadataProvider {
      * Can be overridden
      */
     protected String makeQueryMinimizeResultSet(String query) {
-        return String.format("SELECT * FROM (%s) subQ LIMIT 1", query);
+        return String.format("SELECT * FROM %s subQ LIMIT 1", query);
     }
 
-    protected RelationDefinition extractBlackBoxViewWithoutConnectingToDB(String query) throws InvalidQueryException {
+    protected final RelationDefinition extractBlackBoxViewWithoutConnectingToDB(String query) throws InvalidQueryException {
         ImmutableList<QuotedID> attributes;
         try {
             DefaultSelectQueryAttributeExtractor sqae = new DefaultSelectQueryAttributeExtractor(this, coreSingletons);
@@ -692,5 +713,4 @@ public abstract class AbstractDBMetadataProvider implements DBMetadataProvider {
             return (endTime - startTime)/ count;
         }
     }
-
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DuckDBDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DuckDBDBMetadataProvider.java
@@ -105,12 +105,7 @@ public class DuckDBDBMetadataProvider extends DefaultSchemaCatalogDBMetadataProv
             return super.getRelation(id);
         }
         catch (RelationNotFoundInMetadataException e) {
-            try {
-                return extractFileBasedTableByConnectingToDB(id);
-            }
-            catch (RelationNotFoundInMetadataException e2) {
-                throw e;
-            }
+            return extractFileBasedTableByConnectingToDB(id);
         }
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DuckDBDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/DuckDBDBMetadataProvider.java
@@ -2,7 +2,11 @@ package it.unibz.inf.ontop.dbschema.impl;
 
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import it.unibz.inf.ontop.dbschema.NamedRelationDefinition;
+import it.unibz.inf.ontop.dbschema.RelationDefinition;
+import it.unibz.inf.ontop.dbschema.RelationID;
 import it.unibz.inf.ontop.exception.MetadataExtractionException;
+import it.unibz.inf.ontop.exception.RelationNotFoundInMetadataException;
 import it.unibz.inf.ontop.injection.CoreSingletons;
 
 import java.sql.*;
@@ -93,5 +97,20 @@ public class DuckDBDBMetadataProvider extends DefaultSchemaCatalogDBMetadataProv
     protected ResultSet getRelationIDsResultSet() throws SQLException {
         // In duckdb, the type "TABLE" is called "BASE TABLE" instead, so we have to change this method.
         return metadata.getTables(null, null, null, new String[] { "BASE TABLE", "VIEW" });
+    }
+
+    @Override
+    public NamedRelationDefinition getRelation(RelationID id) throws MetadataExtractionException {
+        try {
+            return super.getRelation(id);
+        }
+        catch (RelationNotFoundInMetadataException e) {
+            try {
+                return extractFileBasedTableByConnectingToDB(id);
+            }
+            catch (RelationNotFoundInMetadataException e2) {
+                throw e;
+            }
+        }
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/FileBasedNamedRelationDefinition.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/FileBasedNamedRelationDefinition.java
@@ -6,23 +6,24 @@ import it.unibz.inf.ontop.dbschema.RelationID;
 
 import java.util.stream.Collectors;
 
-public class DatabaseTableDefinition extends AbstractNamedRelationDefinition {
+public class FileBasedNamedRelationDefinition extends AbstractNamedRelationDefinition {
 
     /**
      *
      * @param allIds
      * @param builder
      */
-    public DatabaseTableDefinition(ImmutableList<RelationID> allIds, AttributeListBuilder builder) {
+    public FileBasedNamedRelationDefinition(ImmutableList<RelationID> allIds, AttributeListBuilder builder) {
         super(allIds, builder);
     }
 
     @Override
     public String toString() {
-        return "CREATE TABLE " + getID() + " (\n   " +
+        return "file " + getID() + " (\n   " +
                 getAttributes().stream()
                         .map(Attribute::toString)
                         .collect(Collectors.joining(",\n   ")) +
                 "\n)";
     }
 }
+

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/FileBasedRelationNotFoundInMetadataException.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/FileBasedRelationNotFoundInMetadataException.java
@@ -1,0 +1,12 @@
+package it.unibz.inf.ontop.dbschema.impl;
+
+import it.unibz.inf.ontop.dbschema.RelationID;
+import it.unibz.inf.ontop.exception.RelationNotFoundInMetadataException;
+
+import java.util.Collection;
+
+public class FileBasedRelationNotFoundInMetadataException extends RelationNotFoundInMetadataException {
+    public FileBasedRelationNotFoundInMetadataException(RelationID id, Collection<RelationID> choices) {
+        super(id, choices, "; file-based relation cannot be found either");
+    }
+}

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/OracleDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/OracleDBMetadataProvider.java
@@ -289,7 +289,7 @@ public class OracleDBMetadataProvider extends DefaultSchemaDBMetadataProvider {
 
     @Override
     protected String makeQueryMinimizeResultSet(String query) {
-        return String.format("SELECT * FROM (%s) subQ FETCH NEXT 1 ROWS ONLY", query);
+        return String.format("SELECT * FROM %s subQ FETCH NEXT 1 ROWS ONLY", query);
     }
 
     @Override

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLServerDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SQLServerDBMetadataProvider.java
@@ -60,7 +60,7 @@ public class SQLServerDBMetadataProvider extends AbstractDBMetadataProvider {
 
     @Override
     protected String makeQueryMinimizeResultSet(String query) {
-        return String.format("SELECT * FROM (%s) subQ ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY", query);
+        return String.format("SELECT * FROM %s subQ ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY", query);
     }
 
 

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SparkSQLDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SparkSQLDBMetadataProvider.java
@@ -3,9 +3,11 @@ package it.unibz.inf.ontop.dbschema.impl;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import it.unibz.inf.ontop.dbschema.NamedRelationDefinition;
 import it.unibz.inf.ontop.dbschema.QuotedID;
 import it.unibz.inf.ontop.dbschema.RelationID;
 import it.unibz.inf.ontop.exception.MetadataExtractionException;
+import it.unibz.inf.ontop.exception.RelationNotFoundInMetadataException;
 import it.unibz.inf.ontop.injection.CoreSingletons;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,4 +131,18 @@ public class SparkSQLDBMetadataProvider extends AbstractDBMetadataProvider {
         return rawIdFactory.createRelationID(rs.getString(catalogNameColumn), rs.getString(schemaNameColumn), rs.getString(tableNameColumn));
     }
 
+    @Override
+    public NamedRelationDefinition getRelation(RelationID id) throws MetadataExtractionException {
+        try {
+            return super.getRelation(id);
+        }
+        catch (RelationNotFoundInMetadataException e) {
+            try {
+                return extractFileBasedTableByConnectingToDB(id);
+            }
+            catch (RelationNotFoundInMetadataException e2) {
+                throw e;
+            }
+        }
+    }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SparkSQLDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/SparkSQLDBMetadataProvider.java
@@ -3,6 +3,7 @@ package it.unibz.inf.ontop.dbschema.impl;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import it.unibz.inf.ontop.dbschema.MetadataLookup;
 import it.unibz.inf.ontop.dbschema.NamedRelationDefinition;
 import it.unibz.inf.ontop.dbschema.QuotedID;
 import it.unibz.inf.ontop.dbschema.RelationID;
@@ -137,12 +138,15 @@ public class SparkSQLDBMetadataProvider extends AbstractDBMetadataProvider {
             return super.getRelation(id);
         }
         catch (RelationNotFoundInMetadataException e) {
-            try {
-                return extractFileBasedTableByConnectingToDB(id);
-            }
-            catch (RelationNotFoundInMetadataException e2) {
-                throw e;
-            }
+            return extractFileBasedTableByConnectingToDB(id);
         }
+    }
+
+    @Override
+    public void insertIntegrityConstraints(NamedRelationDefinition relation, MetadataLookup metadataLookup) throws MetadataExtractionException {
+        if (relation instanceof FileBasedNamedRelationDefinition)
+            return;
+
+        super.insertIntegrityConstraints(relation, metadataLookup);
     }
 }

--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonDatabaseTable.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/json/JsonDatabaseTable.java
@@ -84,7 +84,7 @@ public class JsonDatabaseTable extends JsonOpenObject {
                     idFactory.createAttributeID(attribute.name),
                     attribute.datatype != null
                             ? dbTypeFactory.getDBTermType(attribute.datatype)
-                            :dbTypeFactory.getAbstractRootDBType(),
+                            : dbTypeFactory.getAbstractRootDBType(),
                     attribute.isNullable);
 
         ImmutableList<RelationID> allIDs = Stream.concat(Stream.of(name), otherNames.stream())


### PR DESCRIPTION
The pull request addresses issue 451 and introduces `FileBasedNamedRelationDefinition`. Instances of this classes can be created by a `DBMetadataProvider.` when the relation ID is in fact a path to a CSV file or another type of external database object. Examples include `SELECT * FROM 'weather.csv'` (DuckDB) or <code>select * from json.\`s3://MY_BUCKET/MY_TABLE_DIR/\`</code> (SparkSQL/Databricks).