### PR TITLE
Fix MalformedQueryException in QuestOWL consistency check for asymmetric/inverse object properties

### DIFF
--- a/protege/plugin/src/main/java/it/unibz/inf/ontop/owlapi/impl/QuestOWL.java
+++ b/protege/plugin/src/main/java/it/unibz/inf/ontop/owlapi/impl/QuestOWL.java
@@ -330,16 +330,15 @@ public class QuestOWL extends OWLReasonerBase implements OntopOWLReasoner {
 		
 		//deal with disjoint properties
 		{
-			final String strQueryProp = "ASK {?x <%s> ?y; <%s> ?y }";
-
 			for(NaryAxiom<ObjectPropertyExpression> dda
 						: classifiedTBox.disjointObjectProperties()) {
-				// TODO: handle role inverses and multiple arguments			
+				// build each atom from the property IRI + direction so inverse expressions
+				// (e.g. an asymmetric property p, classified as p disjoint inv(p)) are handled
 				Collection<ObjectPropertyExpression> props = dda.getComponents();
 				Iterator<ObjectPropertyExpression> iterator = props.iterator();
 				ObjectPropertyExpression p1 = iterator.next();
 				ObjectPropertyExpression p2 = iterator.next();
-				String strQuery = String.format(strQueryProp, p1, p2);
+				String strQuery = "ASK { " + objectPropertyAtom(p1) + " . " + objectPropertyAtom(p2) + " }";
 				
 				boolean isConsistent = executeConsistencyQuery(strQuery);
 				if (!isConsistent) {
@@ -404,6 +403,15 @@ public class QuestOWL extends OWLReasonerBase implements OntopOWLReasoner {
 		return true;
 	}
 	
+	// Renders a disjoint-object-property component as a SPARQL triple atom, honouring inverses:
+	// an inverse expression inv(q) becomes the swapped pattern "?y <q> ?x" instead of being
+	// string-formatted into an IRI slot (which produced a malformed query for inverse roles).
+	private static String objectPropertyAtom(ObjectPropertyExpression p) {
+		String iri = p.getIRI().getIRIString();
+		return p.isInverse() ? String.format("?y <%s> ?x", iri)
+		                     : String.format("?x <%s> ?y", iri);
+	}
+
 	private boolean executeConsistencyQuery(String strQuery) throws OWLException {
 		try (OntopConnection connection = queryEngine.getConnection();
 			 OntopStatement st = connection.createStatement()) {

--- a/protege/plugin/src/test/java/it/unibz/inf/ontop/owlapi/InconsistencyCheckingTest.java
+++ b/protege/plugin/src/test/java/it/unibz/inf/ontop/owlapi/InconsistencyCheckingTest.java
@@ -132,4 +132,22 @@ public class InconsistencyCheckingTest {
 
 		assertFalse(reasoner.isConsistent());
 	} 
+	@Test
+	public void testAsymmetricObjectPropConsistency() throws Exception {
+		// p asymmetric, single assertion p(a,b) -> consistent
+		manager.addAxiom(ontology, AsymmetricObjectProperty(r1));
+		manager.addAxiom(ontology, ObjectPropertyAssertion(r1, a, b));
+		startReasoner();
+		assertTrue(reasoner.isConsistent());
+	}
+
+	@Test
+	public void testAsymmetricObjectPropInconsistency() throws Exception {
+		// p asymmetric, p(a,b) and p(b,a) -> inconsistent
+		manager.addAxiom(ontology, AsymmetricObjectProperty(r1));
+		manager.addAxiom(ontology, ObjectPropertyAssertion(r1, a, b));
+		manager.addAxiom(ontology, ObjectPropertyAssertion(r1, b, a));
+		startReasoner();
+		assertFalse(reasoner.isConsistent());
+	}
 }


### PR DESCRIPTION
### Problem
`QuestOWL.isConsistent()` throws `ReasonerInterruptedException` (wrapping a `MalformedQueryException`) on any ontology that declares an `owl:AsymmetricProperty` — or, more generally, any disjoint object-property axiom whose components include an inverse property expression.

Minimal reproduction:
```turtle
:p a owl:ObjectProperty, owl:AsymmetricProperty .
:a :p :b .
```
`reasoner.isConsistent()` →
```
ReasonerInterruptedException: ... MalformedQueryException: Encountered "<" at line 1, column N
```

### Root cause
In `QuestOWL.isDisjointAxiomsConsistent()` the disjoint-object-property consistency query is built as
```java
final String strQueryProp = "ASK {?x <%s> ?y; <%s> ?y }";
String strQuery = String.format(strQueryProp, p1, p2);
```
`p1`/`p2` are `ObjectPropertyExpression`s formatted via `toString()` into the `<%s>` IRI slots. An asymmetric `p` is classified as `p` disjoint `inverse(p)`, so one component is an **inverse** expression whose `toString()` is not a bare IRI → a malformed IRI in the generated SPARQL. This is the case the existing `// TODO: handle role inverses` refers to.

### Fix
Build each atom from the property IRI and its direction, so an inverse `inv(q)` becomes the swapped pattern `?y <q> ?x`:
```java
private static String objectPropertyAtom(ObjectPropertyExpression p) {
    String iri = p.getIRI().getIRIString();
    return p.isInverse() ? String.format("?y <%s> ?x", iri)
                         : String.format("?x <%s> ?y", iri);
}
// ...
String strQuery = "ASK { " + objectPropertyAtom(p1) + " . " + objectPropertyAtom(p2) + " }";
```

### Why existing behaviour is unchanged
`InconsistencyCheckingTest` covers disjoint object properties with **named, non-inverse** properties (`hasMother`/`hasFather`). For those, the new code emits `ASK { ?x <hasMother> ?y . ?x <hasFather> ?y }`, which is semantically identical to the previous `ASK {?x <hasMother> ?y; <hasFather> ?y }` — same verdicts. The disjoint-class, disjoint-data-property and functional-property checks are untouched. Behaviour changes only for the previously-broken inverse case, which had no test.

### Test
Adds `testAsymmetricObjectPropConsistency` / `testAsymmetricObjectPropInconsistency` to `InconsistencyCheckingTest` (an asymmetric property: a single assertion → consistent; `:a :p :b . :b :p :a .` → inconsistent).