### PR TITLE
Query ID returned as HTTP header for the reformulation endpoint

### DIFF
--- a/binding/rdf4j/src/main/java/it/unibz/inf/ontop/rdf4j/repository/OntopRepositoryConnection.java
+++ b/binding/rdf4j/src/main/java/it/unibz/inf/ontop/rdf4j/repository/OntopRepositoryConnection.java
@@ -4,6 +4,8 @@ import com.google.common.collect.ImmutableMultimap;
 import org.eclipse.rdf4j.query.*;
 import org.eclipse.rdf4j.repository.RepositoryException;
 
+import java.util.UUID;
+
 public interface OntopRepositoryConnection extends org.eclipse.rdf4j.repository.RepositoryConnection {
 
     Query prepareQuery(QueryLanguage ql, String query, ImmutableMultimap<String, String> httpHeaders)
@@ -30,10 +32,14 @@ public interface OntopRepositoryConnection extends org.eclipse.rdf4j.repository.
      */
     String reformulate(String sparql, ImmutableMultimap<String, String> httpHeaders) throws RepositoryException;
 
+    ReformulationAndId reformulateWithId(String sparql, ImmutableMultimap<String, String> httpHeaders) throws RepositoryException;
+
     /**
      * Renders the native query
      */
     String reformulateIntoNativeQuery(String sparql, ImmutableMultimap<String, String> httpHeaders, boolean forNativeConsumption) throws RepositoryException;
+
+    ReformulationAndId reformulateIntoNativeQueryWithId(String sparql, ImmutableMultimap<String, String> httpHeaders, boolean forNativeConsumption) throws RepositoryException;
 
     @Deprecated(since = "5.6.0")
     default String reformulateIntoNativeQuery(String sparql, ImmutableMultimap<String, String> httpHeaders) throws RepositoryException {
@@ -47,5 +53,13 @@ public interface OntopRepositoryConnection extends org.eclipse.rdf4j.repository.
 
     default String reformulateIntoNativeQuery(String sparql, boolean forNativeConsumption) throws RepositoryException {
         return reformulateIntoNativeQuery(sparql, ImmutableMultimap.of(), forNativeConsumption);
+    }
+
+    /**
+     * TODO: replace it by a record when upgrading to Java >= 17
+     */
+    interface ReformulationAndId {
+        UUID getQueryId();
+        String getReformulation();
     }
 }

--- a/binding/rdf4j/src/main/java/it/unibz/inf/ontop/rdf4j/repository/impl/OntopRepositoryConnectionImpl.java
+++ b/binding/rdf4j/src/main/java/it/unibz/inf/ontop/rdf4j/repository/impl/OntopRepositoryConnectionImpl.java
@@ -611,9 +611,17 @@ public class OntopRepositoryConnectionImpl implements OntopRepositoryConnection 
     @Override
     public String reformulate(String sparql, ImmutableMultimap<String, String> httpHeaders)
             throws RepositoryException {
+        return reformulateWithId(sparql, httpHeaders).getReformulation();
+    }
+
+    @Override
+    public ReformulationAndId reformulateWithId(String sparql, ImmutableMultimap<String, String> httpHeaders) throws RepositoryException{
         try {
             SPARQLQuery<?> sparqlQuery = ontopConnection.getInputQueryFactory().createSPARQLQuery(sparql);
-            return ontopConnection.createStatement().getExecutableQuery(sparqlQuery, httpHeaders, false).toString();
+            UUID queryId = UUID.randomUUID();
+            String reformulation = ontopConnection.createStatement().getExecutableQuery(sparqlQuery, httpHeaders, false, queryId).toString();
+            return new ReformulationAndIdImpl(queryId, reformulation);
+
         } catch (OntopKGQueryException | OntopReformulationException | OntopConnectionException e) {
             throw new RepositoryException(e);
         }
@@ -622,21 +630,50 @@ public class OntopRepositoryConnectionImpl implements OntopRepositoryConnection 
     @Override
     public String reformulateIntoNativeQuery(String sparql, ImmutableMultimap<String, String> httpHeaders, boolean forNativeConsumption)
             throws RepositoryException {
+        return reformulateIntoNativeQueryWithId(sparql, httpHeaders, forNativeConsumption).getReformulation();
+    }
+
+    @Override
+    public ReformulationAndId reformulateIntoNativeQueryWithId(String sparql, ImmutableMultimap<String, String> httpHeaders, boolean forNativeConsumption) throws RepositoryException {
         try {
             SPARQLQuery<?> sparqlQuery = ontopConnection.getInputQueryFactory().createSPARQLQuery(sparql);
-            IQTree executableTree = ontopConnection.createStatement().getExecutableQuery(sparqlQuery, httpHeaders, forNativeConsumption)
+            UUID queryId = UUID.randomUUID();
+            IQTree executableTree = ontopConnection.createStatement().getExecutableQuery(sparqlQuery, httpHeaders, forNativeConsumption, queryId)
                     .getTree();
 
             var construction = UnaryIQTreeDecomposition.of(executableTree, ConstructionNode.class);
             if (construction.isPresent()) {
                 IQTree child = construction.getChild();
                 if (child instanceof NativeNode)
-                    return ((NativeNode) child).getNativeQueryString();
+                    return new ReformulationAndIdImpl(
+                            queryId,
+                            ((NativeNode) child).getNativeQueryString());
             }
             throw new MinorOntopInternalBugException("Unexpected structure of the executable IQTree: " + executableTree);
 
         } catch (OntopKGQueryException | OntopReformulationException | OntopConnectionException e) {
             throw new RepositoryException(e);
+        }
+    }
+
+    protected static class ReformulationAndIdImpl implements ReformulationAndId {
+
+        private final UUID queryId;
+        private final String nativeQuery;
+
+        protected ReformulationAndIdImpl(UUID queryId, String nativeQuery) {
+            this.queryId = queryId;
+            this.nativeQuery = nativeQuery;
+        }
+
+        @Override
+        public UUID getQueryId() {
+            return queryId;
+        }
+
+        @Override
+        public String getReformulation() {
+            return nativeQuery;
         }
     }
 

--- a/client/cli/src/test/java/it/unibz/inf/ontop/cli/OntopEndpointReformulateTest.java
+++ b/client/cli/src/test/java/it/unibz/inf/ontop/cli/OntopEndpointReformulateTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -159,6 +160,22 @@ public class OntopEndpointReformulateTest {
         String body = reformulate(ASK_QUERY, true);
         LOGGER.debug("Reformulation ASK (for native consumption):\n{}", body);
         assertTrue("Native consumption body should only contain the SQL query", body.trim().startsWith("SELECT"));
+    }
+
+    @Test
+    public void testReformulateReturnsQueryIdHeader() throws IOException {
+        String encodedQuery = URLEncoder.encode(SELECT_QUERY, StandardCharsets.UTF_8);
+        String url = "http://localhost:" + PORT + "/ontop/reformulate?query=" + encodedQuery;
+        HttpUriRequest request = new HttpGet(url);
+        HttpResponse response = HttpClientBuilder.create().build().execute(request);
+        assertThat("Reformulate endpoint should return 200",
+                response.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_OK));
+
+        var header = response.getFirstHeader("X-Query-ID");
+        assertNotNull("Response should contain an X-Query-ID header", header);
+        UUID queryId = UUID.fromString(header.getValue());
+        assertNotNull("X-Query-ID header should be a valid UUID", queryId);
     }
 
     private String reformulate(String sparqlQuery) throws IOException {

--- a/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/controllers/ReformulateController.java
+++ b/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/controllers/ReformulateController.java
@@ -2,9 +2,8 @@ package it.unibz.inf.ontop.endpoint.controllers;
 
 import com.google.common.collect.ImmutableMultimap;
 import it.unibz.inf.ontop.endpoint.processor.SparqlQueryExecutor;
-import it.unibz.inf.ontop.exception.OntopConnectionException;
-import it.unibz.inf.ontop.exception.OntopReformulationException;
 import it.unibz.inf.ontop.rdf4j.repository.OntopRepositoryConnection;
+import it.unibz.inf.ontop.rdf4j.repository.OntopRepositoryConnection.ReformulationAndId;
 import it.unibz.inf.ontop.rdf4j.repository.impl.OntopVirtualRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -41,13 +40,14 @@ public class ReformulateController {
         ImmutableMultimap<String, String> inputHeaders = SparqlQueryExecutor.extractHttpHeaders(request);
 
         try (OntopRepositoryConnection connection = repository.getConnection()) {
-            String reformulation = forNativeConsumption
-                    ? connection.reformulateIntoNativeQuery(query, inputHeaders, true)
-                    : connection.reformulate(query, inputHeaders);
+            ReformulationAndId reformulationAndId = forNativeConsumption
+                    ? connection.reformulateIntoNativeQueryWithId(query, inputHeaders, true)
+                    : connection.reformulateWithId(query, inputHeaders);
 
             HttpHeaders returnedHeaders = new HttpHeaders();
             returnedHeaders.set(CONTENT_TYPE, "text/plain; charset=UTF-8");
-            return new ResponseEntity<>(reformulation, returnedHeaders, HttpStatus.OK);
+            returnedHeaders.set("X-Query-ID", reformulationAndId.getQueryId().toString());
+            return new ResponseEntity<>(reformulationAndId.getReformulation(), returnedHeaders, HttpStatus.OK);
         }
     }
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/evaluator/QueryContext.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/evaluator/QueryContext.java
@@ -30,6 +30,7 @@ public interface QueryContext {
 
     interface Factory {
         QueryContext create(ImmutableMap<String, String> normalizedHttpHeaders);
+        QueryContext create(ImmutableMap<String, String> normalizedHttpHeaders, UUID queryId);
     }
 
 }

--- a/core/model/src/main/java/it/unibz/inf/ontop/evaluator/impl/QueryContextImpl.java
+++ b/core/model/src/main/java/it/unibz/inf/ontop/evaluator/impl/QueryContextImpl.java
@@ -36,8 +36,19 @@ public class QueryContextImpl implements QueryContext {
         this(normalizedHttpHeaders, settings, UUID.randomUUID());
     }
 
+    @AssistedInject
+    protected QueryContextImpl(@Assisted ImmutableMap<String, String> normalizedHttpHeaders,
+                               @Assisted UUID queryId, OntopModelSettings settings) {
+        this(normalizedHttpHeaders, queryId, settings, UUID.randomUUID());
+    }
+
     protected QueryContextImpl(ImmutableMap<String, String> normalizedHttpHeaders,
-                             OntopModelSettings settings, UUID salt) {
+                               OntopModelSettings settings, UUID salt) {
+        this(normalizedHttpHeaders, UUID.randomUUID(),settings, salt);
+    }
+
+    protected QueryContextImpl(ImmutableMap<String, String> normalizedHttpHeaders,
+                             UUID queryId, OntopModelSettings settings, UUID salt) {
         this.httpHeaders = normalizedHttpHeaders;
         if (settings.isAuthorizationEnabled()) {
             var commaSplitter = Splitter.on(",");
@@ -59,7 +70,7 @@ public class QueryContextImpl implements QueryContext {
 
         this.salt = salt;
         this.settings = settings;
-        this.queryId = UUID.randomUUID();
+        this.queryId = queryId;
     }
 
     @Override

--- a/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/connection/OntopStatement.java
+++ b/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/connection/OntopStatement.java
@@ -11,6 +11,8 @@ import it.unibz.inf.ontop.query.resultset.TupleResultSet;
 import it.unibz.inf.ontop.exception.*;
 import it.unibz.inf.ontop.iq.IQ;
 
+import java.util.UUID;
+
 /**
  * OBDAStatement specific to Ontop.
  *
@@ -27,6 +29,11 @@ public interface OntopStatement extends OBDAStatement {
     <R extends OBDAResultSet> String getRewritingRendering(KGQuery<R> inputQuery) throws OntopReformulationException;
 
     <R extends OBDAResultSet> IQ getExecutableQuery(KGQuery<R> inputQuery, ImmutableMultimap<String, String> httpHeaders, boolean forNativeConsumption) throws OntopReformulationException;
+
+    /**
+     * Make sure the queryId is unique
+     */
+    <R extends OBDAResultSet> IQ getExecutableQuery(KGQuery<R> inputQuery, ImmutableMultimap<String, String> httpHeaders, boolean forNativeConsumption, UUID queryId) throws OntopReformulationException;
 
     TupleResultSet executeSelectQuery(IQ executableQuery, QueryLogger queryLogger)
             throws OntopQueryEvaluationException;

--- a/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/connection/impl/QuestStatement.java
+++ b/engine/system/core/src/main/java/it/unibz/inf/ontop/answering/connection/impl/QuestStatement.java
@@ -18,6 +18,7 @@ import it.unibz.inf.ontop.utils.ImmutableCollectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
 
@@ -321,6 +322,14 @@ public abstract class QuestStatement implements OntopStatement {
 	public  <R extends OBDAResultSet>  IQ getExecutableQuery(KGQuery<R> inputQuery, ImmutableMultimap<String, String> httpHeaders, boolean forNativeConsumption) throws OntopReformulationException {
 		ImmutableMap<String, String> normalizedHttpHeaders = normalizeHttpHeaders(httpHeaders);
 		QueryContext queryContext = queryContextFactory.create(normalizedHttpHeaders);
+
+		return engine.reformulateIntoNativeQuery(inputQuery, queryContext, queryLoggerFactory.create(queryContext), forNativeConsumption);
+	}
+
+	@Override
+	public  <R extends OBDAResultSet>  IQ getExecutableQuery(KGQuery<R> inputQuery, ImmutableMultimap<String, String> httpHeaders, boolean forNativeConsumption, UUID queryID) throws OntopReformulationException {
+		ImmutableMap<String, String> normalizedHttpHeaders = normalizeHttpHeaders(httpHeaders);
+		QueryContext queryContext = queryContextFactory.create(normalizedHttpHeaders, queryID);
 
 		return engine.reformulateIntoNativeQuery(inputQuery, queryContext, queryLoggerFactory.create(queryContext), forNativeConsumption);
 	}


### PR DESCRIPTION
#924 exposes the query ID as a special SPARQL function. The query ID value is returned with the query results. However, when calling the query reformulation endpoint, this value is accessible inside the generated SQL query string, and SQL parsing would be needed to retrieve it.

This PR returns the query ID with the `X-Query-ID` HTTP header when calling the query reformulation endpoint, whether the query ID function is used in the SPARQL query or not.