### PR TITLE
Rejected SQL translation for  PostgreSQL "text #>> unknown"

### DIFF
--- a/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/PostgreSQLDBFunctionSymbolFactory.java
+++ b/db/rdb/src/main/java/it/unibz/inf/ontop/model/term/functionsymbol/db/impl/PostgreSQLDBFunctionSymbolFactory.java
@@ -275,7 +275,7 @@ public class PostgreSQLDBFunctionSymbolFactory extends AbstractSQLDBFunctionSymb
     protected String serializeDateTimeNormWithTZ(ImmutableList<? extends ImmutableTerm> terms, Function<ImmutableTerm, String> termConverter, TermFactory termFactory) {
         // Enforces ISO 8601: https://stackoverflow.com/questions/38834022/turn-postgres-date-representation-into-iso-8601-string
         // However, use the local TZ instead of the stored TZ
-        return String.format("TO_JSON(%s)#>>'{}'", termConverter.apply(terms.get(0)));
+        return String.format("(TO_JSON(%s)#>>'{}')", termConverter.apply(terms.get(0)));
     }
 
     @Override

--- a/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/postgresql/other/DatetimeConcatTest.java
+++ b/test/lightweight-tests/src/test/java/it/unibz/inf/ontop/docker/lightweight/postgresql/other/DatetimeConcatTest.java
@@ -1,0 +1,40 @@
+package it.unibz.inf.ontop.docker.lightweight.postgresql.other;
+
+import com.google.common.collect.ImmutableSet;
+import it.unibz.inf.ontop.docker.lightweight.AbstractDockerRDF4JTest;
+import it.unibz.inf.ontop.docker.lightweight.PostgreSQLLightweightTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@PostgreSQLLightweightTest
+public class DatetimeConcatTest extends AbstractDockerRDF4JTest {
+
+    private static final String OWL_FILE = "/books/books.owl";
+    private static final String OBDA_FILE = "/books/postgresql/books-timestamp.obda";
+    private static final String PROPERTIES_FILE = "/books/postgresql/books-timestamp-postgresql.properties";
+
+    @BeforeAll
+    public static void before() {
+        initOBDA(OBDA_FILE, OWL_FILE, PROPERTIES_FILE);
+    }
+
+    @AfterAll
+    public static void after() {
+        release();
+    }
+
+    @Test
+    public void testTimestampConcatenatedInMapping() {
+        String query = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n" +
+                "SELECT ?v WHERE {\n" +
+                "  ?b rdfs:label ?v .\n" +
+                "} ORDER BY ?v";
+
+        executeAndCompareValues(query, ImmutableSet.of(
+                "\"published on 1970-11-05T07:50:00\"^^xsd:string",
+                "\"published on 2011-12-08T11:30:00\"^^xsd:string",
+                "\"published on 2014-06-05T16:47:52\"^^xsd:string",
+                "\"published on 2015-09-21T09:23:06\"^^xsd:string"));
+    }
+}

--- a/test/lightweight-tests/src/test/resources/books/postgresql/books-timestamp-postgresql.properties
+++ b/test/lightweight-tests/src/test/resources/books/postgresql/books-timestamp-postgresql.properties
@@ -1,0 +1,7 @@
+jdbc.url = jdbc:postgresql://${docker.url}:7777/books
+jdbc.user = postgres
+jdbc.password = ${docker.pgsql.password}
+jdbc.driver = org.postgresql.Driver
+jdbc.initScript = SET TIME ZONE 'UTC';
+# To trigger the issue with the concatenation
+ontop.avoidPostProcessing=true

--- a/test/lightweight-tests/src/test/resources/books/postgresql/books-timestamp.obda
+++ b/test/lightweight-tests/src/test/resources/books/postgresql/books-timestamp.obda
@@ -1,0 +1,12 @@
+[PrefixDeclaration]
+:       http://example.org/book
+ns:     http://example.org/ns#
+rdfs:   http://www.w3.org/2000/01/rdf-schema#
+xsd:    http://www.w3.org/2001/XMLSchema#
+
+
+[MappingDeclaration] @collection [[
+mappingId	book-datetime-label
+target		:{id} a :Book ; rdfs:label "published on {publication_date}"^^xsd:string .
+source		SELECT id, publication_date FROM books WHERE lang = 'en'
+]]


### PR DESCRIPTION
On PostgreSQL, serializing a timestamp to its lexical form is translated as `TO_JSON(<ts>)#>>'{}'`. When the serialized timestamp is concatenated into a larger string, PostgreSQL rejects the query with:

```
ERROR: operator does not exist: text #>> unknown
```

This is due to operator precedence: `#>>` shares its precedence level with `||` and is left-associative. Since `TO_JSON(...)#>>'{}'` was emitted without wrapping parentheses, an expression such as:

```sql
('published on ' || TO_JSON(v1."publication_date")#>>'{}')
```

is parsed left-to-right as `('published on ' || TO_JSON(v1."publication_date")) #>> '{}'`, so `#>>` is applied to a `text` value (the concatenation) instead of to `TO_JSON(...)`.

The fix was to simply wrap the serialization in parentheses:

```sql
('published on ' || (TO_JSON(v1."publication_date")#>>'{}'))
```