### PR TITLE
Fix Critical Tomcat and Spring CVEs in the Docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 all-test:
   script:
-      - export JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
+      - export JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
       - set MAVEN_OPTS="-Xms6000m -Xmx8000m"
       - ./mvnw install --fail-at-end
       - cd test/docker-tests && ../../mvnw install -Ddocker.url=tom.inf.unibz.it -DskipTests=false --fail-at-end

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.28-amzn
+java=17.0.16-amzn

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Compiling, packing, testing, etc.
 
 The project is a [Maven](http://maven.apache.org/) project. Compiling,
 running the unit tests, building the release binaries all can be done
-using Maven.  Currently, we use Maven 3.6+ and Java 11 to build the
+using Maven.  Currently, we use Maven 3.6+ and Java 17 to build the
 project.
 
 

--- a/client/docker/Dockerfile
+++ b/client/docker/Dockerfile
@@ -1,19 +1,19 @@
 #
 # ONTOP DOCKERFILE
 #
-# Multi-platform (linux, amd64/arm64), multi-stage dockerfile based on Eclipse Temurin JDK 11
+# Multi-platform (linux, amd64/arm64), multi-stage dockerfile based on Eclipse Temurin JDK 17
 # - use with 'docker buildx build client/docker/Dockerfile .' (from root folder)
 # - use with script 'build-image.sh' (call './build-image.sh --help' for instructions)
 #
 
 # JRE BUILD STAGE using 'jlink' to build a compact JRE with the only modules required by Ontop
-# - based on Eclipse Temurin JRE 11 (on Ubuntu 22.04 LTS 'jammy', for both amd64 and arm64)
+# - based on Eclipse Temurin JRE 17 (on Ubuntu 22.04 LTS 'jammy', for both amd64 and arm64)
 # - run './build-image.sh -d' to detect required Java modules to be used with '--add-modules'
 #   then manually add the following modules (for JMX and SSL/TLS to work properly)
 #   jdk.management.agent,jdk.crypto.cryptoki,jdk.crypto.ec
 # - pass --build-arg ONTOP_JRE_MODULES=<comma-separated-list> to override the set of modules,
 #   or use "ALL-MODULE-PATH" as value to include *all* JRE modules (34M image size increase)
-FROM eclipse-temurin:11-jammy AS jre-builder
+FROM eclipse-temurin:17-jammy AS jre-builder
 ARG ONTOP_JRE_MODULES=\
 "java.base,java.compiler,java.desktop,java.instrument,java.management.rmi,"\
 "java.naming,java.prefs,java.scripting,java.security.jgss,java.sql,"\
@@ -60,9 +60,9 @@ HEALTHCHECK --interval=5s --timeout=5s --start-period=60s --retries=3 CMD [ "/bi
 
 # ONTOP BUILD STAGE triggered by 'ontop-image-from-sources' to compile with a Maven Docker image
 # - except for generated binaries, content here will not end up in the built Ontop image
-# - maven:3-eclipse-temurin-11 is based on the same Ubuntu 22.04 "jammy" used as base image
+# - maven:3-eclipse-temurin-17 is based on the same Ubuntu 22.04 "jammy" used as base image
 # - this stage runs only on the current platform as Java compiling is platform-independent
-FROM --platform=${BUILDPLATFORM} maven:3-eclipse-temurin-11 AS ontop-builder
+FROM --platform=${BUILDPLATFORM} maven:3-eclipse-temurin-17 AS ontop-builder
 WORKDIR /build
 COPY . ./
 RUN --mount=type=cache,target=/root/.m2 \

--- a/client/endpoint-core/pom.xml
+++ b/client/endpoint-core/pom.xml
@@ -47,8 +47,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/client/endpoint-core/src/main/java/it/unibz/inf/ontop/endpoint/processor/SparqlQueryExecutor.java
+++ b/client/endpoint-core/src/main/java/it/unibz/inf/ontop/endpoint/processor/SparqlQueryExecutor.java
@@ -24,8 +24,8 @@ import org.eclipse.rdf4j.rio.turtle.TurtleWriter;
 import org.eclipse.rdf4j.rio.ntriples.NTriplesWriter;
 import org.eclipse.rdf4j.rio.nquads.NQuadsWriter;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;

--- a/client/endpoint/pom.xml
+++ b/client/endpoint/pom.xml
@@ -51,8 +51,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/controllers/PredefinedQueryController.java
+++ b/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/controllers/PredefinedQueryController.java
@@ -14,9 +14,9 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collections;

--- a/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/controllers/ReformulateController.java
+++ b/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/controllers/ReformulateController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 

--- a/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/controllers/SparqlQueryController.java
+++ b/client/endpoint/src/main/java/it/unibz/inf/ontop/endpoint/controllers/SparqlQueryController.java
@@ -12,8 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <maven-surefire-plugin.version>3.0.0-M9</maven-surefire-plugin.version>
         <maven-surefire-report-plugin.version>3.0.0-M9</maven-surefire-report-plugin.version>
         <sortpom-maven-plugin.version>3.2.1</sortpom-maven-plugin.version>
-        <spring-boot-maven-plugin.version>2.7.9</spring-boot-maven-plugin.version> <!-- 3.0.0+ needs JDK17 (via Spring Boot 3) -->
+        <spring-boot-maven-plugin.version>3.5.16</spring-boot-maven-plugin.version>
         <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
 
         <!-- Dependency versions: core dependencies -->
@@ -141,8 +141,9 @@
         <hikari-cp.version>3.4.5</hikari-cp.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.14</httpcore.version>
-        <jackson.version>2.18.6</jackson.version>
-        <jackson-databind.version>2.18.6</jackson-databind.version>
+        <jackson.version>2.21.5</jackson.version>
+        <jackson-databind.version>2.21.5</jackson-databind.version>
+        <jackson-annotations.version>2.21</jackson-annotations.version>
         <javax-inject.version>1</javax-inject.version>
         <jgrapht.version>0.9.3</jgrapht.version>
         <jsqlparser.version>4.4</jsqlparser.version>
@@ -150,7 +151,7 @@
         <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <junit-system-stubs.version>2.1.5</junit-system-stubs.version>
-        <logback.version>1.2.13</logback.version>
+        <logback.version>1.5.34</logback.version>
         <nullanno.version>3.0.0</nullanno.version>
         <opencsv.version>5.7.1</opencsv.version>
         <owlapi.version>5.5.1</owlapi.version>
@@ -159,9 +160,9 @@
         <r2rml-api.version>0.9.1</r2rml-api.version>
         <rdf4j.version>5.1.6</rdf4j.version>
         <servlet2-api.version>2.5</servlet2-api.version>
-        <servlet4-api.version>4.0.1</servlet4-api.version>
-        <slf4j.version>1.7.36</slf4j.version>
-        <spring-boot.version>2.7.18</spring-boot.version>
+        <jakarta-servlet.version>6.0.0</jakarta-servlet.version>
+        <slf4j.version>2.0.18</slf4j.version>
+        <spring-boot.version>3.5.16</spring-boot.version>
         <urlbuilder.version>2.0.9</urlbuilder.version>
         <tomcat-jdbc.version>10.0.0-M7</tomcat-jdbc.version>
         <toml4j.version>0.7.2</toml4j.version>
@@ -174,12 +175,12 @@
         <jsonld-java.version>0.13.0</jsonld-java.version>
         <semargl-sesame.version>0.6.1</semargl-sesame.version>
         <semargl.version>0.7</semargl.version>
-        <thymeleaf.version>3.0.15.RELEASE</thymeleaf.version>
-        <tomcat-embed-core.version>9.0.117</tomcat-embed-core.version>
+        <thymeleaf.version>3.1.5.RELEASE</thymeleaf.version>
+        <tomcat-embed-core.version>10.1.57</tomcat-embed-core.version>
         <log4j2.version>2.19.0</log4j2.version>
 
         <!-- JDK version -->
-        <jdk.version>11</jdk.version>
+        <jdk.version>17</jdk.version>
     </properties>
 
     <dependencyManagement>
@@ -816,9 +817,9 @@
                 <version>${servlet2-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>${servlet4-api.version}</version>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta-servlet.version}</version>
             </dependency>
 
             <!-- Apache HttpClient -->
@@ -972,7 +973,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -987,6 +988,16 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-parameter-names</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
 
@@ -1119,6 +1130,16 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat-embed-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat-embed-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
                 <version>${tomcat-embed-core.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
- Published `ontop/ontop` images were flagged by Grype for 4 Criticals: CVE-2026-41293, CVE-2026-43512, CVE-2026-43515 (`tomcat-embed-core` 9.0.111) and CVE-2016-1000027 (`spring-web` 5.3.31).
- Upgrade Spring Boot 2.7.18 → 3.5.16, Java 11 → 17, Tomcat 9 → 10.1.57, and `javax.servlet` → `jakarta.servlet` (import-only in the SPARQL endpoint).
- Pin `tomcat-embed-el` and `tomcat-embed-websocket` to the same 10.1.57 so mixed 9.0.83 leftovers cannot remain.

## Notes
- SPARQL rewrite / mapping logic is unchanged; Java source edits are `javax.servlet` → `jakarta.servlet` imports only.
- Docker base image is `eclipse-temurin:17-jammy`. GitLab CI and `.sdkmanrc` also use JDK 17.
- GitHub Actions (`main.yml`) still lists JDK 11 in this PR because the token used to push lacks `workflow` scope. A follow-up should set the workflow matrix to JDK 17.

## Test plan
- [ ] `mvn package -Passet-cli -Dmaven.test.skip` on JDK 17
- [ ] Confirm tree has `spring-web` 6.x and `tomcat-embed-*` 10.1.57
- [ ] Rebuild Docker image and Grype-scan: the 4 Criticals should be gone
- [ ] Smoke SPARQL endpoint (`/sparql`) against a known mapping
