### PR TITLE
Circular dependency involving the OptimizationSingletons fixed

### DIFF
--- a/core/optimization/src/main/java/it/unibz/inf/ontop/injection/OptimizationSingletons.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/injection/OptimizationSingletons.java
@@ -17,17 +17,11 @@ public interface OptimizationSingletons {
 
     CoreSingletons getCoreSingletons();
 
-    DefinitionPushDownTransformer getDefinitionPushDownTransformer();
-
-    RequiredExtensionalDataNodeExtractor getRequiredExtensionalDataNodeExtractor();
-
-    GeneralStructuralAndSemanticIQOptimizer getGeneralStructuralAndSemanticIQOptimizer();
-
-    JoinLikeOptimizer getJoinLikeOptimizer();
-
-    QueryPlanner getQueryPlanner();
-
     OntopOptimizationSettings getSettings();
 
-    // TODO: complete
+    // used by downstream applications outside Ontop
+    GeneralStructuralAndSemanticIQOptimizer getGeneralStructuralAndSemanticIQOptimizer();
+
+    // used by downstream applications outside Ontop
+    QueryPlanner getQueryPlanner();
 }

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/injection/impl/OptimizationSingletonsImpl.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/injection/impl/OptimizationSingletonsImpl.java
@@ -15,26 +15,18 @@ import it.unibz.inf.ontop.iq.visitor.RequiredExtensionalDataNodeExtractor;
 public class OptimizationSingletonsImpl implements OptimizationSingletons {
 
     private final CoreSingletons coreSingletons;
-    private final RequiredExtensionalDataNodeExtractor requiredExtensionalDataNodeExtractor;
     private final OntopOptimizationSettings settings;
     private final GeneralStructuralAndSemanticIQOptimizer generalStructuralAndSemanticIQOptimizer;
-    private final JoinLikeOptimizer joinLikeOptimizer;
     private final QueryPlanner queryPlanner;
-    private final DefinitionPushDownTransformer definitionPushDownTransformer;
 
     @Inject
     protected OptimizationSingletonsImpl(CoreSingletons coreSingletons,
-                                         RequiredExtensionalDataNodeExtractor requiredExtensionalDataNodeExtractor,
                                          GeneralStructuralAndSemanticIQOptimizer generalStructuralAndSemanticIQOptimizer,
-                                         JoinLikeOptimizer joinLikeOptimizer, QueryPlanner queryPlanner,
-                                         OntopOptimizationSettings settings, DefinitionPushDownTransformer definitionPushDownTransformer) {
+                                         QueryPlanner queryPlanner, OntopOptimizationSettings settings) {
         this.coreSingletons = coreSingletons;
-        this.requiredExtensionalDataNodeExtractor = requiredExtensionalDataNodeExtractor;
         this.settings = settings;
         this.generalStructuralAndSemanticIQOptimizer = generalStructuralAndSemanticIQOptimizer;
-        this.joinLikeOptimizer = joinLikeOptimizer;
         this.queryPlanner = queryPlanner;
-        this.definitionPushDownTransformer = definitionPushDownTransformer;
     }
 
     @Override
@@ -43,28 +35,13 @@ public class OptimizationSingletonsImpl implements OptimizationSingletons {
     }
 
     @Override
-    public DefinitionPushDownTransformer getDefinitionPushDownTransformer() {
-        return definitionPushDownTransformer;
-    }
-
-    @Override
     public OntopOptimizationSettings getSettings() {
         return settings;
     }
 
     @Override
-    public RequiredExtensionalDataNodeExtractor getRequiredExtensionalDataNodeExtractor() {
-        return requiredExtensionalDataNodeExtractor;
-    }
-
-    @Override
     public GeneralStructuralAndSemanticIQOptimizer getGeneralStructuralAndSemanticIQOptimizer() {
         return generalStructuralAndSemanticIQOptimizer;
-    }
-
-    @Override
-    public JoinLikeOptimizer getJoinLikeOptimizer() {
-        return joinLikeOptimizer;
     }
 
     @Override

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/AggregationSimplifierImpl.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/AggregationSimplifierImpl.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.injection.CoreSingletons;
-import it.unibz.inf.ontop.injection.OptimizationSingletons;
 import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.UnaryIQTree;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
@@ -13,6 +12,7 @@ import it.unibz.inf.ontop.iq.node.ConstructionNode;
 import it.unibz.inf.ontop.iq.node.QueryNode;
 import it.unibz.inf.ontop.iq.optimizer.AggregationSimplifier;
 import it.unibz.inf.ontop.iq.transform.IQTreeVariableGeneratorTransformer;
+import it.unibz.inf.ontop.iq.transformer.DefinitionPushDownTransformer;
 import it.unibz.inf.ontop.iq.transformer.impl.RDFTypeDependentSimplifyingTransformer;
 import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.model.term.functionsymbol.FunctionSymbol;
@@ -29,20 +29,21 @@ import java.util.Optional;
 
 public class AggregationSimplifierImpl extends AbstractIQOptimizer implements AggregationSimplifier {
 
-    private final OptimizationSingletons optimizationSingletons;
+    private final CoreSingletons coreSingletons;
     private final TermFactory termFactory;
     private final IQTreeTools iqTreeTools;
+    private final DefinitionPushDownTransformer definitionPushDownTransformer;
 
     private final IQTreeVariableGeneratorTransformer transformer;
 
     @Inject
-    private AggregationSimplifierImpl(OptimizationSingletons optimizationSingletons) {
+    private AggregationSimplifierImpl(CoreSingletons coreSingletons, DefinitionPushDownTransformer definitionPushDownTransformer) {
         // no equality check
-        super(optimizationSingletons.getCoreSingletons().getIQFactory());
-        this.optimizationSingletons = optimizationSingletons;
-        CoreSingletons coreSingletons = optimizationSingletons.getCoreSingletons();
+        super(coreSingletons.getIQFactory());
+        this.coreSingletons = coreSingletons;
         this.termFactory = coreSingletons.getTermFactory();
         this.iqTreeTools = coreSingletons.getIQTreeTools();
+        this.definitionPushDownTransformer = definitionPushDownTransformer;
 
         this.transformer = IQTreeVariableGeneratorTransformer.of(
                 IQTreeVariableGeneratorTransformer.of(AggregationSimplifyingTransformer::new),
@@ -60,7 +61,7 @@ public class AggregationSimplifierImpl extends AbstractIQOptimizer implements Ag
     private class AggregationSimplifyingTransformer extends RDFTypeDependentSimplifyingTransformer {
 
         AggregationSimplifyingTransformer(VariableGenerator variableGenerator) {
-            super(optimizationSingletons, variableGenerator);
+            super(coreSingletons, definitionPushDownTransformer,  variableGenerator);
         }
 
         @Override

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/OrderBySimplifierImpl.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/optimizer/impl/OrderBySimplifierImpl.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import it.unibz.inf.ontop.injection.CoreSingletons;
-import it.unibz.inf.ontop.injection.OptimizationSingletons;
 import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.UnaryIQTree;
 import it.unibz.inf.ontop.iq.impl.IQTreeTools;
@@ -12,6 +11,7 @@ import it.unibz.inf.ontop.iq.node.OrderByNode;
 import it.unibz.inf.ontop.iq.optimizer.OrderBySimplifier;
 import it.unibz.inf.ontop.iq.request.DefinitionPushDownRequest;
 import it.unibz.inf.ontop.iq.transform.IQTreeVariableGeneratorTransformer;
+import it.unibz.inf.ontop.iq.transformer.DefinitionPushDownTransformer;
 import it.unibz.inf.ontop.iq.transformer.impl.RDFTypeDependentSimplifyingTransformer;
 import it.unibz.inf.ontop.model.term.*;
 import it.unibz.inf.ontop.model.term.functionsymbol.RDFTermFunctionSymbol;
@@ -26,7 +26,8 @@ import java.util.stream.Stream;
 
 public class OrderBySimplifierImpl extends AbstractIQOptimizer implements OrderBySimplifier {
 
-    private final OptimizationSingletons optimizationSingletons;
+    private final CoreSingletons coreSingletons;
+    private final DefinitionPushDownTransformer definitionPushDownTransformer;
     private final IQTreeTools iqTreeTools;
     private final TermFactory termFactory;
     private final TypeFactory typeFactory;
@@ -35,11 +36,11 @@ public class OrderBySimplifierImpl extends AbstractIQOptimizer implements OrderB
     private final IQTreeVariableGeneratorTransformer transformer;
 
     @Inject
-    protected OrderBySimplifierImpl(OptimizationSingletons optimizationSingletons) {
+    protected OrderBySimplifierImpl(CoreSingletons coreSingletons, DefinitionPushDownTransformer definitionPushDownTransformer) {
         // no equality check
-        super(optimizationSingletons.getCoreSingletons().getIQFactory());
-        this.optimizationSingletons = optimizationSingletons;
-        CoreSingletons coreSingletons = optimizationSingletons.getCoreSingletons();
+        super(coreSingletons.getIQFactory());
+        this.coreSingletons = coreSingletons;
+        this.definitionPushDownTransformer = definitionPushDownTransformer;
         this.termFactory = coreSingletons.getTermFactory();
         this.typeFactory = coreSingletons.getTypeFactory();
         this.iqTreeTools = coreSingletons.getIQTreeTools();
@@ -57,7 +58,7 @@ public class OrderBySimplifierImpl extends AbstractIQOptimizer implements OrderB
     private class OrderBySimplifyingTransformer extends RDFTypeDependentSimplifyingTransformer {
 
         OrderBySimplifyingTransformer(VariableGenerator variableGenerator) {
-            super(optimizationSingletons, variableGenerator);
+            super(coreSingletons, definitionPushDownTransformer, variableGenerator);
         }
 
         @Override

--- a/core/optimization/src/main/java/it/unibz/inf/ontop/iq/transformer/impl/RDFTypeDependentSimplifyingTransformer.java
+++ b/core/optimization/src/main/java/it/unibz/inf/ontop/iq/transformer/impl/RDFTypeDependentSimplifyingTransformer.java
@@ -2,7 +2,7 @@ package it.unibz.inf.ontop.iq.transformer.impl;
 
 import com.google.common.collect.ImmutableSet;
 import it.unibz.inf.ontop.exception.MinorOntopInternalBugException;
-import it.unibz.inf.ontop.injection.OptimizationSingletons;
+import it.unibz.inf.ontop.injection.CoreSingletons;
 import it.unibz.inf.ontop.iq.IQTree;
 import it.unibz.inf.ontop.iq.request.DefinitionPushDownRequest;
 import it.unibz.inf.ontop.iq.transformer.DefinitionPushDownTransformer;
@@ -26,9 +26,9 @@ public abstract class RDFTypeDependentSimplifyingTransformer extends DefaultRecu
 
     private final DefinitionPushDownTransformer definitionPushDownTransformer;
 
-    protected RDFTypeDependentSimplifyingTransformer(OptimizationSingletons optimizationSingletons, VariableGenerator variableGenerator) {
-        super(optimizationSingletons.getCoreSingletons().getIQFactory(), variableGenerator);
-        this.definitionPushDownTransformer = optimizationSingletons.getDefinitionPushDownTransformer();
+    protected RDFTypeDependentSimplifyingTransformer(CoreSingletons coreSingletons, DefinitionPushDownTransformer definitionPushDownTransformer, VariableGenerator variableGenerator) {
+        super(coreSingletons.getIQFactory(), variableGenerator);
+        this.definitionPushDownTransformer = definitionPushDownTransformer;
     }
 
     protected ImmutableTerm unwrapIfElseNull(ImmutableTerm term) {


### PR DESCRIPTION
In order to solve a circular dependency involving the `OptimizationSingletons` class, this PR refactors some classes to receive the required dependencies (`CoreSingletons` and `DefinitionPushDownTransformer`) via constructor injection instead of accessing them directly from the `OptimizationSingletons` class.

This circular dependency is causing problems to downstream applications. For Ontop itself, Guice managed to handle it automatically.