### PR TITLE
Update RDF4J for TSV serialization fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <proj4j.version>1.1.1</proj4j.version>
         <protege-xmlcatalog.version>1.0.5</protege-xmlcatalog.version>
         <r2rml-api.version>0.9.1</r2rml-api.version>
-        <rdf4j.version>5.1.4</rdf4j.version>
+        <rdf4j.version>5.1.6</rdf4j.version>
         <servlet2-api.version>2.5</servlet2-api.version>
         <servlet4-api.version>4.0.1</servlet4-api.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
Addresses issue #939 .

The version of RDF4J in use (`5.1.4`) contains a bug regarding unquoted string literals that was fixed in version `5.1.6` (https://github.com/eclipse-rdf4j/rdf4j/issues/5256) .

This PR bumps the RDF4J dependency in Ontop from `5.1.4` to `5.1.6` to address this