### PR TITLE
Support FILTER EXISTS/NOT EXISTS with constant-only subqueries

### DIFF
--- a/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/ExistsTest.java
+++ b/binding/rdf4j/src/test/java/it/unibz/inf/ontop/rdf4j/repository/ExistsTest.java
@@ -102,19 +102,17 @@ public class ExistsTest extends AbstractRDF4JTest {
                 "http://person.example.org/person/2", "http://person.example.org/person/5"));
     }
 
-    // Not supported (no variables in the exists graph pattern)
-    @Test(expected = QueryEvaluationException.class)
+    @Test
     public void testOnlyConstantsInFilter() {
         String sparql = "PREFIX : <http://person.example.org/>\n" +
                 "SELECT ?s WHERE {\n" +
                 "   ?s a :Person .\n" +
                 "   FILTER EXISTS { <http://person.example.org/person/1> :firstName \"Roger\" }\n" +
                 "}";
-        Assert.assertEquals(5, runQueryAndCount(sparql));
+        Assert.assertEquals(6, runQueryAndCount(sparql));
     }
 
-    // Not supported (no variables in the exists graph pattern)
-    @Test(expected = QueryEvaluationException.class)
+    @Test
     public void testOnlyConstantsInFilter1() {
         String sparql = "PREFIX : <http://person.example.org/>\n" +
                 "SELECT ?s WHERE {\n" +
@@ -180,16 +178,14 @@ public class ExistsTest extends AbstractRDF4JTest {
         runQueryAndCompare(sparql, ImmutableSet.of("http://person.example.org/person/2"));
     }
 
-    // Not supported (no variables present in the not exists graph pattern)
-    @Test(expected = QueryEvaluationException.class)
+    @Test
     public void testFilterNotExistsAllConstants() {
         String sparql = "PREFIX : <http://person.example.org/>\n" +
                 "SELECT ?v WHERE { " +
                 "       ?v :firstName ?fname ; \n" +
                 "       FILTER NOT EXISTS { <http://person.example.org/person/1> :firstName \"Roger\" } \n" +
                 "}\n";
-        int countResults = runQueryAndCount(sparql);
-        assertEquals(0, countResults);
+        assertEquals(0, runQueryAndCount(sparql));
     }
 
     // The inner filter variables not bound in the not exists graph pattern is not supported
@@ -713,6 +709,58 @@ public class ExistsTest extends AbstractRDF4JTest {
                 "} GROUP BY ?person ?fname  \n";
 
         runQueryAndCompare(sparql, ImmutableList.of("1", "1", "1"));
+    }
+
+    @Test
+    public void testConstantTriplesInFilterExists() {
+        String sparql = "PREFIX : <http://person.example.org/>\n" +
+                "SELECT ?s WHERE {\n" +
+                "   ?s a :Person .\n" +
+                "   FILTER EXISTS { " +
+                "       <http://person.example.org/person/1> :firstName \"Roger\" ." +
+                "       <http://person.example.org/person/1> :lastName \"Smith\" ."+
+                "}\n" +
+                "}";
+        Assert.assertEquals(6, runQueryAndCount(sparql));
+    }
+
+    @Test
+    public void testConstantTriplesInFilterExists2() {
+        String sparql = "PREFIX : <http://person.example.org/>\n" +
+                "SELECT ?s WHERE {\n" +
+                "   ?s a :Person .\n" +
+                "   FILTER EXISTS { " +
+                "       <http://person.example.org/person/1> :firstName \"Roger\" ." +
+                "       <http://person.example.org/person/1> :lastName \"WrongLastName\" ."+
+                "}\n" +
+                "}";
+        Assert.assertEquals(0, runQueryAndCount(sparql));
+    }
+
+    @Test
+    public void testConstantTriplesInFilterNotExists() {
+        String sparql = "PREFIX : <http://person.example.org/>\n" +
+                "SELECT ?s WHERE {\n" +
+                "   ?s a :Person .\n" +
+                "   FILTER NOT EXISTS { " +
+                "       <http://person.example.org/person/1> :firstName \"Roger\" ." +
+                "       <http://person.example.org/person/1> :lastName \"Smith\" ."+
+                "}\n" +
+                "}";
+        Assert.assertEquals(0, runQueryAndCount(sparql));
+    }
+
+    @Test
+    public void testConstantTriplesInFilterNotExists2() {
+        String sparql = "PREFIX : <http://person.example.org/>\n" +
+                "SELECT ?s WHERE {\n" +
+                "   ?s a :Person .\n" +
+                "   FILTER NOT EXISTS { " +
+                "       <http://person.example.org/person/1> :firstName \"Roger\" ." +
+                "       <http://person.example.org/person/1> :lastName \"WrongLastName\" ."+
+                "}\n" +
+                "}";
+        Assert.assertEquals(6, runQueryAndCount(sparql));
     }
 
 }

--- a/core/kg-query/src/main/java/it/unibz/inf/ontop/query/translation/impl/RDF4JTupleExprTranslator.java
+++ b/core/kg-query/src/main/java/it/unibz/inf/ontop/query/translation/impl/RDF4JTupleExprTranslator.java
@@ -414,13 +414,16 @@ public class RDF4JTupleExprTranslator {
                 child.nullableVariables);
     }
 
-    private ImmutableExpression getLeftJoinCondition(InjectiveSubstitution<Variable> sharedVarsRenaming, TranslationResult leftTranslation, TranslationResult rightTranslation) {
+    private Optional<ImmutableExpression> getLeftJoinCondition(InjectiveSubstitution<Variable> sharedVarsRenaming, TranslationResult leftTranslation, TranslationResult rightTranslation) {
+        if (sharedVarsRenaming.isEmpty()) {
+            return Optional.empty();
+        }
+
         return termFactory.getConjunction(Stream.concat(
                         sharedVarsRenaming.builder()
                                 .toStream((v, t) -> getCompatibilityCondition(v, t, leftTranslation.nullableVariables.contains(v), rightTranslation.nullableVariables.contains(v))),
                         Stream.of(termFactory.getDisjunction(sharedVarsRenaming.builder()
-                                .toStream(termFactory::getStrictEquality).collect(ImmutableCollectors.toList()))))
-                .collect(ImmutableCollectors.toList()));
+                                .toStream(termFactory::getStrictEquality).collect(ImmutableCollectors.toList())))));
     }
 
     private IQTree createExistsSubtree(Exists exists, Variable rightProvenanceVar, TranslationResult leftTranslation) throws OntopUnsupportedKGQueryException, OntopInvalidKGQueryException {
@@ -431,7 +434,7 @@ public class RDF4JTupleExprTranslator {
 
         InjectiveSubstitution<Variable> sharedVarsRenaming = getSharedVariablesRenaming(leftTranslation.iqTree, rightTranslation.iqTree);
 
-        ImmutableExpression ljCond = getLeftJoinCondition(sharedVarsRenaming, leftTranslation, rightTranslation);
+        Optional<ImmutableExpression> ljCond = getLeftJoinCondition(sharedVarsRenaming, leftTranslation, rightTranslation);
 
         IQTree renamedRightTree = applyInDepthRenaming(
                 getRightConflictingProvenanceRenaming(rightTranslation, rightProvenanceVar),
@@ -485,6 +488,18 @@ public class RDF4JTupleExprTranslator {
 
         checkIfExistsIsTranslatable(leftTranslation, rightTranslation, exists.getSubQuery());
 
+        if (getSharedVariables(leftTranslation.iqTree, rightTranslation.iqTree).isEmpty()) {
+            Variable provenanceVar = variableGenerator.generateNewVariable("prov");
+            IQTree treeWithProv = createExistsSubtree(exists, provenanceVar, leftTranslation);
+            return createTranslationResult(
+                    iqFactory.createUnaryIQTree(
+                            iqFactory.createConstructionNode(leftTranslation.iqTree.getVariables()),
+                            iqFactory.createUnaryIQTree(
+                                    iqFactory.createFilterNode(termFactory.getDBIsNull(provenanceVar)),
+                                    treeWithProv)),
+                    leftTranslation.nullableVariables);
+        }
+
         return translateMinusOperation(leftTranslation, rightTranslation);
     }
 
@@ -493,7 +508,7 @@ public class RDF4JTupleExprTranslator {
 
         InjectiveSubstitution<Variable> sharedVarsRenaming = getSharedVariablesRenaming(leftTranslation.iqTree, rightTranslation.iqTree);
 
-        ImmutableExpression ljCond = getLeftJoinCondition(sharedVarsRenaming, leftTranslation, rightTranslation);
+        Optional<ImmutableExpression> ljCond = getLeftJoinCondition(sharedVarsRenaming, leftTranslation, rightTranslation);
 
         ImmutableExpression filter = termFactory.getConjunction(sharedVarsRenaming.getRangeSet().stream()
                 .map(termFactory::getDBIsNull)
@@ -509,20 +524,20 @@ public class RDF4JTupleExprTranslator {
     }
 
     private void checkIfExistsIsTranslatable(TranslationResult leftTranslation, TranslationResult rightTranslation, TupleExpr existsSubquery) throws OntopUnsupportedKGQueryException {
-        Sets.SetView<Variable> sharedVariables = getSharedVariables(leftTranslation.iqTree, rightTranslation.iqTree);
-
-        if (sharedVariables.isEmpty()) {
-            throw new OntopUnsupportedKGQueryException("The EXISTS operator is not supported with no common variables");
-        }
-
-        if (sharedVariables.stream().anyMatch(v -> v.isNullable(leftTranslation.nullableVariables)
-                || v.isNullable(rightTranslation.nullableVariables))) {
-            throw new OntopUnsupportedKGQueryException("The EXISTS operator is not supported when there are non-nullable common variables");
-        }
-
         ExistsSubtreeVisitor existsVisitor = new ExistsSubtreeVisitor(termFactory, existsSubquery);
         if (!existsVisitor.isExistsSubtreeSupported()) {
             throw new OntopUnsupportedKGQueryException("The EXISTS subquery is not supported: " + existsSubquery);
+        }
+
+        Sets.SetView<Variable> sharedVariables = getSharedVariables(leftTranslation.iqTree, rightTranslation.iqTree);
+
+        if (sharedVariables.isEmpty() && !existsVisitor.getVariables().isEmpty()) {
+            throw new OntopUnsupportedKGQueryException("The EXISTS operator is not supported with no common variables");
+        }
+
+        if (!sharedVariables.isEmpty() && sharedVariables.stream().anyMatch(v -> v.isNullable(leftTranslation.nullableVariables)
+                || v.isNullable(rightTranslation.nullableVariables))) {
+            throw new OntopUnsupportedKGQueryException("The EXISTS operator is not supported when there are non-nullable common variables");
         }
 
         Sets.SetView<Variable> unboundVariables = Sets.difference(existsVisitor.getVariables(), rightTranslation.iqTree.getKnownVariables());


### PR DESCRIPTION
`FILTER EXISTS` and `FILTER NOT EXISTS` now work when the subquery contains only constant patterns, e.g. `FILTER EXISTS { <:a> :p "v" }`. Previously these threw `OntopUnsupportedKGQueryException`.

For `FILTER EXISTS` the translation is unchanged, the only fix is relaxing the guard in `checkIfExistsIsTranslatable` to allow such queries.

For `FILTER NOT EXISTS` the existing minus-based translation cannot be used in the constant-only case: per the SPARQL spec (https://www.w3.org/TR/sparql11-query/#neg-notexists-minus), `FILTER NOT EXISTS { :a :b :c }` removes all outer rows if the triple exists in the data, whereas `MINUS { :a :b :c }` has no effect (no  shared variables means no solutions are eliminated). 
Instead, the constant-only case reuses the same left-join+provenance tree as `FILTER EXISTS` and wraps the result with an `IS_NULL(prov)` check.