### PR TITLE
Cannot create a lens with Athena

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AthenaDBMetadataProvider.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/dbschema/impl/AthenaDBMetadataProvider.java
@@ -5,11 +5,14 @@ import com.google.inject.assistedinject.AssistedInject;
 import it.unibz.inf.ontop.dbschema.RelationID;
 import it.unibz.inf.ontop.exception.MetadataExtractionException;
 import it.unibz.inf.ontop.injection.CoreSingletons;
+import it.unibz.inf.ontop.utils.ImmutableCollectors;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 
 public class AthenaDBMetadataProvider extends TrinoDBMetadataProvider {
 
@@ -29,6 +32,47 @@ public class AthenaDBMetadataProvider extends TrinoDBMetadataProvider {
         stmt.closeOnCompletion();
         return stmt.executeQuery("SELECT TABLE_CATALOG AS TABLE_CAT, TABLE_SCHEMA AS TABLE_SCHEM, TABLE_NAME " +
                 "FROM INFORMATION_SCHEMA.TABLES");
+    }
+
+    /**
+     * Simba's Athena JDBC driver implements DatabaseMetaData.getColumns with a
+     * case-sensitive comparison on the catalog argument, even though Athena SQL itself is
+     * case-insensitive. We bypass the driver and query INFORMATION_SCHEMA.COLUMNS directly.
+     * The TABLE_CAT, TABLE_SCHEM and TABLE_NAME stored in INFORMATION_SCHEMA.COLUMNS are normalized
+     * to lowercase, which can differ from the case of the canonical RelationID (e.g. when the catalog
+     * has been padded in from the JDBC URL's Catalog=... parameter). We return the bound parameters instead
+     * of the normalized ones.
+     */
+    @Override
+    protected ResultSet getColumnsResultSet(RelationID id) throws SQLException {
+        String catalog = getRelationCatalog(id);
+        String schema = getRelationSchema(id);
+        String table = getRelationName(id);
+        PreparedStatement st = connection.prepareStatement(
+                "SELECT ? AS TABLE_CAT, " +
+                        "       ? AS TABLE_SCHEM, " +
+                        "       ? AS TABLE_NAME, " +
+                        "       column_name AS COLUMN_NAME, " +
+                        "       data_type   AS TYPE_NAME, " +
+                        // TYPE_NAME already carries parameters (varchar(100), decimal(38,2)), DATA_TYPE=OTHER avoids extractSQLTypeName re-appending precision.
+                        "       CAST(" + Types.OTHER + " AS INTEGER) AS DATA_TYPE, " +
+                        // COLUMN_SIZE and DECIMAL_DIGITS are placeholders
+                        "       CAST(0 AS INTEGER) AS COLUMN_SIZE, " +
+                        "       CAST(0 AS INTEGER) AS DECIMAL_DIGITS, " +
+                        "       CASE WHEN is_nullable = 'YES' THEN 1 ELSE 0 END AS NULLABLE " +
+                        "FROM INFORMATION_SCHEMA.COLUMNS " +
+                        "WHERE LOWER(table_catalog) = LOWER(?) " +
+                        "  AND LOWER(table_schema)  = LOWER(?) " +
+                        "  AND LOWER(table_name)    = LOWER(?) " +
+                        "ORDER BY ordinal_position");
+        st.closeOnCompletion();
+        st.setString(1, catalog);
+        st.setString(2, schema);
+        st.setString(3, table);
+        st.setString(4, catalog);
+        st.setString(5, schema);
+        st.setString(6, table);
+        return st.executeQuery();
     }
 
     @Override

--- a/test/lightweight-tests/src/test/resources/books/athena/books-athena.obda
+++ b/test/lightweight-tests/src/test/resources/books/athena/books-athena.obda
@@ -7,7 +7,7 @@ ns:  http://example.org/ns#
 [MappingDeclaration] @collection [[
 mappingId	mapping1
 target	:{id} a :Book ; dc:title {title}@en ; ns:price {price} ; ns:discount {discount} ; ns:pubYear {publication_date} ; dc:description {description}@en .
-source	SELECT id, title, price, discount, publication_date, description, lang FROM books.books WHERE lang = 'en'
+source	SELECT id, title, price, discount, publication_date, description, lang FROM "AwsDataCatalog"."books"."books" WHERE lang = 'en'
 
 mappingId	divisionTest
 target	dc:divisionResult dc:value {value} .

--- a/test/lightweight-tests/src/test/resources/prof/athena/prof-athena.obda
+++ b/test/lightweight-tests/src/test/resources/prof/athena/prof-athena.obda
@@ -10,35 +10,35 @@ rdfs:		http://www.w3.org/2000/01/rdf-schema#
 [MappingDeclaration] @collection [[
 mappingId	MAPID-professor
 target		:professor/{prof_id} a :Professor . 
-source		SELECT prof_id, last_name FROM university.professors;
+source		SELECT prof_id, last_name FROM AwsDataCatalog.university.professors;
 
 mappingId	MAPID-fname
 target		:professor/{prof_id} :firstName {first_name} .
-source		SELECT prof_id, first_name FROM university.professors;
+source		SELECT prof_id, first_name FROM "AwsDataCatalog".university.professors;
 
 mappingId	MAPID-lname
 target		:professor/{prof_id} :lastName {last_name} .
-source		SELECT prof_id, last_name FROM university.professors;
+source		SELECT prof_id, last_name FROM awsdatacatalog.university.professors;
 
 mappingId	MAPID-nickname
 target		:professor/{prof_id} :nickname {nickname} .
-source		SELECT prof_id, nickname FROM university.professors;
+source		SELECT prof_id, nickname FROM "awsdatacatalog".university.professors;
 
 mappingId	MAPID-teaches
 target		:professor/{prof_id} :teaches :course/{course_id} . 
-source		SELECT prof_id, course_id FROM university.teaching;
+source		SELECT prof_id, course_id FROM AWSDATACATALOG.UNIVERSITY.TEACHING;
 
 mappingId	MAPID-teachesAt
 target		:professor/{prof_id} :teachesAt :university/Bolzano .
-source		SELECT prof_id FROM university.teaching;
+source		SELECT prof_id FROM "AWSDATACATALOG"."UNIVERSITY"."TEACHING";
 
 mappingId	MAPID-teacherID
 target		:professor/{prof_id} :teacherID {prof_id} .
-source		SELECT prof_id FROM university.teaching;
+source		SELECT prof_id FROM university.Teaching;
 
 mappingId	MAPID-course
 target		:course/{course_id} a :Course ; :duration {duration} ; :nbStudents {nb_students} .
-source		SELECT * FROM university.course;
+source		SELECT * FROM University.course;
 
 mappingId	MAPID-prof-student-count
 target		:professor/{prof_id} :nbStudents {count} .

--- a/test/lightweight-tests/src/test/resources/university/university-athena.obda
+++ b/test/lightweight-tests/src/test/resources/university/university-athena.obda
@@ -4,9 +4,9 @@
 [MappingDeclaration] @collection [[
 mappingId	course
 target		:{course_id} a :Course ; :numberOfStudents "{nb_students}"^^xsd:integer ; :duration "{duration}"^^xsd:decimal .
-source		select course_id, nb_students, duration from awsdatacatalog.university.course
+source		select course_id, nb_students, duration from university.course
 
 mappingId	teaches
 target		:{prof_id} a :Professor ; :teaches :{course_id} .
-source		select prof_id, course_id from awsdatacatalog.university.teaching
+source		select prof_id, course_id from university.teaching
 ]]

--- a/test/lightweight-tests/src/test/resources/university/university-athena.obda
+++ b/test/lightweight-tests/src/test/resources/university/university-athena.obda
@@ -4,9 +4,9 @@
 [MappingDeclaration] @collection [[
 mappingId	course
 target		:{course_id} a :Course ; :numberOfStudents "{nb_students}"^^xsd:integer ; :duration "{duration}"^^xsd:decimal .
-source		select course_id, nb_students, duration from university.course
+source		select course_id, nb_students, duration from awsdatacatalog.university.course
 
 mappingId	teaches
 target		:{prof_id} a :Professor ; :teaches :{course_id} .
-source		select prof_id, course_id from university.teaching
+source		select prof_id, course_id from awsdatacatalog.university.teaching
 ]]


### PR DESCRIPTION
Fixes relation resolution for AWS Athena so that the same table can be referenced through any of the catalog/schema/table case variants Athena accepts at the SQL level (e.g. `awsdatacatalog.books.books`, `"AWSDATACATALOG"."books"."books"`, `"books"."books"`, …).

## Root cause

The Simba Athena JDBC driver's `DatabaseMetaData.getColumns(catalog, schema, table, …)` is case-sensitive on the catalog argument, even though Athena SQL itself is case-insensitive at the identifier-resolution level.

## Fix

Override `AthenaDBMetadataProvider.getColumnsResultSet` to bypass the Simba JDBC implementation and query `INFORMATION_SCHEMA.COLUMNS` directly.

This trades one driver-specific quirk for a SQL one: `INFORMATION_SCHEMA` stores all identifiers lowercased, while the canonical `RelationID` we resolve may carry a different case, either because the user wrote it that way in the mapping, or because the catalog was padded from the JDBC URL's `Catalog=…` parameter. Returning the row's stored values would make the row's identifier disagree with the canonical id (consistency check in `extractRelationID`). Instead of selecting from the table, we echo the bound parameters back for `TABLE_CAT`/`TABLE_SCHEM`/`TABLE_NAME`.

The remaining JDBC-contract columns are populated as follows:

| Column                            | Source                | Notes |
|---                                |---                    |---|
| `COLUMN_NAME`                     | `column_name`         |  |
| `TYPE_NAME`                       | `data_type`           | already carries parameters with precision (`varchar(100)`, `decimal(38,2)`) |
| `DATA_TYPE`                       | `Types.OTHER` (1111)  | placeholder. Only used to append precision which is already present in `TYPE_NAME` |
| `COLUMN_SIZE`, `DECIMAL_DIGITS`   | `0`                   | placeholders, unused |
| `NULLABLE`                        | `CASE WHEN is_nullable = 'YES' THEN 1 ELSE 0 END` | maps Athena's `'YES'`/`'NO'` to the JDBC int contract (`columnNullable=1`, `columnNoNulls=0`) |