### PR TITLE
New SPARQL function: Query ID

### DIFF
--- a/binding/rdf4j/src/main/java/it/unibz/inf/ontop/rdf4j/predefined/impl/OntopRDF4JPredefinedQueryEngineImpl.java
+++ b/binding/rdf4j/src/main/java/it/unibz/inf/ontop/rdf4j/predefined/impl/OntopRDF4JPredefinedQueryEngineImpl.java
@@ -307,8 +307,8 @@ public class OntopRDF4JPredefinedQueryEngineImpl implements OntopRDF4JPredefined
                 .newBindings(bindingSet);
 
         // TODO: shall we consider some HTTP headers?
-        QueryLogger tmpQueryLogger = queryLoggerFactory.create(ImmutableMap.of());
         QueryContext emptyQueryContext = queryContextFactory.create(ImmutableMap.of());
+        QueryLogger tmpQueryLogger = queryLoggerFactory.create(emptyQueryContext);
 
         LOGGER.debug("Generating the reference query for {} with ref parameters {}",
                 predefinedQuery.getId(),
@@ -319,7 +319,8 @@ public class OntopRDF4JPredefinedQueryEngineImpl implements OntopRDF4JPredefined
 
     private QueryLogger createQueryLogger(PredefinedQuery<?> predefinedQuery, ImmutableMap<String, String> bindings,
                                           ImmutableMap<String, String> httpHeaders) {
-        QueryLogger queryLogger = queryLoggerFactory.create(httpHeaders);
+        QueryContext queryContext = queryContextFactory.create(httpHeaders);
+        QueryLogger queryLogger = queryLoggerFactory.create(queryContext);
         queryLogger.setPredefinedQuery(predefinedQuery.getId(), bindings);
         return queryLogger;
     }

--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/EmployeeTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/EmployeeTest.java
@@ -15,10 +15,11 @@ public class EmployeeTest extends AbstractRDF4JTest {
 
     private static final String OBDA_FILE = "/employee/employee.obda";
     private static final String SQL_SCRIPT = "/employee/employee.sql";
+    private static final String PROPERTIES = "/employee/employee-logging.properties";
 
     @BeforeClass
     public static void before() throws IOException, SQLException {
-        initOBDA(SQL_SCRIPT, OBDA_FILE);
+        initOBDA(SQL_SCRIPT, OBDA_FILE, null, PROPERTIES);
     }
 
     @AfterClass
@@ -106,5 +107,23 @@ public class EmployeeTest extends AbstractRDF4JTest {
         int countResults = runQueryAndCount(sparql);
         assertEquals(1, countResults);
         runQueryAndCompare(sparql, ImmutableSet.of("0"));
+    }
+
+    @Test
+    public void testQueryId() {
+        String sparql = "PREFIX schema: <http://schema.org/>\n" +
+                "PREFIX : <http://employee.example.org/voc#>\n" +
+                "PREFIX obdaf: <https://w3id.org/obda/functions#>\n" +
+                "\n" +
+                "SELECT *\n" +
+                "WHERE {\n" +
+                "  BIND(obdaf:queryId() AS ?v) .\n" +
+                "}\n";
+
+        var results = runQuery(sparql);
+        assertEquals(1, results.size());
+        // Check the first result is a UUID
+        String queryId = results.get(0);
+        assertEquals(36, queryId.length());
     }
 }

--- a/binding/rdf4j/src/test/resources/employee/employee-logging.properties
+++ b/binding/rdf4j/src/test/resources/employee/employee-logging.properties
@@ -1,0 +1,1 @@
+ontop.queryLogging=true

--- a/core/model/src/main/java/it/unibz/inf/ontop/evaluator/QueryContext.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/evaluator/QueryContext.java
@@ -22,6 +22,10 @@ public interface QueryContext {
 
     UUID getSalt();
 
+    ImmutableMap<String, String> getHttpHeaders();
+
+    QueryContext duplicateForNewQuery();
+
     interface Factory {
         QueryContext create(ImmutableMap<String, String> normalizedHttpHeaders);
     }

--- a/core/model/src/main/java/it/unibz/inf/ontop/evaluator/QueryContext.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/evaluator/QueryContext.java
@@ -24,7 +24,9 @@ public interface QueryContext {
 
     ImmutableMap<String, String> getHttpHeaders();
 
-    QueryContext duplicateForNewQuery();
+    QueryContext duplicateForNewQueryWithSameSalt();
+
+    UUID getQueryId();
 
     interface Factory {
         QueryContext create(ImmutableMap<String, String> normalizedHttpHeaders);

--- a/core/model/src/main/java/it/unibz/inf/ontop/evaluator/impl/QueryContextImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/evaluator/impl/QueryContextImpl.java
@@ -26,10 +26,12 @@ public class QueryContextImpl implements QueryContext {
     private final ImmutableSet<String> roles;
     private final ImmutableSet<String> groups;
     private final UUID salt;
+    private final ImmutableMap<String, String> httpHeaders;
 
     @AssistedInject
     protected QueryContextImpl(@Assisted ImmutableMap<String, String> normalizedHttpHeaders,
                                OntopModelSettings settings) {
+        this.httpHeaders = normalizedHttpHeaders;
         if (settings.isAuthorizationEnabled()) {
             var commaSplitter = Splitter.on(",");
             // TODO: validate user name
@@ -82,6 +84,17 @@ public class QueryContextImpl implements QueryContext {
     @Override
     public UUID getSalt() {
         return salt;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getHttpHeaders() {
+        return httpHeaders;
+    }
+
+    @Override
+    public QueryContext duplicateForNewQuery() {
+        // TODO: implement correctly
+        return this;
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/evaluator/impl/QueryContextImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/evaluator/impl/QueryContextImpl.java
@@ -27,10 +27,17 @@ public class QueryContextImpl implements QueryContext {
     private final ImmutableSet<String> groups;
     private final UUID salt;
     private final ImmutableMap<String, String> httpHeaders;
+    private final OntopModelSettings settings;
+    private final UUID queryId;
 
     @AssistedInject
     protected QueryContextImpl(@Assisted ImmutableMap<String, String> normalizedHttpHeaders,
                                OntopModelSettings settings) {
+        this(normalizedHttpHeaders, settings, UUID.randomUUID());
+    }
+
+    protected QueryContextImpl(ImmutableMap<String, String> normalizedHttpHeaders,
+                             OntopModelSettings settings, UUID salt) {
         this.httpHeaders = normalizedHttpHeaders;
         if (settings.isAuthorizationEnabled()) {
             var commaSplitter = Splitter.on(",");
@@ -50,7 +57,9 @@ public class QueryContextImpl implements QueryContext {
             groups = ImmutableSet.of();
         }
 
-        this.salt = UUID.randomUUID();
+        this.salt = salt;
+        this.settings = settings;
+        this.queryId = UUID.randomUUID();
     }
 
     @Override
@@ -92,9 +101,13 @@ public class QueryContextImpl implements QueryContext {
     }
 
     @Override
-    public QueryContext duplicateForNewQuery() {
-        // TODO: implement correctly
-        return this;
+    public QueryContext duplicateForNewQueryWithSameSalt() {
+        return new QueryContextImpl(httpHeaders, settings, salt);
+    }
+
+    @Override
+    public UUID getQueryId() {
+        return queryId;
     }
 
     @Override

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/FunctionSymbolFactory.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/FunctionSymbolFactory.java
@@ -133,4 +133,6 @@ public interface FunctionSymbolFactory {
     FunctionSymbol getExtractLexicalTermFromRDFTerm();
 
     FunctionSymbol getIdentity();
+
+    FunctionSymbol getQueryId();
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/FunctionSymbolFactoryImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/FunctionSymbolFactoryImpl.java
@@ -1,7 +1,6 @@
 package it.unibz.inf.ontop.model.term.functionsymbol.impl;
 
 import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
 import com.google.inject.Inject;
@@ -57,6 +56,7 @@ public class FunctionSymbolFactoryImpl implements FunctionSymbolFactory {
 
     private final FunctionSymbol identityFunctionSymbol;
     private final SPARQLFunctionSymbol bnodeTolerantSPARQLStrFunctionSymbol;
+    private final FunctionSymbol queryIdFunctionSymbol;
 
     /**
      * Created in init()
@@ -66,7 +66,6 @@ public class FunctionSymbolFactoryImpl implements FunctionSymbolFactory {
      * Created in init()
      */
     private ImmutableTable<String, Integer, SPARQLFunctionSymbol> distinctSparqlAggregateFunctionTable;
-
 
 
     @Inject
@@ -79,7 +78,6 @@ public class FunctionSymbolFactoryImpl implements FunctionSymbolFactory {
 
         DBTypeFactory dbTypeFactory = typeFactory.getDBTypeFactory();
         this.dbStringType = dbTypeFactory.getDBStringType();
-
         this.dbBooleanType = dbTypeFactory.getDBBooleanType();
         this.metaRDFType = typeFactory.getMetaRDFTermType();
 
@@ -115,6 +113,7 @@ public class FunctionSymbolFactoryImpl implements FunctionSymbolFactory {
         this.identityFunctionSymbol = new IdentityFunctionSymbol(dbTypeFactory.getAbstractRootDBType());
 
         this.bnodeTolerantSPARQLStrFunctionSymbol = new BNodeTolerantStrSPARQLFunctionSymbolImpl(abstractRDFType, xsdStringType);
+        this.queryIdFunctionSymbol = new QueryIdFunctionSymbol(dbStringType);
     }
 
     @Inject
@@ -251,6 +250,8 @@ public class FunctionSymbolFactoryImpl implements FunctionSymbolFactory {
                         xsdDatetime, xsdDecimal, false, TermFactory::getDBMilliseconds),
                 new SimpleUnarySPARQLFunctionSymbolImpl("SP_MICROSECONDS", Ontop.MICROSECONDS_FROM_DATETIME,
                         xsdDatetime, xsdInteger, false, TermFactory::getDBMicroseconds),
+                new SimpleNullarySPARQLFunctionSymbolImpl("SP_QUERY_ID", Ontop.QUERY_ID,
+                        xsdString, termFactory -> termFactory.getImmutableFunctionalTerm(queryIdFunctionSymbol)),
 
                 new DateTruncSPARQLFunctionSymbolImpl(xsdDatetime,
                         xsdString, (t) -> dbFunctionSymbolFactory.getDBDateTrunc(t)),
@@ -721,5 +722,10 @@ public class FunctionSymbolFactoryImpl implements FunctionSymbolFactory {
     @Override
     public SPARQLFunctionSymbol getBNodeTolerantSPARQLStrFunctionSymbol() {
         return bnodeTolerantSPARQLStrFunctionSymbol;
+    }
+
+    @Override
+    public FunctionSymbol getQueryId() {
+        return queryIdFunctionSymbol;
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/QueryIdFunctionSymbol.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/QueryIdFunctionSymbol.java
@@ -1,0 +1,51 @@
+package it.unibz.inf.ontop.model.term.functionsymbol.impl;
+
+import com.google.common.collect.ImmutableList;
+import it.unibz.inf.ontop.evaluator.QueryContext;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.term.functionsymbol.db.QueryContextSimplifiableFunctionSymbol;
+import it.unibz.inf.ontop.model.type.DBTermType;
+import it.unibz.inf.ontop.model.type.TermTypeInference;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+public class QueryIdFunctionSymbol extends FunctionSymbolImpl implements QueryContextSimplifiableFunctionSymbol {
+    private final DBTermType dbStringType;
+
+    protected QueryIdFunctionSymbol(DBTermType dbStringType) {
+        super("ontop_query_id", ImmutableList.of());
+        this.dbStringType = dbStringType;
+    }
+
+    @Override
+    public ImmutableTerm simplifyWithContext(ImmutableList<ImmutableTerm> terms, @Nonnull QueryContext queryContext, TermFactory termFactory) {
+        return termFactory.getDBStringConstant(queryContext.getQueryId().toString());
+    }
+
+    @Override
+    protected boolean isAlwaysInjectiveInTheAbsenceOfNonInjectiveFunctionalTerms() {
+        return true;
+    }
+
+    @Override
+    protected boolean tolerateNulls() {
+        return false;
+    }
+
+    @Override
+    protected boolean mayReturnNullWithoutNullArguments() {
+        return false;
+    }
+
+    @Override
+    public Optional<TermTypeInference> inferType(ImmutableList<? extends ImmutableTerm> terms) {
+        return Optional.of(TermTypeInference.declareTermType(dbStringType));
+    }
+
+    @Override
+    public boolean canBePostProcessed(ImmutableList<? extends ImmutableTerm> arguments) {
+        return false;
+    }
+}

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/SimpleNullarySPARQLFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/SimpleNullarySPARQLFunctionSymbolImpl.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 
-public class SimpleNullarySPARQLFunctionSymbolImpl extends ReduciblePositiveAritySPARQLFunctionSymbolImpl {
+public class SimpleNullarySPARQLFunctionSymbolImpl extends SPARQLFunctionSymbolImpl {
 
     private final RDFTermType targetType;
     private final Function<TermFactory, ImmutableFunctionalTerm> dbFunctionalTermFct;
@@ -26,10 +26,23 @@ public class SimpleNullarySPARQLFunctionSymbolImpl extends ReduciblePositiveArit
         this.targetType = targetType;
         this.dbFunctionalTermFct = dbFunctionalTermFct;
     }
-    
+
     @Override
     public Optional<TermTypeInference> inferType(ImmutableList<? extends ImmutableTerm> terms) {
         return Optional.of(TermTypeInference.declareTermType(targetType));
+    }
+
+    @Override
+    protected ImmutableTerm buildTermAfterEvaluation(ImmutableList<ImmutableTerm> newTerms, TermFactory termFactory,
+                                                     VariableNullability variableNullability) {
+        var lexicalTerm = dbFunctionalTermFct.apply(termFactory);
+        return termFactory.getRDFFunctionalTerm(
+                lexicalTerm,
+                termFactory.getIfElseNull(
+                        termFactory.getDBIsNotNull(lexicalTerm),
+                        termFactory.getRDFTermTypeConstant(targetType)
+                )
+        );
     }
 
     @Override
@@ -38,21 +51,12 @@ public class SimpleNullarySPARQLFunctionSymbolImpl extends ReduciblePositiveArit
     }
 
     @Override
-    protected ImmutableTerm computeLexicalTerm(ImmutableList<ImmutableTerm> subLexicalTerms,
-                                               ImmutableList<ImmutableTerm> typeTerms, TermFactory termFactory,
-                                               ImmutableTerm returnedTypeTerm) {
-        return termFactory.getConversion2RDFLexical(dbFunctionalTermFct.apply(termFactory), targetType);
-    }
-
-    @Override
-    protected ImmutableTerm computeTypeTerm(ImmutableList<? extends ImmutableTerm> subLexicalTerms,
-                                            ImmutableList<ImmutableTerm> typeTerms, TermFactory termFactory,
-                                            VariableNullability variableNullability) {
-        return termFactory.getRDFTermTypeConstant(targetType);
-    }
-
-    @Override
     public boolean isAlwaysInjectiveInTheAbsenceOfNonInjectiveFunctionalTerms() {
+        return false;
+    }
+
+    @Override
+    protected boolean tolerateNulls() {
         return true;
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/SimpleNullarySPARQLFunctionSymbolImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/impl/SimpleNullarySPARQLFunctionSymbolImpl.java
@@ -1,0 +1,58 @@
+package it.unibz.inf.ontop.model.term.functionsymbol.impl;
+
+import com.google.common.collect.ImmutableList;
+import it.unibz.inf.ontop.iq.node.VariableNullability;
+import it.unibz.inf.ontop.model.term.ImmutableFunctionalTerm;
+import it.unibz.inf.ontop.model.term.ImmutableTerm;
+import it.unibz.inf.ontop.model.term.TermFactory;
+import it.unibz.inf.ontop.model.type.RDFTermType;
+import it.unibz.inf.ontop.model.type.TermTypeInference;
+import org.apache.commons.rdf.api.IRI;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+import java.util.function.Function;
+
+
+public class SimpleNullarySPARQLFunctionSymbolImpl extends ReduciblePositiveAritySPARQLFunctionSymbolImpl {
+
+    private final RDFTermType targetType;
+    private final Function<TermFactory, ImmutableFunctionalTerm> dbFunctionalTermFct;
+
+    protected SimpleNullarySPARQLFunctionSymbolImpl(@Nonnull String name, IRI functionIRI,
+                                                    RDFTermType targetType,
+                                                    Function<TermFactory, ImmutableFunctionalTerm> dbFunctionalTermFct) {
+        super(name, functionIRI, ImmutableList.of());
+        this.targetType = targetType;
+        this.dbFunctionalTermFct = dbFunctionalTermFct;
+    }
+    
+    @Override
+    public Optional<TermTypeInference> inferType(ImmutableList<? extends ImmutableTerm> terms) {
+        return Optional.of(TermTypeInference.declareTermType(targetType));
+    }
+
+    @Override
+    public boolean canBePostProcessed(ImmutableList<? extends ImmutableTerm> arguments) {
+        return false;
+    }
+
+    @Override
+    protected ImmutableTerm computeLexicalTerm(ImmutableList<ImmutableTerm> subLexicalTerms,
+                                               ImmutableList<ImmutableTerm> typeTerms, TermFactory termFactory,
+                                               ImmutableTerm returnedTypeTerm) {
+        return termFactory.getConversion2RDFLexical(dbFunctionalTermFct.apply(termFactory), targetType);
+    }
+
+    @Override
+    protected ImmutableTerm computeTypeTerm(ImmutableList<? extends ImmutableTerm> subLexicalTerms,
+                                            ImmutableList<ImmutableTerm> typeTerms, TermFactory termFactory,
+                                            VariableNullability variableNullability) {
+        return termFactory.getRDFTermTypeConstant(targetType);
+    }
+
+    @Override
+    public boolean isAlwaysInjectiveInTheAbsenceOfNonInjectiveFunctionalTerms() {
+        return true;
+    }
+}

--- a/core/model/src/main/java/it/unibz/inf/ontop/model/vocabulary/Ontop.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/model/vocabulary/Ontop.java
@@ -19,6 +19,7 @@ public class Ontop {
     public static final IRI MILLISECONDS_FROM_DATETIME;
     public static final IRI MICROSECONDS_FROM_DATETIME;
     public static final IRI DATE_TRUNC;
+    public static final IRI QUERY_ID;
 
     static {
         org.apache.commons.rdf.api.RDF factory = new SimpleRDF();
@@ -31,5 +32,6 @@ public class Ontop {
         MILLISECONDS_FROM_DATETIME = factory.createIRI(FUNCTION_PREFIX + "milliseconds-from-dateTime");
         MICROSECONDS_FROM_DATETIME = factory.createIRI(FUNCTION_PREFIX + "microseconds-from-dateTime");
         DATE_TRUNC = factory.createIRI(FUNCTION_PREFIX + "dateTrunc");
+        QUERY_ID = factory.createIRI(FUNCTION_PREFIX + "queryId");
     }
 }

--- a/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/answering/logging/QueryLogger.java
+++ b/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/answering/logging/QueryLogger.java
@@ -1,6 +1,7 @@
 package it.unibz.inf.ontop.answering.logging;
 
 import com.google.common.collect.ImmutableMap;
+import it.unibz.inf.ontop.evaluator.QueryContext;
 import it.unibz.inf.ontop.exception.OntopReformulationException;
 import it.unibz.inf.ontop.iq.IQ;
 import it.unibz.inf.ontop.spec.ontology.InconsistentOntologyException;
@@ -33,6 +34,6 @@ public interface QueryLogger {
     void setPredefinedQuery(String queryId, ImmutableMap<String, String> bindings);
 
     interface Factory {
-        QueryLogger create(ImmutableMap<String, String> httpHeaders);
+        QueryLogger create(QueryContext queryContext);
     }
 }

--- a/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/answering/logging/impl/QueryLoggerImpl.java
+++ b/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/answering/logging/impl/QueryLoggerImpl.java
@@ -10,6 +10,7 @@ import com.google.inject.assistedinject.AssistedInject;
 import it.unibz.inf.ontop.answering.logging.QueryLogger;
 import it.unibz.inf.ontop.answering.logging.impl.ClassAndPropertyExtractor.ClassesAndProperties;
 import it.unibz.inf.ontop.answering.logging.impl.QueryTemplateExtractor.QueryTemplateExtraction;
+import it.unibz.inf.ontop.evaluator.QueryContext;
 import it.unibz.inf.ontop.evaluator.impl.QueryContextImpl;
 import it.unibz.inf.ontop.exception.OntopReformulationException;
 import it.unibz.inf.ontop.injection.OntopReformulationSettings;
@@ -92,6 +93,7 @@ public class QueryLoggerImpl implements QueryLogger {
     private final JsonFactory jsonFactory;
     private final boolean isDecompositionEnabled;
     private final boolean isMergingEnabled;
+    private final QueryContext queryContext;
     private long reformulationTime;
     private long unblockedResulSetTime;
     private final ClassAndPropertyExtractor classAndPropertyExtractor;
@@ -121,20 +123,21 @@ public class QueryLoggerImpl implements QueryLogger {
     private ImmutableMap<String, String> bindings;
 
     @AssistedInject
-    protected QueryLoggerImpl(@Assisted ImmutableMap<String, String> httpHeaders,
+    protected QueryLoggerImpl(@Assisted QueryContext queryContext,
                               OntopReformulationSettings settings,
                               ClassAndPropertyExtractor classAndPropertyExtractor,
                               RelationNameExtractor relationNameExtractor,
                               QueryTemplateExtractor queryTemplateExtractor) {
-        this(System.out, httpHeaders, settings, classAndPropertyExtractor, relationNameExtractor, queryTemplateExtractor);
+        this(System.out, queryContext, settings, classAndPropertyExtractor, relationNameExtractor, queryTemplateExtractor);
     }
 
-    protected QueryLoggerImpl(PrintStream outputStream, ImmutableMap<String, String> httpHeaders,
+    protected QueryLoggerImpl(PrintStream outputStream, QueryContext queryContext,
                               OntopReformulationSettings settings,
                               ClassAndPropertyExtractor classAndPropertyExtractor,
                               RelationNameExtractor relationNameExtractor, QueryTemplateExtractor queryTemplateExtractor) {
         this.outputStream = outputStream;
-        this.httpHeaders = httpHeaders;
+        this.queryContext = queryContext;
+        this.httpHeaders = queryContext.getHttpHeaders();
         this.settings = settings;
         this.classAndPropertyExtractor = classAndPropertyExtractor;
         this.relationNameExtractor = relationNameExtractor;

--- a/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/answering/logging/impl/QueryLoggerImpl.java
+++ b/engine/reformulation/core/src/main/java/it/unibz/inf/ontop/answering/logging/impl/QueryLoggerImpl.java
@@ -142,7 +142,7 @@ public class QueryLoggerImpl implements QueryLogger {
         this.classAndPropertyExtractor = classAndPropertyExtractor;
         this.relationNameExtractor = relationNameExtractor;
         this.queryTemplateExtractor = queryTemplateExtractor;
-        this.queryId = UUID.randomUUID();
+        this.queryId = queryContext.getQueryId();
         creationTime = System.currentTimeMillis();
         applicationName = settings.getApplicationName();
         reformulationTime = -1;

--- a/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/connection/impl/QuestStatement.java
+++ b/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/connection/impl/QuestStatement.java
@@ -230,10 +230,9 @@ public abstract class QuestStatement implements OntopStatement {
 
 		ImmutableMap<String, String> normalizedHttpHeaders = normalizeHttpHeaders(httpHeaders);
 
-		QueryLogger queryLogger = queryLoggerFactory.create(normalizedHttpHeaders);
-		queryLogger.setSparqlQuery(inputQuery.getOriginalString());
-
 		QueryContext queryContext = queryContextFactory.create(normalizedHttpHeaders);
+		QueryLogger queryLogger = queryLoggerFactory.create(queryContext);
+		queryLogger.setSparqlQuery(inputQuery.getOriginalString());
 
 		CountDownLatch monitor = new CountDownLatch(1);
 
@@ -308,8 +307,9 @@ public abstract class QuestStatement implements OntopStatement {
 	@Override
 	public  <R extends OBDAResultSet>  IQ getExecutableQuery(KGQuery<R> inputQuery, ImmutableMultimap<String, String> httpHeaders) throws OntopReformulationException {
 		ImmutableMap<String, String> normalizedHttpHeaders = normalizeHttpHeaders(httpHeaders);
-		return engine.reformulateIntoNativeQuery(inputQuery, queryContextFactory.create(normalizedHttpHeaders),
-				queryLoggerFactory.create(normalizedHttpHeaders));
+		QueryContext queryContext = queryContextFactory.create(normalizedHttpHeaders);
+
+		return engine.reformulateIntoNativeQuery(inputQuery, queryContext, queryLoggerFactory.create(queryContext));
 	}
 
 }

--- a/engine/system/core/src/main/java/it/unibz/inf/ontop/query/resultset/impl/DefaultDescribeGraphResultSet.java
+++ b/engine/system/core/src/main/java/it/unibz/inf/ontop/query/resultset/impl/DefaultDescribeGraphResultSet.java
@@ -116,7 +116,7 @@ public class DefaultDescribeGraphResultSet implements GraphResultSet {
             do {
                 if (currentGraphResultSetIterator == null) {
                     if (constructQueryIterator.hasNext()) {
-                        QueryContext newQueryContext = queryContext.duplicateForNewQuery();
+                        QueryContext newQueryContext = queryContext.duplicateForNewQueryWithSameSalt();
                         QueryLogger constructQueryLogger = queryLoggerFactory.create(newQueryContext);
                         try {
                             GraphResultSet graphResultSet = constructQueryEvaluator.evaluate(constructQueryIterator.next(),

--- a/engine/system/core/src/main/java/it/unibz/inf/ontop/query/resultset/impl/DefaultDescribeGraphResultSet.java
+++ b/engine/system/core/src/main/java/it/unibz/inf/ontop/query/resultset/impl/DefaultDescribeGraphResultSet.java
@@ -20,8 +20,7 @@ public class DefaultDescribeGraphResultSet implements GraphResultSet {
     private final ResultSetIterator iterator;
 
     public DefaultDescribeGraphResultSet(DescribeQuery describeQuery, QueryLogger queryLogger,
-                                         QueryLogger.Factory queryLoggerFactory,
-                                         QueryContext queryContext,
+                                         QueryLogger.Factory queryLoggerFactory, QueryContext queryContext,
                                          Evaluator<TupleResultSet, SelectQuery> selectQueryEvaluator,
                                          Evaluator<GraphResultSet, ConstructQuery> constructQueryEvaluator,
                                          OntopConnectionCloseable statementClosingCB)
@@ -42,7 +41,7 @@ public class DefaultDescribeGraphResultSet implements GraphResultSet {
                                                               Evaluator<TupleResultSet, SelectQuery> selectQueryEvaluator)
             throws OntopQueryEvaluationException, OntopConnectionException,
             OntopReformulationException, OntopResultConversionException {
-        QueryLogger selectQueryLogger = queryLoggerFactory.create(ImmutableMap.of());
+        QueryLogger selectQueryLogger = queryLoggerFactory.create(queryContext);
         try (TupleResultSet resultSet = selectQueryEvaluator.evaluate(inputQuery.getSelectQuery(), queryContext, selectQueryLogger)) {
             queryLogger.declareResultSetUnblockedAndSerialize();
 
@@ -99,8 +98,7 @@ public class DefaultDescribeGraphResultSet implements GraphResultSet {
 
         public ResultSetIterator(ImmutableCollection<ConstructQuery> constructQueries,
                                  QueryLogger queryLogger, QueryLogger.Factory queryLoggerFactory,
-                                 QueryContext queryContext,
-                                 Evaluator<GraphResultSet, ConstructQuery> constructQueryEvaluator,
+                                 QueryContext queryContext, Evaluator<GraphResultSet, ConstructQuery> constructQueryEvaluator,
                                  OntopConnectionCloseable statementClosingCB) {
 
             this.constructQueryIterator = constructQueries.iterator();
@@ -118,10 +116,11 @@ public class DefaultDescribeGraphResultSet implements GraphResultSet {
             do {
                 if (currentGraphResultSetIterator == null) {
                     if (constructQueryIterator.hasNext()) {
-                        QueryLogger constructQueryLogger = queryLoggerFactory.create(ImmutableMap.of());
+                        QueryContext newQueryContext = queryContext.duplicateForNewQuery();
+                        QueryLogger constructQueryLogger = queryLoggerFactory.create(newQueryContext);
                         try {
                             GraphResultSet graphResultSet = constructQueryEvaluator.evaluate(constructQueryIterator.next(),
-                                    queryContext, constructQueryLogger);
+                                    newQueryContext, constructQueryLogger);
                             currentGraphResultSetIterator = graphResultSet.iterator();
                         } catch (OntopQueryEvaluationException e) {
                             throw new LateQueryEvaluationExceptionWhenDescribing(e);

--- a/engine/system/sql/core/src/test/java/it/unibz/inf/ontop/answering/reformulation/OfflineOnlineMarriageTest.java
+++ b/engine/system/sql/core/src/test/java/it/unibz/inf/ontop/answering/reformulation/OfflineOnlineMarriageTest.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.answering.OntopQueryEngine;
 import it.unibz.inf.ontop.answering.connection.OntopConnection;
 import it.unibz.inf.ontop.answering.connection.OntopStatement;
+import it.unibz.inf.ontop.evaluator.QueryContext;
 import it.unibz.inf.ontop.query.KGQueryFactory;
 import it.unibz.inf.ontop.query.SelectQuery;
 import it.unibz.inf.ontop.query.resultset.OntopBinding;
@@ -84,10 +85,12 @@ public class OfflineOnlineMarriageTest {
 
         SelectQuery query = kgQueryFactory.createSelectQuery(PERSON_QUERY_STRING);
 
+        QueryContext queryContext = queryReformulator.getQueryContextFactory().create(ImmutableMap.of());
+
 
         IQ executableQuery = queryReformulator.reformulateIntoNativeQuery(query,
-                queryReformulator.getQueryContextFactory().create(ImmutableMap.of()),
-                queryReformulator.getQueryLoggerFactory().create(ImmutableMap.of()));
+                queryContext,
+                queryReformulator.getQueryLoggerFactory().create(queryContext));
         String sqlQuery = Optional.of(executableQuery.getTree())
                 .filter(t -> t instanceof UnaryIQTree)
                 .map(t -> ((UnaryIQTree) t).getChild().getRootNode())

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/dremio/other/StringTypesAliasingDremioTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/dremio/other/StringTypesAliasingDremioTest.java
@@ -2,6 +2,7 @@ package it.unibz.inf.ontop.docker.lightweight.dremio.other;
 
 import com.google.common.collect.ImmutableMap;
 import it.unibz.inf.ontop.answering.reformulation.QueryReformulator;
+import it.unibz.inf.ontop.evaluator.QueryContext;
 import it.unibz.inf.ontop.exception.OntopInvalidKGQueryException;
 import it.unibz.inf.ontop.exception.OntopReformulationException;
 import it.unibz.inf.ontop.exception.OntopUnsupportedKGQueryException;
@@ -86,9 +87,10 @@ public class StringTypesAliasingDremioTest {
 
     private String reformulate(String query) throws OntopUnsupportedKGQueryException, OntopInvalidKGQueryException, OntopReformulationException {
         QueryReformulator reformulator = repository.getOntopEngine().getQueryReformulator();
+        QueryContext queryContext = reformulator.getQueryContextFactory().create(ImmutableMap.of());
         return reformulator.reformulateIntoNativeQuery(kgQueryFactory.createSPARQLQuery(query),
-                        reformulator.getQueryContextFactory().create(ImmutableMap.of()),
-                        reformulator.getQueryLoggerFactory().create(ImmutableMap.of()))
+                        queryContext,
+                        reformulator.getQueryLoggerFactory().create(queryContext))
                 .toString();
     }
 }


### PR DESCRIPTION
This PR adds support for `obdaf:queryId`, a nullary SPARQL function returning the ID the SPARQL query.
The value returned is the same as the one included in the query log (when enabled).

This allows joining metadata logs produced on the client side (issuing the SPARQL query) and on the Ontop side (reformulating the query).

Query loggers are now created out of query contexts